### PR TITLE
add new RendererDialogFragment annotation

### DIFF
--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/Data.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/Data.kt
@@ -71,6 +71,7 @@ data class RendererFragmentData(
     override val parentScope: ClassName,
     override val dependencies: ClassName,
 
+    val fragmentBaseClass: ClassName,
     val factory: ClassName,
     override val stateMachine: ClassName,
 

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/Data.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/Data.kt
@@ -71,9 +71,9 @@ data class RendererFragmentData(
     override val parentScope: ClassName,
     override val dependencies: ClassName,
 
-    val fragmentBaseClass: ClassName,
     val factory: ClassName,
     override val stateMachine: ClassName,
+    val fragmentBaseClass: ClassName,
 
     override val navigation: Navigation?,
 

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/WhetstoneCodeGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/WhetstoneCodeGenerator.kt
@@ -3,6 +3,7 @@ package com.freeletics.mad.whetstone
 import com.freeletics.mad.whetstone.codegen.FileGenerator
 import com.freeletics.mad.whetstone.codegen.util.composeFqName
 import com.freeletics.mad.whetstone.codegen.util.composeFragmentFqName
+import com.freeletics.mad.whetstone.codegen.util.dialogFragment
 import com.freeletics.mad.whetstone.codegen.util.emptyNavigationHandler
 import com.freeletics.mad.whetstone.codegen.util.emptyNavigator
 import com.freeletics.mad.whetstone.codegen.util.fragment
@@ -80,9 +81,9 @@ class WhetstoneCodeGenerator : CodeGenerator {
             scope = renderer.requireClassArgument("scope", 0, module),
             parentScope = renderer.requireClassArgument("parentScope", 1, module),
             dependencies = renderer.requireClassArgument("dependencies", 2, module),
-            fragmentBaseClass = fragment,
             factory = renderer.requireClassArgument("rendererFactory", 3, module),
             stateMachine = renderer.requireClassArgument("stateMachine", 4, module),
+            fragmentBaseClass = fragment,
             navigation = renderer.toNavigation(5, 6, module),
             coroutinesEnabled = renderer.optionalBooleanArgument("coroutinesEnabled", 7) ?: false,
             rxJavaEnabled = renderer.optionalBooleanArgument("rxJavaEnabled", 8) ?: false,
@@ -110,9 +111,9 @@ class WhetstoneCodeGenerator : CodeGenerator {
             scope = renderer.requireClassArgument("scope", 0, module),
             parentScope = renderer.requireClassArgument("parentScope", 1, module),
             dependencies = renderer.requireClassArgument("dependencies", 2, module),
-            fragmentBaseClass = renderer.requireClassArgument("dialogFragmentBaseClass", 3, module),
-            factory = renderer.requireClassArgument("rendererFactory", 4, module),
-            stateMachine = renderer.requireClassArgument("stateMachine", 5, module),
+            factory = renderer.requireClassArgument("rendererFactory", 3, module),
+            stateMachine = renderer.requireClassArgument("stateMachine", 4, module),
+            fragmentBaseClass = renderer.optionalClassArgument("dialogFragmentBaseClass", 5, module) ?: dialogFragment,
             navigation = renderer.toNavigation(6, 7, module),
             coroutinesEnabled = renderer.optionalBooleanArgument("coroutinesEnabled", 8) ?: false,
             rxJavaEnabled = renderer.optionalBooleanArgument("rxJavaEnabled", 9) ?: false,

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/renderer/RendererFragmentGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/renderer/RendererFragmentGenerator.kt
@@ -30,7 +30,7 @@ internal class RendererFragmentGenerator(
     internal fun generate(): TypeSpec {
         return TypeSpec.classBuilder(rendererFragmentClassName)
             .addAnnotation(optInAnnotation())
-            .superclass(fragment)
+            .superclass(data.fragmentBaseClass)
             .addProperty(lateinitPropertySpec(data.factory))
             .addProperty(lateinitPropertySpec(data.stateMachine))
             .addFunction(rendererOnCreateViewFun())

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
@@ -8,6 +8,8 @@ import org.jetbrains.kotlin.name.FqName
 // Whetstone Public API
 internal val rendererFragment = ClassName("com.freeletics.mad.whetstone", "RendererFragment")
 internal val rendererFragmentFqName = FqName(rendererFragment.canonicalName)
+internal val rendererDialogFragment = ClassName("com.freeletics.mad.whetstone", "RendererDialogFragment")
+internal val rendererDialogFragmentFqName = FqName(rendererDialogFragment.canonicalName)
 internal val composeFragment = ClassName("com.freeletics.mad.whetstone", "ComposeFragment")
 internal val composeFragmentFqName = FqName(composeFragment.canonicalName)
 internal val compose = ClassName("com.freeletics.mad.whetstone", "ComposeScreen")

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
@@ -61,6 +61,7 @@ internal val moduleFqName = FqName(module.canonicalName)
 
 // AndroidX
 internal val fragment = ClassName("androidx.fragment.app", "Fragment")
+internal val dialogFragment = ClassName("androidx.fragment.app", "DialogFragment")
 
 internal val onBackPressedDispatcher = ClassName("androidx.activity", "OnBackPressedDispatcher")
 internal val locaOnBackPressedDispatcherOwner = ClassName("androidx.activity.compose", "LocalOnBackPressedDispatcherOwner")

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestRendererFragment.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestRendererFragment.kt
@@ -14,6 +14,7 @@ class FileGeneratorTestRendererFragment {
         scope = ClassName("com.test", "TestScreen"),
         parentScope = ClassName("com.test.parent", "TestParentScope"),
         dependencies = ClassName("com.test", "TestDependencies"),
+        fragmentBaseClass = ClassName("androidx.fragment.app", "Fragment"),
         factory = ClassName("com.test", "RendererFactory"),
         stateMachine = ClassName("com.test", "TestStateMachine"),
         navigation = CommonData.Navigation(
@@ -243,6 +244,126 @@ class FileGeneratorTestRendererFragment {
 
                 rendererFactory = component.rendererFactory
                 testStateMachine = component.testStateMachine
+              }
+            }
+            
+        """.trimIndent()
+    }
+
+    @Test
+    fun `generates code for RendererFragmentData, dialog fragment`() {
+        val dialogFragment = full.copy(
+            fragmentBaseClass = ClassName("androidx.fragment.app", "DialogFragment")
+        )
+
+        FileGenerator().generate(dialogFragment).toString() shouldBe """
+            package com.test
+
+            import android.os.Bundle
+            import android.view.LayoutInflater
+            import android.view.View
+            import android.view.ViewGroup
+            import androidx.fragment.app.DialogFragment
+            import androidx.lifecycle.SavedStateHandle
+            import androidx.lifecycle.ViewModel
+            import com.freeletics.mad.whetstone.ScopeTo
+            import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
+            import com.freeletics.mad.whetstone.`internal`.viewModelProvider
+            import com.gabrielittner.renderer.connect.connect
+            import com.squareup.anvil.annotations.MergeComponent
+            import com.test.navigation.TestNavigationHandler
+            import com.test.parent.TestParentScope
+            import dagger.BindsInstance
+            import dagger.Component
+            import io.reactivex.disposables.CompositeDisposable
+            import kotlin.OptIn
+            import kotlin.Unit
+            import kotlinx.coroutines.CoroutineScope
+            import kotlinx.coroutines.MainScope
+            import kotlinx.coroutines.cancel
+
+            @InternalWhetstoneApi
+            @ScopeTo(TestScreen::class)
+            @MergeComponent(
+              scope = TestScreen::class,
+              dependencies = [TestDependencies::class]
+            )
+            internal interface RetainedTestComponent {
+              public val testStateMachine: TestStateMachine
+
+              public val testNavigator: TestNavigator
+
+              public val testNavigationHandler: TestNavigationHandler
+            
+              public val rendererFactory: RendererFactory
+
+              @Component.Factory
+              public interface Factory {
+                public fun create(
+                  dependencies: TestDependencies,
+                  @BindsInstance savedStateHandle: SavedStateHandle,
+                  @BindsInstance arguments: Bundle,
+                  @BindsInstance compositeDisposable: CompositeDisposable,
+                  @BindsInstance coroutineScope: CoroutineScope
+                ): RetainedTestComponent
+              }
+            }
+
+            @InternalWhetstoneApi
+            internal class TestViewModel(
+              dependencies: TestDependencies,
+              savedStateHandle: SavedStateHandle,
+              arguments: Bundle
+            ) : ViewModel() {
+              private val disposable: CompositeDisposable = CompositeDisposable()
+
+              private val scope: CoroutineScope = MainScope()
+
+              public val component: RetainedTestComponent =
+                  DaggerRetainedTestComponent.factory().create(dependencies, savedStateHandle, arguments,
+                  disposable, scope)
+
+              public override fun onCleared(): Unit {
+                disposable.clear()
+                scope.cancel()
+              }
+            }
+            
+            @OptIn(InternalWhetstoneApi::class)
+            public class TestFragment : DialogFragment() {
+              private lateinit var rendererFactory: RendererFactory
+
+              private lateinit var testStateMachine: TestStateMachine
+
+              public override fun onCreateView(
+                inflater: LayoutInflater,
+                container: ViewGroup?,
+                savedInstanceState: Bundle?
+              ): View {
+                if (!::testStateMachine.isInitialized) {
+                  inject()
+                }
+            
+                val renderer = rendererFactory.inflate(inflater, container)
+                connect(renderer, testStateMachine)
+                return renderer.rootView
+              }
+
+              private fun inject(): Unit {
+                val viewModelProvider = viewModelProvider<TestDependencies>(this, TestParentScope::class) {
+                    dependencies, handle -> 
+                  val arguments = arguments ?: Bundle.EMPTY
+                  TestViewModel(dependencies, handle, arguments)
+                }
+                val viewModel = viewModelProvider[TestViewModel::class.java]
+                val component = viewModel.component
+
+                rendererFactory = component.rendererFactory
+                testStateMachine = component.testStateMachine
+
+                val handler = component.testNavigationHandler
+                val navigator = component.testNavigator
+                handler.handle(this, navigator)
               }
             }
             

--- a/whetstone/runtime/src/main/java/com/freeletics/mad/whetstone/RendererDialogFragment.kt
+++ b/whetstone/runtime/src/main/java/com/freeletics/mad/whetstone/RendererDialogFragment.kt
@@ -65,13 +65,13 @@ annotation class RendererDialogFragment(
     val parentScope: KClass<*>,
     val dependencies: KClass<*>,
 
-    val dialogFragmentBaseClass: KClass<out DialogFragment>,
     //TODO should be KClass<out ViewRenderer.Factory<*, *>>
     // leaving out the constraint for now to be compatible with some custom factories using the same signature
     val rendererFactory: KClass<*>,
     //TODO should be KClass<out StateMachine<*, *>>
     // leaving out the constraint for now to be compatible with Renderer's LiveDataStateMachine
     val stateMachine: KClass<*>,
+    val dialogFragmentBaseClass: KClass<out DialogFragment> = DialogFragment::class,
 
     val navigator: KClass<out Navigator> = EmptyNavigator::class,
     val navigationHandler: KClass<out NavigationHandler<*>> = EmptyNavigationHandler::class,

--- a/whetstone/runtime/src/main/java/com/freeletics/mad/whetstone/RendererDialogFragment.kt
+++ b/whetstone/runtime/src/main/java/com/freeletics/mad/whetstone/RendererDialogFragment.kt
@@ -1,5 +1,6 @@
 package com.freeletics.mad.whetstone
 
+import androidx.fragment.app.DialogFragment
 import com.freeletics.mad.whetstone.internal.EmptyNavigationHandler
 import com.freeletics.mad.whetstone.internal.EmptyNavigator
 import com.freeletics.mad.navigator.NavigationHandler
@@ -10,9 +11,10 @@ import kotlin.annotation.AnnotationTarget.CLASS
 import kotlin.reflect.KClass
 
 /**
- * By adding this annotation to a [com.gabrielittner.renderer.ViewRenderer] class, a Fragment is
- * generated that will have the same name with `Fragment` as suffix. The Fragment will use the
- * given [rendererFactory] as it's view.
+ * By adding this annotation to a [com.gabrielittner.renderer.ViewRenderer] class, a
+ * DialogFragment is generated that will have the same name with `Fragment` as suffix. The
+ * DialogFragment will use the given [dialogFragmentBaseClass] as it's super class and
+ * the [rendererFactory] as it's view.
  *
  * **StateMachine**
  *
@@ -58,11 +60,12 @@ import kotlin.reflect.KClass
  */
 @Target(CLASS)
 @Retention(RUNTIME)
-annotation class RendererFragment(
+annotation class RendererDialogFragment(
     val scope: KClass<*>,
     val parentScope: KClass<*>,
     val dependencies: KClass<*>,
 
+    val dialogFragmentBaseClass: KClass<out DialogFragment>,
     //TODO should be KClass<out ViewRenderer.Factory<*, *>>
     // leaving out the constraint for now to be compatible with some custom factories using the same signature
     val rendererFactory: KClass<*>,


### PR DESCRIPTION
This works the same as the already existing `@RendererFragment` annotation. The only difference is a new `val dialogFragmentBaseClass: KClass<out DialogFragment>` parameter. That parameter exists so that we also support `BottomSheetDialogFragment`.

On the codegen side `RendererFragmentData` does now have a `fragmentBaseClass` field that is always `androidx.fragment.app.Fragment` for the existing annotation and the `dialogFragmentBaseClass` parameter for the new annoation. The field is then used as a super class for the generated `Fragment`.