### PR TITLE
support providing custom composition locals through dagger

### DIFF
--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/FileGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/FileGenerator.kt
@@ -14,12 +14,14 @@ import com.freeletics.mad.whetstone.codegen.naventry.NavEntryFactoryProviderGene
 import com.freeletics.mad.whetstone.codegen.naventry.NavEntrySubcomponentGenerator
 import com.freeletics.mad.whetstone.codegen.naventry.NavEntryViewModelGenerator
 import com.freeletics.mad.whetstone.codegen.renderer.RendererFragmentGenerator
+import com.freeletics.mad.whetstone.codegen.util.simplePropertySpec
 import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.PropertySpec
 
 internal class FileGenerator{
 
     fun generate(data: ComposeScreenData): FileSpec {
-        val retainedComponentGenerator = RetainedComponentGenerator(data, null)
+        val retainedComponentGenerator = RetainedComponentGenerator(data)
         val viewModelGenerator = ViewModelGenerator(data)
         val composeGenerator = ComposeGenerator(data)
 
@@ -31,7 +33,7 @@ internal class FileGenerator{
     }
 
     fun generate(data: ComposeFragmentData): FileSpec {
-        val retainedComponentGenerator = RetainedComponentGenerator(data, null)
+        val retainedComponentGenerator = RetainedComponentGenerator(data)
         val viewModelGenerator = ViewModelGenerator(data)
         val composeFragmentGenerator = ComposeFragmentGenerator(data)
         val composeGenerator = ComposeGenerator(data)
@@ -45,7 +47,7 @@ internal class FileGenerator{
     }
 
     fun generate(data: RendererFragmentData): FileSpec {
-        val retainedComponentGenerator = RetainedComponentGenerator(data, data.factory)
+        val retainedComponentGenerator = RetainedComponentGenerator(data)
         val viewModelGenerator = ViewModelGenerator(data)
         val rendererFragmentGenerator = RendererFragmentGenerator(data)
 

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/FileGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/FileGenerator.kt
@@ -14,9 +14,7 @@ import com.freeletics.mad.whetstone.codegen.naventry.NavEntryFactoryProviderGene
 import com.freeletics.mad.whetstone.codegen.naventry.NavEntrySubcomponentGenerator
 import com.freeletics.mad.whetstone.codegen.naventry.NavEntryViewModelGenerator
 import com.freeletics.mad.whetstone.codegen.renderer.RendererFragmentGenerator
-import com.freeletics.mad.whetstone.codegen.util.simplePropertySpec
 import com.squareup.kotlinpoet.FileSpec
-import com.squareup.kotlinpoet.PropertySpec
 
 internal class FileGenerator{
 

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/RetainedComponentGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/RetainedComponentGenerator.kt
@@ -13,7 +13,6 @@ import com.freeletics.mad.whetstone.codegen.util.composeProviderValueModule
 import com.freeletics.mad.whetstone.codegen.util.compositeDisposable
 import com.freeletics.mad.whetstone.codegen.util.coroutineScope
 import com.freeletics.mad.whetstone.codegen.util.internalApiAnnotation
-import com.freeletics.mad.whetstone.codegen.util.propertyName
 import com.freeletics.mad.whetstone.codegen.util.providedValue
 import com.freeletics.mad.whetstone.codegen.util.savedStateHandle
 import com.freeletics.mad.whetstone.codegen.util.scopeToAnnotation
@@ -27,7 +26,6 @@ import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.SET
 import com.squareup.kotlinpoet.STAR
 import com.squareup.kotlinpoet.TypeSpec
-import com.squareup.kotlinpoet.WildcardTypeName
 
 internal val Generator<out CommonData>.retainedComponentClassName get() = ClassName("Retained${data.baseName}Component")
 

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/RetainedComponentGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/RetainedComponentGenerator.kt
@@ -1,14 +1,20 @@
 package com.freeletics.mad.whetstone.codegen.common
 
 import com.freeletics.mad.whetstone.CommonData
+import com.freeletics.mad.whetstone.ComposeFragmentData
+import com.freeletics.mad.whetstone.ComposeScreenData
+import com.freeletics.mad.whetstone.RendererFragmentData
 import com.freeletics.mad.whetstone.codegen.util.Generator
 import com.freeletics.mad.whetstone.codegen.util.bindsInstanceParameter
 import com.freeletics.mad.whetstone.codegen.util.bundle
 import com.freeletics.mad.whetstone.codegen.util.componentAnnotation
 import com.freeletics.mad.whetstone.codegen.util.componentFactory
+import com.freeletics.mad.whetstone.codegen.util.composeProviderValueModule
 import com.freeletics.mad.whetstone.codegen.util.compositeDisposable
 import com.freeletics.mad.whetstone.codegen.util.coroutineScope
 import com.freeletics.mad.whetstone.codegen.util.internalApiAnnotation
+import com.freeletics.mad.whetstone.codegen.util.propertyName
+import com.freeletics.mad.whetstone.codegen.util.providedValue
 import com.freeletics.mad.whetstone.codegen.util.savedStateHandle
 import com.freeletics.mad.whetstone.codegen.util.scopeToAnnotation
 import com.freeletics.mad.whetstone.codegen.util.simplePropertySpec
@@ -16,16 +22,21 @@ import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.KModifier.ABSTRACT
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.SET
+import com.squareup.kotlinpoet.STAR
 import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.WildcardTypeName
 
 internal val Generator<out CommonData>.retainedComponentClassName get() = ClassName("Retained${data.baseName}Component")
 
 internal const val retainedComponentFactoryCreateName = "create"
 
+internal const val providedValueSetPropertyName = "providedValues"
+
 internal class RetainedComponentGenerator(
     override val data: CommonData,
-    val extraProperty: ClassName?,
 ) : Generator<CommonData>() {
 
     fun generate(): TypeSpec {
@@ -33,10 +44,18 @@ internal class RetainedComponentGenerator(
             .addModifiers(KModifier.INTERNAL)
             .addAnnotation(internalApiAnnotation())
             .addAnnotation(scopeToAnnotation(data.scope))
-            .addAnnotation(componentAnnotation(data.scope, data.dependencies))
+            .addAnnotation(componentAnnotation(data.scope, data.dependencies, moduleClassName()))
             .addProperties(componentProperties())
             .addType(retainedComponentFactory())
             .build()
+    }
+
+    private fun moduleClassName(): ClassName? {
+        return when (data) {
+            is ComposeFragmentData -> composeProviderValueModule
+            is ComposeScreenData -> composeProviderValueModule
+            is RendererFragmentData -> null
+        }
     }
 
     private fun componentProperties(): List<PropertySpec> {
@@ -46,10 +65,17 @@ internal class RetainedComponentGenerator(
             properties += simplePropertySpec(data.navigation!!.navigator)
             properties += simplePropertySpec(data.navigation!!.navigationHandler)
         }
-        if (extraProperty != null) {
-            properties += simplePropertySpec(extraProperty)
+        properties += when (data) {
+            is ComposeFragmentData -> providedValueSetProperty()
+            is ComposeScreenData -> providedValueSetProperty()
+            is RendererFragmentData -> simplePropertySpec(data.factory)
         }
         return properties
+    }
+
+    private fun providedValueSetProperty(): PropertySpec {
+        val type = SET.parameterizedBy(providedValue.parameterizedBy(STAR))
+        return PropertySpec.builder(providedValueSetPropertyName, type).build()
     }
 
     private val retainedComponentFactoryClassName = retainedComponentClassName.peerClass("Factory")

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
@@ -25,6 +25,7 @@ internal val internalWhetstoneApi = ClassName("com.freeletics.mad.whetstone.inte
 internal val viewModelProvider = MemberName("com.freeletics.mad.whetstone.internal", "viewModelProvider")
 internal val rememberViewModelProvider = MemberName("com.freeletics.mad.whetstone.internal", "rememberViewModelProvider")
 internal val navEntryComponentGetterKey = ClassName("com.freeletics.mad.whetstone.internal", "NavEntryComponentGetterKey")
+internal val composeProviderValueModule = ClassName("com.freeletics.mad.whetstone.internal", "ComposeProviderValueModule")
 
 // Navigator
 internal val navigationHandler = ClassName("com.freeletics.mad.navigator", "NavigationHandler")
@@ -60,24 +61,24 @@ internal val moduleFqName = FqName(module.canonicalName)
 // AndroidX
 internal val fragment = ClassName("androidx.fragment.app", "Fragment")
 
-internal val onBackPressedDispatcher = ClassName("androidx.activity", "OnBackPressedDispatcher")
-internal val locaOnBackPressedDispatcherOwner = ClassName("androidx.activity.compose", "LocalOnBackPressedDispatcherOwner")
+internal val localOnBackPressedDispatcherOwner = ClassName("androidx.activity.compose", "LocalOnBackPressedDispatcherOwner")
 
 internal val viewModel = ClassName("androidx.lifecycle", "ViewModel")
 internal val savedStateHandle = ClassName("androidx.lifecycle", "SavedStateHandle")
-internal val lifecycleCoroutineScope = MemberName("androidx.lifecycle", "coroutineScope")
 
 internal val navController = ClassName("androidx.navigation", "NavController")
 internal val navBackStackEntry = ClassName("androidx.navigation", "NavBackStackEntry")
 internal val findNavController = MemberName("androidx.navigation.fragment", "findNavController")
 
+// Compose
 internal val composable = ClassName("androidx.compose.runtime", "Composable")
 internal val launchedEffect = MemberName("androidx.compose.runtime", "LaunchedEffect")
 internal val collectAsState = MemberName("androidx.compose.runtime", "collectAsState")
 internal val getValue = MemberName("androidx.compose.runtime", "getValue")
 internal val rememberCoroutineScope = MemberName("androidx.compose.runtime", "rememberCoroutineScope")
-internal val composeView = ClassName("androidx.compose.ui.platform", "ComposeView")
 internal val compositionLocalProvider = ClassName("androidx.compose.runtime", "CompositionLocalProvider")
+internal val providedValue = ClassName("androidx.compose.runtime", "ProvidedValue")
+internal val composeView = ClassName("androidx.compose.ui.platform", "ComposeView")
 
 // Accompanist
 internal val localWindowInsets = ClassName("com.google.accompanist.insets", "LocalWindowInsets")

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/Helper.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/Helper.kt
@@ -32,10 +32,19 @@ internal fun lateinitPropertySpec(className: ClassName): PropertySpec {
         .build()
 }
 
-internal fun componentAnnotation(scope: ClassName, dependencies: ClassName): AnnotationSpec {
+internal fun componentAnnotation(
+    scope: ClassName,
+    dependencies: ClassName,
+    module: ClassName? = null
+): AnnotationSpec {
     return AnnotationSpec.builder(MergeComponent::class)
         .addMember("scope = %T::class", scope)
         .addMember("dependencies = [%T::class]", dependencies)
+        .apply {
+            if (module != null) {
+                addMember("modules = [%T::class]", module)
+            }
+        }
         .build()
 }
 

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
@@ -24,20 +24,23 @@ class FileGeneratorTestCompose {
     )
 
     @Test
-    fun `generates code for ComposeScreenData no fragment`() {
+    fun `generates code for ComposeScreenData`() {
         FileGenerator().generate(full).toString() shouldBe """
             package com.test
 
             import android.os.Bundle
             import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
             import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.CompositionLocalProvider
             import androidx.compose.runtime.LaunchedEffect
+            import androidx.compose.runtime.ProvidedValue
             import androidx.compose.runtime.collectAsState
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
             import androidx.navigation.NavController
             import com.freeletics.mad.whetstone.ScopeTo
+            import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.rememberViewModelProvider
             import com.squareup.anvil.annotations.MergeComponent
@@ -48,6 +51,7 @@ class FileGeneratorTestCompose {
             import io.reactivex.disposables.CompositeDisposable
             import kotlin.OptIn
             import kotlin.Unit
+            import kotlin.collections.Set
             import kotlinx.coroutines.CoroutineScope
             import kotlinx.coroutines.MainScope
             import kotlinx.coroutines.cancel
@@ -57,7 +61,8 @@ class FileGeneratorTestCompose {
             @ScopeTo(TestScreen::class)
             @MergeComponent(
               scope = TestScreen::class,
-              dependencies = [TestDependencies::class]
+              dependencies = [TestDependencies::class],
+              modules = [ComposeProviderValueModule::class]
             )
             internal interface RetainedTestComponent {
               public val testStateMachine: TestStateMachine
@@ -65,6 +70,8 @@ class FileGeneratorTestCompose {
               public val testNavigator: TestNavigator
 
               public val testNavigationHandler: TestNavigationHandler
+
+              public val providedValues: Set<ProvidedValue<*>>
 
               @Component.Factory
               public interface Factory {
@@ -116,11 +123,14 @@ class FileGeneratorTestCompose {
                 handler.handle(this, navController, onBackPressedDispatcher, navigator)
               }
 
-              val stateMachine = component.testStateMachine
-              val state = stateMachine.state.collectAsState()
-              val scope = rememberCoroutineScope()
-              Test(state.value) { action ->
-                scope.launch { stateMachine.dispatch(action) }
+              val providedValues = component.providedValues
+              CompositionLocalProvider(*providedValues.toTypedArray()) {
+                val stateMachine = component.testStateMachine
+                val state = stateMachine.state.collectAsState()
+                val scope = rememberCoroutineScope()
+                Test(state.value) { action ->
+                  scope.launch { stateMachine.dispatch(action) }
+                }
               }
             }
             
@@ -128,7 +138,7 @@ class FileGeneratorTestCompose {
     }
 
     @Test
-    fun `generates code for ComposeScreenData no fragment compose, no navigation`() {
+    fun `generates code for ComposeScreenData, no navigation`() {
         val noNavigation = full.copy(navigation = null)
 
         FileGenerator().generate(noNavigation).toString() shouldBe """
@@ -136,12 +146,15 @@ class FileGeneratorTestCompose {
 
             import android.os.Bundle
             import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.CompositionLocalProvider
+            import androidx.compose.runtime.ProvidedValue
             import androidx.compose.runtime.collectAsState
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
             import androidx.navigation.NavController
             import com.freeletics.mad.whetstone.ScopeTo
+            import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.rememberViewModelProvider
             import com.squareup.anvil.annotations.MergeComponent
@@ -151,6 +164,7 @@ class FileGeneratorTestCompose {
             import io.reactivex.disposables.CompositeDisposable
             import kotlin.OptIn
             import kotlin.Unit
+            import kotlin.collections.Set
             import kotlinx.coroutines.CoroutineScope
             import kotlinx.coroutines.MainScope
             import kotlinx.coroutines.cancel
@@ -160,10 +174,13 @@ class FileGeneratorTestCompose {
             @ScopeTo(TestScreen::class)
             @MergeComponent(
               scope = TestScreen::class,
-              dependencies = [TestDependencies::class]
+              dependencies = [TestDependencies::class],
+              modules = [ComposeProviderValueModule::class]
             )
             internal interface RetainedTestComponent {
               public val testStateMachine: TestStateMachine
+
+              public val providedValues: Set<ProvidedValue<*>>
 
               @Component.Factory
               public interface Factory {
@@ -208,11 +225,14 @@ class FileGeneratorTestCompose {
               val viewModel = viewModelProvider[TestViewModel::class.java]
               val component = viewModel.component
 
-              val stateMachine = component.testStateMachine
-              val state = stateMachine.state.collectAsState()
-              val scope = rememberCoroutineScope()
-              Test(state.value) { action ->
-                scope.launch { stateMachine.dispatch(action) }
+              val providedValues = component.providedValues
+              CompositionLocalProvider(*providedValues.toTypedArray()) {
+                val stateMachine = component.testStateMachine
+                val state = stateMachine.state.collectAsState()
+                val scope = rememberCoroutineScope()
+                Test(state.value) { action ->
+                  scope.launch { stateMachine.dispatch(action) }
+                }
               }
             }
             
@@ -220,7 +240,7 @@ class FileGeneratorTestCompose {
     }
 
     @Test
-    fun `generates code for ComposeScreenData without coroutines`() {
+    fun `generates code for ComposeScreenData, without coroutines`() {
         val withoutCoroutines = full.copy(coroutinesEnabled = false)
 
         FileGenerator().generate(withoutCoroutines).toString() shouldBe """
@@ -229,13 +249,16 @@ class FileGeneratorTestCompose {
             import android.os.Bundle
             import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
             import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.CompositionLocalProvider
             import androidx.compose.runtime.LaunchedEffect
+            import androidx.compose.runtime.ProvidedValue
             import androidx.compose.runtime.collectAsState
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
             import androidx.navigation.NavController
             import com.freeletics.mad.whetstone.ScopeTo
+            import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.rememberViewModelProvider
             import com.squareup.anvil.annotations.MergeComponent
@@ -246,13 +269,15 @@ class FileGeneratorTestCompose {
             import io.reactivex.disposables.CompositeDisposable
             import kotlin.OptIn
             import kotlin.Unit
+            import kotlin.collections.Set
             import kotlinx.coroutines.launch
 
             @InternalWhetstoneApi
             @ScopeTo(TestScreen::class)
             @MergeComponent(
               scope = TestScreen::class,
-              dependencies = [TestDependencies::class]
+              dependencies = [TestDependencies::class],
+              modules = [ComposeProviderValueModule::class]
             )
             internal interface RetainedTestComponent {
               public val testStateMachine: TestStateMachine
@@ -260,6 +285,8 @@ class FileGeneratorTestCompose {
               public val testNavigator: TestNavigator
 
               public val testNavigationHandler: TestNavigationHandler
+
+              public val providedValues: Set<ProvidedValue<*>>
 
               @Component.Factory
               public interface Factory {
@@ -307,11 +334,14 @@ class FileGeneratorTestCompose {
                 handler.handle(this, navController, onBackPressedDispatcher, navigator)
               }
 
-              val stateMachine = component.testStateMachine
-              val state = stateMachine.state.collectAsState()
-              val scope = rememberCoroutineScope()
-              Test(state.value) { action ->
-                scope.launch { stateMachine.dispatch(action) }
+              val providedValues = component.providedValues
+              CompositionLocalProvider(*providedValues.toTypedArray()) {
+                val stateMachine = component.testStateMachine
+                val state = stateMachine.state.collectAsState()
+                val scope = rememberCoroutineScope()
+                Test(state.value) { action ->
+                  scope.launch { stateMachine.dispatch(action) }
+                }
               }
             }
             
@@ -319,7 +349,7 @@ class FileGeneratorTestCompose {
     }
 
     @Test
-    fun `generates code for ComposeScreenData without rxjava`() {
+    fun `generates code for ComposeScreenData, without rxjava`() {
         val withoutRxJava = full.copy(rxJavaEnabled = false)
 
         FileGenerator().generate(withoutRxJava).toString() shouldBe """
@@ -328,13 +358,16 @@ class FileGeneratorTestCompose {
             import android.os.Bundle
             import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
             import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.CompositionLocalProvider
             import androidx.compose.runtime.LaunchedEffect
+            import androidx.compose.runtime.ProvidedValue
             import androidx.compose.runtime.collectAsState
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
             import androidx.navigation.NavController
             import com.freeletics.mad.whetstone.ScopeTo
+            import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.rememberViewModelProvider
             import com.squareup.anvil.annotations.MergeComponent
@@ -344,6 +377,7 @@ class FileGeneratorTestCompose {
             import dagger.Component
             import kotlin.OptIn
             import kotlin.Unit
+            import kotlin.collections.Set
             import kotlinx.coroutines.CoroutineScope
             import kotlinx.coroutines.MainScope
             import kotlinx.coroutines.cancel
@@ -353,7 +387,8 @@ class FileGeneratorTestCompose {
             @ScopeTo(TestScreen::class)
             @MergeComponent(
               scope = TestScreen::class,
-              dependencies = [TestDependencies::class]
+              dependencies = [TestDependencies::class],
+              modules = [ComposeProviderValueModule::class]
             )
             internal interface RetainedTestComponent {
               public val testStateMachine: TestStateMachine
@@ -361,6 +396,8 @@ class FileGeneratorTestCompose {
               public val testNavigator: TestNavigator
 
               public val testNavigationHandler: TestNavigationHandler
+
+              public val providedValues: Set<ProvidedValue<*>>
 
               @Component.Factory
               public interface Factory {
@@ -407,11 +444,14 @@ class FileGeneratorTestCompose {
                 handler.handle(this, navController, onBackPressedDispatcher, navigator)
               }
 
-              val stateMachine = component.testStateMachine
-              val state = stateMachine.state.collectAsState()
-              val scope = rememberCoroutineScope()
-              Test(state.value) { action ->
-                scope.launch { stateMachine.dispatch(action) }
+              val providedValues = component.providedValues
+              CompositionLocalProvider(*providedValues.toTypedArray()) {
+                val stateMachine = component.testStateMachine
+                val state = stateMachine.state.collectAsState()
+                val scope = rememberCoroutineScope()
+                Test(state.value) { action ->
+                  scope.launch { stateMachine.dispatch(action) }
+                }
               }
             }
             

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
@@ -35,6 +35,7 @@ class FileGeneratorTestComposeFragment {
             import android.view.ViewGroup
             import androidx.compose.runtime.Composable
             import androidx.compose.runtime.CompositionLocalProvider
+            import androidx.compose.runtime.ProvidedValue
             import androidx.compose.runtime.collectAsState
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.compose.ui.platform.ComposeView
@@ -44,6 +45,7 @@ class FileGeneratorTestComposeFragment {
             import androidx.navigation.NavController
             import androidx.navigation.fragment.findNavController
             import com.freeletics.mad.whetstone.ScopeTo
+            import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.rememberViewModelProvider
             import com.freeletics.mad.whetstone.`internal`.viewModelProvider
@@ -58,6 +60,7 @@ class FileGeneratorTestComposeFragment {
             import kotlin.Boolean
             import kotlin.OptIn
             import kotlin.Unit
+            import kotlin.collections.Set
             import kotlinx.coroutines.CoroutineScope
             import kotlinx.coroutines.MainScope
             import kotlinx.coroutines.cancel
@@ -67,7 +70,8 @@ class FileGeneratorTestComposeFragment {
             @ScopeTo(TestScreen::class)
             @MergeComponent(
               scope = TestScreen::class,
-              dependencies = [TestDependencies::class]
+              dependencies = [TestDependencies::class],
+              modules = [ComposeProviderValueModule::class]
             )
             internal interface RetainedTestComponent {
               public val testStateMachine: TestStateMachine
@@ -75,6 +79,8 @@ class FileGeneratorTestComposeFragment {
               public val testNavigator: TestNavigator
 
               public val testNavigationHandler: TestNavigationHandler
+
+              public val providedValues: Set<ProvidedValue<*>>
 
               @Component.Factory
               public interface Factory {
@@ -119,11 +125,14 @@ class FileGeneratorTestComposeFragment {
               val viewModel = viewModelProvider[TestViewModel::class.java]
               val component = viewModel.component
 
-              val stateMachine = component.testStateMachine
-              val state = stateMachine.state.collectAsState()
-              val scope = rememberCoroutineScope()
-              Test(state.value) { action ->
-                scope.launch { stateMachine.dispatch(action) }
+              val providedValues = component.providedValues
+              CompositionLocalProvider(*providedValues.toTypedArray()) {
+                val stateMachine = component.testStateMachine
+                val state = stateMachine.state.collectAsState()
+                val scope = rememberCoroutineScope()
+                Test(state.value) { action ->
+                  scope.launch { stateMachine.dispatch(action) }
+                }
               }
             }
             
@@ -185,6 +194,8 @@ class FileGeneratorTestComposeFragment {
             import android.view.View
             import android.view.ViewGroup
             import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.CompositionLocalProvider
+            import androidx.compose.runtime.ProvidedValue
             import androidx.compose.runtime.collectAsState
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.compose.ui.platform.ComposeView
@@ -194,6 +205,7 @@ class FileGeneratorTestComposeFragment {
             import androidx.navigation.NavController
             import androidx.navigation.fragment.findNavController
             import com.freeletics.mad.whetstone.ScopeTo
+            import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.rememberViewModelProvider
             import com.freeletics.mad.whetstone.`internal`.viewModelProvider
@@ -206,6 +218,7 @@ class FileGeneratorTestComposeFragment {
             import kotlin.Boolean
             import kotlin.OptIn
             import kotlin.Unit
+            import kotlin.collections.Set
             import kotlinx.coroutines.CoroutineScope
             import kotlinx.coroutines.MainScope
             import kotlinx.coroutines.cancel
@@ -215,7 +228,8 @@ class FileGeneratorTestComposeFragment {
             @ScopeTo(TestScreen::class)
             @MergeComponent(
               scope = TestScreen::class,
-              dependencies = [TestDependencies::class]
+              dependencies = [TestDependencies::class],
+              modules = [ComposeProviderValueModule::class]
             )
             internal interface RetainedTestComponent {
               public val testStateMachine: TestStateMachine
@@ -223,6 +237,8 @@ class FileGeneratorTestComposeFragment {
               public val testNavigator: TestNavigator
 
               public val testNavigationHandler: TestNavigationHandler
+
+              public val providedValues: Set<ProvidedValue<*>>
 
               @Component.Factory
               public interface Factory {
@@ -267,11 +283,14 @@ class FileGeneratorTestComposeFragment {
               val viewModel = viewModelProvider[TestViewModel::class.java]
               val component = viewModel.component
 
-              val stateMachine = component.testStateMachine
-              val state = stateMachine.state.collectAsState()
-              val scope = rememberCoroutineScope()
-              Test(state.value) { action ->
-                scope.launch { stateMachine.dispatch(action) }
+              val providedValues = component.providedValues
+              CompositionLocalProvider(*providedValues.toTypedArray()) {
+                val stateMachine = component.testStateMachine
+                val state = stateMachine.state.collectAsState()
+                val scope = rememberCoroutineScope()
+                Test(state.value) { action ->
+                  scope.launch { stateMachine.dispatch(action) }
+                }
               }
             }
             
@@ -328,6 +347,7 @@ class FileGeneratorTestComposeFragment {
             import android.view.ViewGroup
             import androidx.compose.runtime.Composable
             import androidx.compose.runtime.CompositionLocalProvider
+            import androidx.compose.runtime.ProvidedValue
             import androidx.compose.runtime.collectAsState
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.compose.ui.platform.ComposeView
@@ -337,6 +357,7 @@ class FileGeneratorTestComposeFragment {
             import androidx.navigation.NavController
             import androidx.navigation.fragment.findNavController
             import com.freeletics.mad.whetstone.ScopeTo
+            import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.rememberViewModelProvider
             import com.google.accompanist.insets.LocalWindowInsets
@@ -348,6 +369,7 @@ class FileGeneratorTestComposeFragment {
             import io.reactivex.disposables.CompositeDisposable
             import kotlin.OptIn
             import kotlin.Unit
+            import kotlin.collections.Set
             import kotlinx.coroutines.CoroutineScope
             import kotlinx.coroutines.MainScope
             import kotlinx.coroutines.cancel
@@ -357,10 +379,13 @@ class FileGeneratorTestComposeFragment {
             @ScopeTo(TestScreen::class)
             @MergeComponent(
               scope = TestScreen::class,
-              dependencies = [TestDependencies::class]
+              dependencies = [TestDependencies::class],
+              modules = [ComposeProviderValueModule::class]
             )
             internal interface RetainedTestComponent {
               public val testStateMachine: TestStateMachine
+
+              public val providedValues: Set<ProvidedValue<*>>
 
               @Component.Factory
               public interface Factory {
@@ -405,11 +430,14 @@ class FileGeneratorTestComposeFragment {
               val viewModel = viewModelProvider[TestViewModel::class.java]
               val component = viewModel.component
 
-              val stateMachine = component.testStateMachine
-              val state = stateMachine.state.collectAsState()
-              val scope = rememberCoroutineScope()
-              Test(state.value) { action ->
-                scope.launch { stateMachine.dispatch(action) }
+              val providedValues = component.providedValues
+              CompositionLocalProvider(*providedValues.toTypedArray()) {
+                val stateMachine = component.testStateMachine
+                val state = stateMachine.state.collectAsState()
+                val scope = rememberCoroutineScope()
+                Test(state.value) { action ->
+                  scope.launch { stateMachine.dispatch(action) }
+                }
               }
             }
             

--- a/whetstone/runtime/src/main/java/com/freeletics/mad/whetstone/internal/ComposeProviderValueModule.kt
+++ b/whetstone/runtime/src/main/java/com/freeletics/mad/whetstone/internal/ComposeProviderValueModule.kt
@@ -1,0 +1,12 @@
+package com.freeletics.mad.whetstone.internal
+
+import androidx.compose.runtime.ProvidedValue
+import dagger.Module
+import dagger.multibindings.Multibinds
+
+@Module
+@InternalWhetstoneApi
+interface ComposeProviderValueModule {
+    @Multibinds
+    fun bindProvidedValues(): Set<ProvidedValue<*>>
+}


### PR DESCRIPTION
With this you'll be able to do the following

```
val LocalFoo = staticCompositionLocalOf<Foo> { error("Foo was not provided") }

@Module
@ContributesTo(ScopeAlsoUsedInGeneratedComponent::class)
object ArenaBoxMatchBriefingRetainedModule {

    @Provides
    @IntoSet
    fun provideFoo(foo: Foo): ProvidedValue<*> { // assumes that Foo is injectable in our component
        return LocalFoo provides Foo
    }
}
```

and can then access `Foo` through `LocalFoo.current` in your composables.

What we're doing internally is creating `Set<ProvidedValue<*>>` in our generated component and then accessing it from our generated composable to do
```
val providedValues = component.providedValues
CompositionLocalProvider(*providedValues.toTypedArray()) {
  // state setup and call to the actual composable like before
}
```

The internal `ComposeProviderValueModule` is automatically included into all generated components to continue supporting not providing any composition locals.