### PR TITLE
add state-machine artifact containing a StateMachine interface

### DIFF
--- a/.github/android-sdk.sh
+++ b/.github/android-sdk.sh
@@ -4,12 +4,21 @@ set -e
 # 5.0.0 rc1
 CMDLINE_TOOLS_VERSION=7006259
 
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  CMDLINE_TOOLS_OS="linux"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  CMDLINE_TOOLS_OS="mac"
+else
+  echo "Unsupported OS $OSTYPE"
+  exit 1
+fi
+
 echo "Setting up Android SDK"
 mkdir -p $ANDROID_HOME/cmdline-tools
 mkdir -p $ANDROID_HOME/licenses
 
 echo "Installing cmdline-tools"
-wget -q -O /tmp/android-sdk.zip https://dl.google.com/android/repository/commandlinetools-linux-${CMDLINE_TOOLS_VERSION}_latest.zip
+wget -q -O /tmp/android-sdk.zip https://dl.google.com/android/repository/commandlinetools-${CMDLINE_TOOLS_OS}-${CMDLINE_TOOLS_VERSION}_latest.zip
 unzip -qo /tmp/android-sdk.zip -d $ANDROID_HOME/cmdline-tools
 mv $ANDROID_HOME/cmdline-tools/cmdline-tools $ANDROID_HOME/cmdline-tools/latest
 

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -38,6 +38,8 @@ jobs:
           cp README.md docs/index.md
           mkdir -p docs/Javadoc/text-resource
           cp -R text-resource/build/dokka/gfm/. docs/Javadoc/text-resource/
+          mkdir -p docs/Javadoc/state-machine
+          cp -R state-machine/build/dokka/gfm/. docs/Javadoc/state-machine/
 
       - name: Deploy MkDocs
         run: |

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,7 +8,13 @@ on:
 jobs:
   publish:
 
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+      # run sequentially to avoid conflicts for closeAndReleaseRepository
+      max-parallel: 1
+
+    runs-on: ${{matrix.os}}
 
     steps:
       - name: Checkout
@@ -21,9 +27,20 @@ jobs:
 
       - name: Install Android SDK
         run: ./.github/android-sdk.sh
+        if: matrix.os == 'macos-latest'
 
       - name: Upload release
         run: ./gradlew publish --no-daemon --no-parallel
+        if: matrix.os == 'macos-latest'
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.MAVEN_SIGNING_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.MAVEN_SIGNING_PASSWORD }}
+
+      - name: Upload release (Windows)
+        run: ./gradlew publishMingwPublicationToMavenRepository --no-daemon --no-parallel
+        if: matrix.os == 'windows-latest'
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -8,7 +8,11 @@ on:
 jobs:
   publish:
 
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+
+    runs-on: ${{matrix.os}}
 
     steps:
       - name: Checkout
@@ -21,14 +25,25 @@ jobs:
 
       - name: Install Android SDK
         run: ./.github/android-sdk.sh
+        if: matrix.os == 'macos-latest'
 
       - name: Retrieve version
         run: |
           echo "VERSION_NAME=$(cat gradle.properties | grep -w "VERSION_NAME" | cut -d'=' -f2)" >> $GITHUB_ENV
+        shell: bash
 
       - name: Publish snapshot
         run: ./gradlew publish --no-daemon --no-parallel
-        if: endsWith(env.VERSION_NAME, '-SNAPSHOT')
+        if: ${{ endsWith(env.VERSION_NAME, '-SNAPSHOT') && matrix.os == 'macos-latest' }}
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.MAVEN_SIGNING_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.MAVEN_SIGNING_PASSWORD }}
+
+      - name: Publish snapshot (Windows)
+        run: ./gradlew publishMingwX64PublicationToMavenCentralRepository --no-daemon --no-parallel
+        if: ${{ endsWith(env.VERSION_NAME, '-SNAPSHOT') && matrix.os == 'windows-latest' }}
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,18 @@ as well as some of our own utilties.
 
 **This repository is a work in progress. More will be added over time.**
 
+## StateMachine
+
+`StateMachine` is a very simple interface to implement a StateMachine with the concept of emitting
+state through a `Flow` and receiving input actions to mutate that state.
+
+For an example on how to build such a state machine check out [FlowRedux][2]. To connect a
+`StateMachine` to a user interface you can look at [Renderer][3].
+
+```groovy
+implementation 'com.freeletics.mad:state-machine:0.1.0'
+```
+
 ## TextResource
 
 `TextResource` is a domain specific model to represent text. Abstracts text
@@ -41,3 +53,5 @@ limitations under the License.
 ```
 
   [1]: https://freeletics.engineering/2021/01/22/abstraction-text-resource.html
+  [2]: https://freeletics.github.io/FlowRedux/dsl/
+  [3]: https://github.com/gabrielittner/renderer

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,2 @@
+include ':state-machine'
 include ':text-resource'

--- a/state-machine/build.gradle
+++ b/state-machine/build.gradle
@@ -1,0 +1,26 @@
+apply plugin: 'org.jetbrains.kotlin.multiplatform'
+apply plugin: 'org.jetbrains.dokka'
+apply plugin: 'com.vanniktech.maven.publish'
+
+kotlin {
+    jvm()
+    iosArm32()
+    iosArm64()
+    iosX64()
+    linuxX64()
+    macosX64()
+    mingwX64()
+    tvosArm64()
+    tvosX64()
+    watchosArm32()
+    watchosArm64()
+    watchosX86()
+
+    sourceSets {
+        commonMain {
+            dependencies {
+                api 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.0'
+            }
+        }
+    }
+}

--- a/state-machine/gradle.properties
+++ b/state-machine/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=state-machine
+POM_NAME=StateMachine
+POM_DESCRIPTION=StateMachine

--- a/state-machine/src/commonMain/kotlin/com/freeletics/mad/statemachine/StateMachine.kt
+++ b/state-machine/src/commonMain/kotlin/com/freeletics/mad/statemachine/StateMachine.kt
@@ -1,0 +1,23 @@
+package com.freeletics.mad.statemachine
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * A state machine that emits [State] objects through the [Flow] returned by [state]. The state
+ * can be mutated through actions passed to [dispatch].
+ */
+interface StateMachine<State : Any, Action : Any> {
+
+    /**
+     * A [Flow] that emits the current state as well as all changes to the state.
+     */
+    val state: Flow<State>
+
+    /**
+     * An an [Action] to the [StateMachine]. The implementation can mutate the [State] based on
+     * these actions or trigger side effects.
+     */
+    suspend fun dispatch(action: Action)
+}
+
+


### PR DESCRIPTION
Adds the `StateMachine` interface that can be used in FlowRedux, Renderer and other things.

This also updates the `android-sdk.sh` script to be able to run on macOS. Our publishing jobs are now executed on macOS instead of linux. That publishes everything except windows artifacts, which are published from their own job running on Windows. I've let the publish snapshot workflow run on this branch once to make sure it works: 
https://github.com/freeletics/mad/actions/runs/931056254

<img width="514" alt="Screenshot 2021-06-12 at 12 52 31" src="https://user-images.githubusercontent.com/1358105/121773569-0f1f6b80-cb7d-11eb-9902-5839e4eebba7.png">