### PR TITLE
add NavEventNavigator implementation

### DIFF
--- a/navigator/runtime-compose/build.gradle
+++ b/navigator/runtime-compose/build.gradle
@@ -1,0 +1,58 @@
+apply plugin: 'com.android.library'
+apply plugin: 'org.jetbrains.kotlin.android'
+apply plugin: 'com.vanniktech.maven.publish'
+
+android {
+    compileSdkVersion 31
+
+    defaultConfig {
+        minSdkVersion 21
+    }
+
+    buildFeatures {
+        compose = true
+    }
+
+    // still needed for Android projects despite toolchain
+    compileOptions {
+        sourceCompatibility(JavaVersion.VERSION_11)
+        targetCompatibility(JavaVersion.VERSION_11)
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.0.4"
+    }
+}
+
+// workaround for https://youtrack.jetbrains.com/issue/KT-37652
+android.kotlinOptions.freeCompilerArgs += "-Xexplicit-api=strict"
+
+kotlin {
+    explicitApi()
+
+    jvmToolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+
+    sourceSets.all {
+        languageSettings {
+            optIn("kotlin.RequiresOptIn")
+        }
+    }
+}
+
+// workaround for https://issuetracker.google.com/issues/194113162
+tasks.withType(JavaCompile).configureEach {
+    javaCompiler = javaToolchains.compilerFor {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
+}
+
+dependencies {
+    api project(":navigator:common-compose")
+    api project(":navigator:runtime")
+    api "androidx.activity:activity-compose:1.4.0"
+    api "androidx.lifecycle:lifecycle-runtime-ktx:2.4.0"
+    api "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2"
+    api "androidx.compose.runtime:runtime:1.0.4"
+}

--- a/navigator/runtime-compose/gradle.properties
+++ b/navigator/runtime-compose/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=navigator-runtime-compose
+POM_NAME=Navigator Runtime Compose
+POM_DESCRIPTION=Navigator Runtime Compose

--- a/navigator/runtime-compose/src/main/AndroidManifest.xml
+++ b/navigator/runtime-compose/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="com.freeletics.mad.navigator.fragment" />

--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavEventNavigationHandler.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavEventNavigationHandler.kt
@@ -1,0 +1,145 @@
+package com.freeletics.mad.navigator.compose
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.ActivityResultLauncher
+import androidx.annotation.CallSuper
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.core.app.ActivityCompat
+import androidx.lifecycle.flowWithLifecycle
+import androidx.navigation.NavController
+import com.freeletics.mad.navigator.NavEvent
+import com.freeletics.mad.navigator.NavEventNavigator
+import com.freeletics.mad.navigator.NavEvent.BackEvent
+import com.freeletics.mad.navigator.NavEvent.BackToEvent
+import com.freeletics.mad.navigator.NavEvent.NavigateToEvent
+import com.freeletics.mad.navigator.NavEvent.ResultLauncherEvent
+import com.freeletics.mad.navigator.NavEvent.UpEvent
+import com.freeletics.mad.navigator.internal.InternalNavigatorApi
+import com.freeletics.mad.navigator.internal.RequestPermissionsContract
+import com.freeletics.mad.navigator.ActivityResultRequest
+import com.freeletics.mad.navigator.PermissionsResultRequest
+import com.freeletics.mad.navigator.PermissionsResultRequest.PermissionResult.GRANTED
+import com.freeletics.mad.navigator.PermissionsResultRequest.PermissionResult.DENIED_PERMANENTLY
+import com.freeletics.mad.navigator.PermissionsResultRequest.PermissionResult.DENIED
+import com.freeletics.mad.navigator.ResultLauncher
+import java.lang.IllegalArgumentException
+import kotlinx.coroutines.flow.collect
+
+/**
+ * A [NavigationHandler] that handles [NavEvent] emitted by a [NavEventNavigator].
+ */
+public open class NavEventNavigationHandler : NavigationHandler<NavEventNavigator> {
+
+    @Composable
+    @OptIn(InternalNavigatorApi::class)
+    @CallSuper
+    override fun Navigation(navController: NavController, navigator: NavEventNavigator) {
+        val lifecycleOwner = LocalLifecycleOwner.current
+
+        val activityLaunchers = navigator.activityResultRequests.associateWith {
+            rememberResultLaunchers(it)
+        }
+        val permissionLaunchers = navigator.permissionsResultRequests.associateWith {
+            rememberResultLaunchers(it)
+        }
+        val launchers: Map<ResultLauncher<*>, ActivityResultLauncher<*>> = activityLaunchers + permissionLaunchers
+
+        val backDispatcher = LocalOnBackPressedDispatcherOwner.current!!.onBackPressedDispatcher
+        DisposableEffect(lifecycleOwner, backDispatcher, navigator) {
+            backDispatcher.addCallback(lifecycleOwner, navigator.onBackPressedCallback)
+
+            onDispose {
+                navigator.onBackPressedCallback.remove()
+            }
+        }
+
+        LaunchedEffect(lifecycleOwner, navController, navigator) {
+            navigator.navEvents
+                .flowWithLifecycle(lifecycleOwner.lifecycle)
+                .collect { navEvent ->
+                    navigate(navController, launchers, navEvent)
+                }
+        }
+    }
+
+    @Composable
+    private fun <I, O> rememberResultLaunchers(
+        request: ActivityResultRequest<I, O>,
+    ): ActivityResultLauncher<*> {
+        return rememberLauncherForActivityResult(request.contract, request::onResult)
+    }
+
+    @Composable
+    @OptIn(InternalNavigatorApi::class)
+    private fun rememberResultLaunchers(
+        request: PermissionsResultRequest,
+    ): ActivityResultLauncher<List<String>> {
+        val context = LocalContext.current
+        return rememberLauncherForActivityResult(RequestPermissionsContract()) { resultMap ->
+            val permissionsResult = resultMap.mapValues { (permission, granted) ->
+                when {
+                    granted -> GRANTED
+                    context.shouldShowRequestPermissionRationale(permission) -> DENIED
+                    else -> DENIED_PERMANENTLY
+                }
+            }
+            request.onResult(permissionsResult)
+        }
+    }
+
+    private fun Context.shouldShowRequestPermissionRationale(permission: String): Boolean {
+        return ActivityCompat.shouldShowRequestPermissionRationale(findActivity(), permission)
+    }
+
+    private fun Context.findActivity(): Activity {
+        var context = this
+        while (context is ContextWrapper) {
+            if (context is Activity) return context
+            context = context.baseContext
+        }
+        throw IllegalStateException("Permissions should be called in the context of an Activity")
+    }
+
+    private fun navigate(
+        controller: NavController,
+        resultLaunchers: Map<ResultLauncher<*>, ActivityResultLauncher<*>>,
+        navEvent: NavEvent
+    ) {
+        when (navEvent) {
+            is NavigateToEvent -> {
+                controller.navigate(
+                    navEvent.navRoute.destinationId,
+                    navEvent.navRoute.getArguments(),
+                    navEvent.navOptions,
+                )
+            }
+            is UpEvent -> {
+                controller.navigateUp()
+            }
+            is BackEvent -> {
+                controller.popBackStack()
+            }
+            is BackToEvent -> {
+                controller.popBackStack(navEvent.destinationId, navEvent.inclusive)
+            }
+            is ResultLauncherEvent<*> -> {
+                val request = navEvent.resultLauncher
+                val launcher = resultLaunchers[request] ?: throw IllegalStateException(
+                    "No launcher registered for $request!\nMake sure you called the appropriate " +
+                        "AbstractNavigator.registerFor... method"
+                )
+                @Suppress("UNCHECKED_CAST")
+                (launcher as ActivityResultLauncher<Any?>).launch(navEvent.input)
+            }
+            else -> throw IllegalArgumentException("Unknown NavEvent $navEvent")
+        }
+    }
+}

--- a/navigator/runtime-fragment/build.gradle
+++ b/navigator/runtime-fragment/build.gradle
@@ -1,0 +1,55 @@
+apply plugin: 'com.android.library'
+apply plugin: 'org.jetbrains.kotlin.android'
+apply plugin: 'com.vanniktech.maven.publish'
+
+android {
+    compileSdkVersion 31
+
+    defaultConfig {
+        minSdkVersion 21
+    }
+
+    // still needed for Android projects despite toolchain
+    compileOptions {
+        sourceCompatibility(JavaVersion.VERSION_11)
+        targetCompatibility(JavaVersion.VERSION_11)
+    }
+}
+
+// workaround for https://youtrack.jetbrains.com/issue/KT-37652
+android.kotlinOptions.freeCompilerArgs += "-Xexplicit-api=strict"
+
+kotlin {
+    explicitApi()
+
+    jvmToolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+
+    sourceSets.all {
+        languageSettings {
+            optIn("kotlin.RequiresOptIn")
+        }
+    }
+}
+
+// workaround for https://issuetracker.google.com/issues/194113162
+tasks.withType(JavaCompile).configureEach {
+    javaCompiler = javaToolchains.compilerFor {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
+}
+
+dependencies {
+    api project(":navigator:common-fragment")
+    api project(":navigator:runtime")
+    api "androidx.lifecycle:lifecycle-runtime-ktx:2.4.0"
+    api "androidx.fragment:fragment:1.3.6"
+    api "androidx.navigation:navigation-runtime-ktx:2.3.5"
+    api "androidx.navigation:navigation-fragment-ktx:2.3.5"
+    api "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2"
+
+    testImplementation "junit:junit:4.13.2"
+    testImplementation "com.google.truth:truth:1.1.3"
+    testImplementation "app.cash.turbine:turbine:0.7.0"
+}

--- a/navigator/runtime-fragment/gradle.properties
+++ b/navigator/runtime-fragment/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=navigator-runtime-fragment
+POM_NAME=Navigator Runtime Fragment
+POM_DESCRIPTION=Navigator Runtime Fragment

--- a/navigator/runtime-fragment/src/main/AndroidManifest.xml
+++ b/navigator/runtime-fragment/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="com.freeletics.mad.navigator.fragment" />

--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/FragmentNavEventNavigator.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/FragmentNavEventNavigator.kt
@@ -1,0 +1,66 @@
+package com.freeletics.mad.navigator.fragment
+
+import android.os.Parcelable
+import com.freeletics.mad.navigator.NavEvent
+import com.freeletics.mad.navigator.NavEventNavigator
+import com.freeletics.mad.navigator.Navigator
+import com.freeletics.mad.navigator.fragment.result.FragmentResultRequest
+import com.freeletics.mad.navigator.internal.InternalNavigatorApi
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * An extension to [NavEventNavigator] that adds support for `Fragment` result APIs. See
+ * [registerForFragmentResult] and [navigateBackWithResult].
+ */
+@Suppress("MemberVisibilityCanBePrivate", "unused")
+public abstract class FragmentNavEventNavigator : NavEventNavigator() {
+
+    private val _fragmentResultRequests = mutableListOf<FragmentResultRequest<*>>()
+
+    /**
+     * Register for receiving fragment results for the given [requestKey].
+     *
+     * The returned [FragmentResultRequest] can be used to collect incoming permission results (via
+     * [FragmentResultRequest.results]).
+     *
+     * Note: This has to be called *before* this [FragmentNavEventNavigator] gets attached to a fragment.
+     *   In practice, this means it should usually be called during initialisation of your subclass.
+     */
+    public fun <O> registerForFragmentResult(requestKey: String): FragmentResultRequest<O> {
+        checkAllowedToAddRequests()
+        val request = FragmentResultRequest<O>(requestKey)
+        _fragmentResultRequests.add(request)
+        return request
+    }
+
+    /**
+     * Triggers a new [NavEvent] that sets the fragment [result] for the given [requestKey] and then
+     * navigates back to the previous destination.
+     */
+    public fun <T : Parcelable> navigateBackWithResult(requestKey: String, result: T) {
+        val event = FragmentResultEvent(requestKey, result)
+        sendNavEvent(event)
+        navigateBack()
+    }
+
+    private var allowedToAddRequests = true
+
+    private fun checkAllowedToAddRequests() {
+        check(allowedToAddRequests) {
+            "Failed to register for result! You must call this before this navigator " +
+                "gets attached to a fragment, e.g. during initialisation of your navigator subclass."
+        }
+    }
+
+    /**
+     * Access to [FragmentResultRequest] objects that were registered with
+     * [registerForFragmentResult]. A `NavEventNavigationHandler` can use these to register
+     * the requests during setup so that results are delivered to them.
+     */
+    @InternalNavigatorApi
+    public val fragmentResultRequests: List<FragmentResultRequest<*>>
+        get() {
+            allowedToAddRequests = false
+            return _fragmentResultRequests.toList()
+        }
+}

--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/FragmentResultEvent.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/FragmentResultEvent.kt
@@ -1,0 +1,14 @@
+package com.freeletics.mad.navigator.fragment
+
+import android.os.Parcelable
+import com.freeletics.mad.navigator.NavEvent
+import com.freeletics.mad.navigator.NavEventNavigator
+
+/**
+ * Delivers a `Fragment` result to a requester that started this `Fragment` with
+ * [NavEventNavigator.navigateForResult].
+ */
+public data class FragmentResultEvent(
+    val requestKey: String,
+    val result: Parcelable
+) : NavEvent

--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavEventNavigationHandler.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavEventNavigationHandler.kt
@@ -1,0 +1,150 @@
+package com.freeletics.mad.navigator.fragment
+
+import android.app.Activity
+import android.os.Bundle
+import androidx.activity.result.ActivityResultCaller
+import androidx.activity.result.ActivityResultLauncher
+import androidx.annotation.CallSuper
+import androidx.core.app.ActivityCompat.shouldShowRequestPermissionRationale
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentResultOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.coroutineScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.navigation.fragment.findNavController
+import com.freeletics.mad.navigator.NavEvent
+import com.freeletics.mad.navigator.NavEventNavigator
+import com.freeletics.mad.navigator.NavEvent.BackEvent
+import com.freeletics.mad.navigator.NavEvent.BackToEvent
+import com.freeletics.mad.navigator.NavEvent.NavigateToEvent
+import com.freeletics.mad.navigator.NavEvent.ResultLauncherEvent
+import com.freeletics.mad.navigator.NavEvent.UpEvent
+import com.freeletics.mad.navigator.fragment.result.FragmentResultRequest
+import com.freeletics.mad.navigator.internal.InternalNavigatorApi
+import com.freeletics.mad.navigator.ActivityResultRequest
+import com.freeletics.mad.navigator.PermissionsResultRequest
+import com.freeletics.mad.navigator.PermissionsResultRequest.PermissionResult.GRANTED
+import com.freeletics.mad.navigator.PermissionsResultRequest.PermissionResult.DENIED_PERMANENTLY
+import com.freeletics.mad.navigator.PermissionsResultRequest.PermissionResult.DENIED
+import com.freeletics.mad.navigator.ResultLauncher
+import com.freeletics.mad.navigator.internal.RequestPermissionsContract
+import java.lang.IllegalArgumentException
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+
+/**
+ * A [NavigationHandler] that handles [NavEvent] emitted by a [NavEventNavigator].
+ */
+public open class NavEventNavigationHandler : NavigationHandler<FragmentNavEventNavigator> {
+
+    @OptIn(InternalNavigatorApi::class)
+    @CallSuper
+    override fun handle(fragment: Fragment, navigator: FragmentNavEventNavigator) {
+        val activityLaunchers = navigator.activityResultRequests.associateWith {
+            it.registerIn(fragment)
+        }
+        val permissionLaunchers = navigator.permissionsResultRequests.associateWith {
+            it.registerIn(fragment, fragment.requireActivity())
+        }
+        val launchers: Map<ResultLauncher<*>, ActivityResultLauncher<*>> = activityLaunchers + permissionLaunchers
+
+        navigator.fragmentResultRequests.forEach {
+            it.registerIn(fragment.parentFragmentManager, fragment)
+        }
+
+        val dispatcher = fragment.requireActivity().onBackPressedDispatcher
+        dispatcher.addCallback(fragment, navigator.onBackPressedCallback)
+
+        val lifecycle = fragment.lifecycle
+        lifecycle.coroutineScope.launch {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                navigator.navEvents.collect { navEvent ->
+                    navigate(fragment, launchers, navEvent)
+                }
+            }
+        }
+    }
+
+    private fun <I, O> ActivityResultRequest<I, O>.registerIn(
+        caller: ActivityResultCaller
+    ): ActivityResultLauncher<*> {
+        return caller.registerForActivityResult(contract, ::onResult)
+    }
+
+    @OptIn(InternalNavigatorApi::class)
+    private fun PermissionsResultRequest.registerIn(
+        caller: ActivityResultCaller,
+        activity: Activity
+    ): ActivityResultLauncher<List<String>> {
+        return caller.registerForActivityResult(RequestPermissionsContract()) { resultMap ->
+            val permissionsResult = resultMap.mapValues { (permission, granted) ->
+                when {
+                    granted -> GRANTED
+                    shouldShowRequestPermissionRationale(activity, permission) -> DENIED
+                    else -> DENIED_PERMANENTLY
+                }
+            }
+            onResult(permissionsResult)
+        }
+    }
+
+    private fun <O> FragmentResultRequest<O>.registerIn(
+        fragmentResultOwner: FragmentResultOwner,
+        lifecycleOwner: LifecycleOwner
+    ) {
+        fragmentResultOwner.setFragmentResultListener(requestKey, lifecycleOwner) { _, bundle ->
+            onResult(bundle.getParcelable(KEY_FRAGMENT_RESULT)!!)
+        }
+    }
+
+    private fun navigate(
+        fragment: Fragment,
+        resultLaunchers: Map<ResultLauncher<*>, ActivityResultLauncher<*>>,
+        navEvent: NavEvent
+    ) {
+        when (navEvent) {
+            is NavigateToEvent -> {
+                val controller = fragment.findNavController()
+                controller.navigate(
+                    navEvent.navRoute.destinationId,
+                    navEvent.navRoute.getArguments(),
+                    navEvent.navOptions,
+                )
+            }
+            is UpEvent -> {
+                val controller = fragment.findNavController()
+                controller.navigateUp()
+            }
+            is BackEvent -> {
+                val controller = fragment.findNavController()
+                controller.popBackStack()
+            }
+            is BackToEvent -> {
+                val controller = fragment.findNavController()
+                controller.popBackStack(navEvent.destinationId, navEvent.inclusive)
+            }
+            is ResultLauncherEvent<*> -> {
+                val request = navEvent.resultLauncher
+                val launcher = resultLaunchers[request] ?: throw IllegalStateException(
+                    "No launcher registered for $request!\nMake sure you called the appropriate " +
+                        "AbstractNavigator.registerFor... method"
+                )
+                @Suppress("UNCHECKED_CAST")
+                (launcher as ActivityResultLauncher<Any?>).launch(navEvent.input)
+            }
+            is FragmentResultEvent -> {
+                val result = Bundle(1).apply {
+                    putParcelable(KEY_FRAGMENT_RESULT, navEvent.result)
+                }
+                fragment.parentFragmentManager.setFragmentResult(navEvent.requestKey, result)
+            }
+            else -> throw IllegalArgumentException("Unknown NavEvent $navEvent")
+        }
+    }
+}
+
+/**
+ * Internal key used to store the result data in the result [Bundle].
+ */
+private const val KEY_FRAGMENT_RESULT = "fragment_result"

--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/result/FragmentResultRequest.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/result/FragmentResultRequest.kt
@@ -1,0 +1,14 @@
+package com.freeletics.mad.navigator.fragment.result
+
+import com.freeletics.mad.navigator.ResultOwner
+
+/**
+ * Class that exposes a [results] [Flow] that can be used to observe incoming fragment results for
+ * the given [requestKey].
+ *
+ * See [ResultOwner] and
+ * [com.freeletics.mad.navigator.fragment.FragmentNavEventNavigator.registerForFragmentResult].
+ */
+public class FragmentResultRequest<O> internal constructor(
+    internal val requestKey: String
+) : ResultOwner<O>()

--- a/navigator/runtime-fragment/src/test/java/com/freeletics/mad/navigator/fragment/FragmentNavEventNavigatorTest.kt
+++ b/navigator/runtime-fragment/src/test/java/com/freeletics/mad/navigator/fragment/FragmentNavEventNavigatorTest.kt
@@ -1,0 +1,50 @@
+package com.freeletics.mad.navigator.fragment
+
+import android.os.Bundle
+import androidx.activity.result.contract.ActivityResultContracts
+import app.cash.turbine.test
+import com.freeletics.mad.navigator.NavEvent
+import com.freeletics.mad.navigator.NavRoute
+import com.freeletics.mad.navigator.internal.InternalNavigatorApi
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+public class FragmentNavEventNavigatorTest {
+
+    private class TestNavigator : FragmentNavEventNavigator()
+    private data class SimpleRoute(override val destinationId: Int) : NavRoute
+
+    @Test
+    public fun `navigateBackWithResult is received`(): Unit = runBlocking {
+        val navigator = TestNavigator()
+
+        navigator.navEvents.test {
+            val result = Bundle()
+            navigator.navigateBackWithResult("test-key", result)
+
+            assertThat(awaitItem()).isEqualTo(FragmentResultEvent("test-key", result))
+            assertThat(awaitItem()).isEqualTo(NavEvent.BackEvent)
+
+            cancel()
+        }
+    }
+
+    @OptIn(InternalNavigatorApi::class)
+    @Test
+    public fun `registerForActivityResult after read is disallowed`(): Unit = runBlocking {
+        val navigator = TestNavigator()
+
+        navigator.fragmentResultRequests
+
+        val exception = assertThrows(IllegalStateException::class.java) {
+            navigator.registerForFragmentResult<String>("test")
+        }
+        assertThat(exception).hasMessageThat().isEqualTo(
+            "Failed to register for " +
+                "result! You must call this before this navigator gets attached to a " +
+                "fragment, e.g. during initialisation of your navigator subclass."
+        )
+    }
+}

--- a/navigator/runtime/build.gradle
+++ b/navigator/runtime/build.gradle
@@ -1,0 +1,53 @@
+apply plugin: 'com.android.library'
+apply plugin: 'org.jetbrains.kotlin.android'
+apply plugin: 'com.vanniktech.maven.publish'
+
+android {
+    compileSdkVersion 31
+
+    defaultConfig {
+        minSdkVersion 21
+    }
+
+    // still needed for Android projects despite toolchain
+    compileOptions {
+        sourceCompatibility(JavaVersion.VERSION_11)
+        targetCompatibility(JavaVersion.VERSION_11)
+    }
+}
+
+// workaround for https://youtrack.jetbrains.com/issue/KT-37652
+android.kotlinOptions.freeCompilerArgs += "-Xexplicit-api=strict"
+
+kotlin {
+    explicitApi()
+
+    jvmToolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+
+    sourceSets.all {
+        languageSettings {
+            optIn("kotlin.RequiresOptIn")
+        }
+    }
+}
+
+// workaround for https://issuetracker.google.com/issues/194113162
+tasks.withType(JavaCompile).configureEach {
+    javaCompiler = javaToolchains.compilerFor {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
+}
+
+dependencies {
+    api project(":navigator:common")
+    api "androidx.activity:activity:1.4.0"
+    api "androidx.navigation:navigation-runtime:2.3.5"
+    api "androidx.navigation:navigation-runtime-ktx:2.3.5"
+    api "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2"
+
+    testImplementation "junit:junit:4.13.2"
+    testImplementation "com.google.truth:truth:1.1.3"
+    testImplementation "app.cash.turbine:turbine:0.7.0"
+}

--- a/navigator/runtime/gradle.properties
+++ b/navigator/runtime/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=navigator-runtime
+POM_NAME=Navigator Runtime
+POM_DESCRIPTION=Navigator Runtime

--- a/navigator/runtime/src/main/AndroidManifest.xml
+++ b/navigator/runtime/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="com.freeletics.mad.navigator.runtime" />

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEvent.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEvent.kt
@@ -1,0 +1,50 @@
+package com.freeletics.mad.navigator
+
+import androidx.annotation.IdRes
+import androidx.navigation.NavOptions
+
+/**
+ * Represents a navigation event that is being sent by a [NavEventNavigator] and handled by
+ * a `NavEventNavigationHandler` implementation. Default implementations of such a handler are
+ * provided in separate artifacts.
+ *
+ * Custom subclasses of `NavEvent` can be sent using [NavEventNavigator.sendNavEvent] but require
+ * providing a custom `NavEventNavigationHandler` that supports handling those events.
+ */
+public interface NavEvent {
+
+    /**
+     * Navigates to the given [navRoute] using the optionally passed [navOptions].
+     */
+    public data class NavigateToEvent(
+        val navRoute: NavRoute,
+        val navOptions: NavOptions? = null,
+    ) : NavEvent
+
+    /**
+     * Navigates up.
+     */
+    public object UpEvent : NavEvent
+
+    /**
+     * Navigates back.
+     */
+    public object BackEvent : NavEvent
+
+    /**
+     * Navigates back to the given [destinationId]. If [inclusive] is `true` the destination itself
+     * will also be popped of the back stack.
+     */
+    public data class BackToEvent(
+        @IdRes val destinationId: Int,
+        val inclusive: Boolean,
+    ) : NavEvent
+
+    /**
+     * Launches the [resultLauncher] to retrieve an event.
+     */
+    public data class ResultLauncherEvent<I>(
+        val resultLauncher: ResultLauncher<I>,
+        val input: I,
+    ) : NavEvent
+}

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
@@ -1,0 +1,264 @@
+package com.freeletics.mad.navigator
+
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.annotation.IdRes
+import androidx.navigation.NavOptions
+import androidx.navigation.NavOptionsBuilder
+import androidx.navigation.navOptions
+import com.freeletics.mad.navigator.NavEvent.BackEvent
+import com.freeletics.mad.navigator.NavEvent.BackToEvent
+import com.freeletics.mad.navigator.NavEvent.ResultLauncherEvent
+import com.freeletics.mad.navigator.NavEvent.NavigateToEvent
+import com.freeletics.mad.navigator.NavEvent.UpEvent
+import com.freeletics.mad.navigator.internal.DelegatingOnBackPressedCallback
+import com.freeletics.mad.navigator.internal.InternalNavigatorApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+
+/**
+ * A [Navigator] implementation that allows to fire [events][NavEvent] through it's methods. These
+ * events are publicly exposed through the [navEvents] [Flow] that can be collected and acted upon
+ * by a `NavigationHandler`. This allows to trigger navigation actions from outside the view layer
+ * without keeping references to Android framework classes that might leak. It also improves
+ * the testability of your navigation logic since it is possible to just write test that
+ * the correct events were emitted.
+ *
+ * For back press handling based on logic [backPresses] is available. Activity results and
+ * permission requests can be handled through [registerForActivityResult]/[navigateForResult]
+ * and [registerForPermissionsResult]/[requestPermissions] respectively.
+ */
+@Suppress("MemberVisibilityCanBePrivate", "unused")
+public abstract class NavEventNavigator : Navigator {
+
+    private val _navEvents = Channel<NavEvent>(Channel.UNLIMITED)
+
+    /**
+     * A [Flow] to collect [NavEvents][NavEvent] produced by this navigator.
+     */
+    public val navEvents: Flow<NavEvent> = _navEvents.receiveAsFlow()
+
+    private val _activityResultRequests = mutableListOf<ActivityResultRequest<*, *>>()
+    private val _permissionsResultRequests = mutableListOf<PermissionsResultRequest>()
+    private val _onBackPressedCallback = DelegatingOnBackPressedCallback()
+
+    /**
+     * Register for receiving activity results for the given [contract].
+     *
+     * The returned [ActivityResultRequest] can be used to collect incoming results (via
+     * [ActivityResultRequest.results]) and to launch the actual activity result call via
+     * [NavEventNavigator.navigateForResult].
+     *
+     * For permission requests prefer using [registerForPermissionsResult] instead.
+     *
+     * Note: This has to be called *before* this [NavEventNavigator] gets attached to a fragment.
+     *   In practice, this means it should usually be called during initialisation of your subclass.
+     */
+    public fun <I, O> registerForActivityResult(
+        contract: ActivityResultContract<I, O>
+    ): ActivityResultRequest<I, O> {
+        checkAllowedToAddRequests()
+        val request = ActivityResultRequest(contract)
+        _activityResultRequests.add(request)
+        return request
+    }
+
+    /**
+     * Register for receiving permission results.
+     *
+     * The returned [PermissionsResultRequest] can be used to collect incoming permission results (via
+     * [PermissionsResultRequest.results]) and to launch the actual permission result call via
+     * [NavEventNavigator.requestPermissions].
+     *
+     * Compared to using [registerForActivityResult] with
+     * [androidx.activity.result.contract.ActivityResultContracts.RequestPermission] this also
+     * gives you the information whether a permission was
+     * [permanently denied][PermissionsResultRequest.PermissionResult.DENIED_PERMANENTLY].
+     *
+     * Note: This has to be called *before* this [NavEventNavigator] gets attached to a fragment.
+     *   In practice, this means it should usually be called during initialisation of your subclass.
+     */
+    public fun registerForPermissionsResult(): PermissionsResultRequest {
+        checkAllowedToAddRequests()
+        val request = PermissionsResultRequest()
+        _permissionsResultRequests.add(request)
+        return request
+    }
+
+    /**
+     * Sends the given new [NavEvent] to the `NavigationHandler` connected to this navigator.
+     */
+    protected fun sendNavEvent(event: NavEvent) {
+        val result = _navEvents.trySendBlocking(event)
+        check(result.isSuccess)
+    }
+
+    /**
+     * Triggers a new [NavEvent] to navigate to the given [route].
+     */
+    public fun navigateTo(route: NavRoute) {
+        val event = NavigateToEvent(route)
+        sendNavEvent(event)
+    }
+
+    /**
+     * Triggers a new [NavEvent] to navigate to the given [route], using [NavOptions]
+     * built with [optionsBuilder].
+     */
+    public fun navigateTo(
+        route: NavRoute,
+        optionsBuilder: NavOptionsBuilder.() -> Unit
+    ) {
+        val event = NavigateToEvent(route, navOptions(optionsBuilder))
+        sendNavEvent(event)
+    }
+
+    /**
+     * Triggers a new [NavEvent] that causes up navigation.
+     */
+    public fun navigateUp() {
+        val event = UpEvent
+        sendNavEvent(event)
+    }
+
+    /**
+     * Triggers a new [NavEvent] that pops the back stack to the previous destination.
+     */
+    public fun navigateBack() {
+        val event = BackEvent
+        sendNavEvent(event)
+    }
+
+    /**
+     * Triggers a new [NavEvent] that pops the back stack to [actionId]. If [inclusive] is `true`
+     * [actionId] itself will also be popped.
+     */
+    public fun navigateBack(@IdRes actionId: Int, inclusive: Boolean = false) {
+        val event = BackToEvent(actionId, inclusive)
+        sendNavEvent(event)
+    }
+
+    /**
+     * Triggers a new [NavEvent] that launches the given [resultLauncher].
+     *
+     * The [resultLauncher] can be obtained by calling [registerForActivityResult].
+     */
+    public fun navigateForResult(resultLauncher: ResultLauncher<Void?>) {
+        navigateForResult(resultLauncher, null)
+    }
+
+    /**
+     * Triggers a new [NavEvent] that launches the given [resultLauncher] with the given [input].
+     *
+     * The [resultLauncher] can be obtained by calling [registerForActivityResult].
+     */
+    public fun <I> navigateForResult(resultLauncher: ResultLauncher<I>, input: I) {
+        val event = ResultLauncherEvent(resultLauncher, input)
+        sendNavEvent(event)
+    }
+
+    /**
+     * Triggers a new [NavEvent] that requests the given [permissions].
+     *
+     * Compared to using [navigateForResult] with
+     * [androidx.activity.result.contract.ActivityResultContracts.RequestPermission] this also
+     * gives you the information whether a permission was
+     * [permanently denied][PermissionsResultRequest.PermissionResult.DENIED_PERMANENTLY].
+     *
+     * The [request] can be obtained by calling [registerForPermissionsResult].
+     */
+    public fun requestPermissions(request: PermissionsResultRequest, vararg permissions: String) {
+        requestPermissions(request, permissions.toList())
+    }
+
+    /**
+     * Triggers a new [NavEvent] that requests the given [permissions].
+     *
+     * Compared to using [navigateForResult] with
+     * [androidx.activity.result.contract.ActivityResultContracts.RequestPermission] this also
+     * gives you the information whether a permission was
+     * [permanently denied][PermissionsResultRequest.PermissionResult.DENIED_PERMANENTLY].
+     *
+     * The [request] can be obtained by calling [registerForPermissionsResult].
+     */
+    public fun requestPermissions(request: PermissionsResultRequest, permissions: List<String>) {
+        navigateForResult(request, permissions.toList())
+    }
+
+    /**
+     * Returns a [Flow] that will emit [Unit] on every back press. While this Flow is being collected
+     * all back presses will be intercepted and none of the default back press handling happens.
+     *
+     * When this is called multiple times only the latest caller will receive emissions.
+     */
+    @ExperimentalCoroutinesApi
+    public fun backPresses(): Flow<Unit> {
+        return backPresses(Unit)
+    }
+
+    /**
+     * Returns a [Flow] that will emit [value] on every back press. While this Flow is being collected
+     * all back presses will be intercepted and none of the default back press handling happens.
+     *
+     * When this is called multiple times only the latest caller will receive emissions.
+     */
+    @ExperimentalCoroutinesApi
+    public fun <T> backPresses(value: T): Flow<T> {
+        return callbackFlow {
+            val onBackPressed = {
+                check(trySendBlocking(value).isSuccess)
+            }
+
+            _onBackPressedCallback.addCallback(onBackPressed)
+
+            awaitClose {
+                _onBackPressedCallback.removeCallback(onBackPressed)
+            }
+        }
+    }
+
+    private var allowedToAddRequests = true
+
+    private fun checkAllowedToAddRequests() {
+        check(allowedToAddRequests) {
+            "Failed to register for result! You must call this before this navigator " +
+                "gets attached to a fragment, e.g. during initialisation of your navigator subclass."
+        }
+    }
+
+    /**
+     * Access to [ActivityResultRequest] objects that were registered with
+     * [registerForActivityResult]. A `NavEventNavigationHandler` can use these to register
+     * the requests during setup so that results are delivered to them.
+     */
+    @InternalNavigatorApi
+    public val activityResultRequests: List<ActivityResultRequest<*, *>>
+        get() {
+            allowedToAddRequests = false
+            return _activityResultRequests.toList()
+        }
+    /**
+     * Access to [PermissionsResultRequest] objects that were registered with
+     * [registerForPermissionsResult]. A `NavEventNavigationHandler` can use these to register
+     * the requests during setup so that results are delivered to them.
+     */
+    @InternalNavigatorApi
+    public val permissionsResultRequests: List<PermissionsResultRequest>
+        get() {
+            allowedToAddRequests = false
+            return _permissionsResultRequests.toList()
+        }
+
+    /**
+     * Access to the internal [OnBackPressedCallback] that backs the [backPresses] `Flow`.
+     * A `NavEventNavigationHandler` can add this to an `OnBackPressedDispatcher` to enable
+     * [backPresses].
+     */
+    @InternalNavigatorApi
+    public val onBackPressedCallback: OnBackPressedCallback get() = _onBackPressedCallback
+}

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavRoute.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavRoute.kt
@@ -1,0 +1,19 @@
+package com.freeletics.mad.navigator
+
+import android.os.Bundle
+
+/**
+ * Represents the route to a destination represented by [destinationId]. [getArguments] can
+ * optionally be overridden to provide extra information to the destination.
+ */
+public interface NavRoute {
+    /**
+     * The destination this route leads to.
+     */
+    public val destinationId: Int
+
+    /**
+     * Arguments provided to the destination. For example an id.
+     */
+    public fun getArguments(): Bundle = Bundle.EMPTY
+}

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/ResultLauncher.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/ResultLauncher.kt
@@ -1,0 +1,50 @@
+package com.freeletics.mad.navigator
+
+import androidx.activity.result.contract.ActivityResultContract
+
+/**
+ * A marker interface for anything that can be passed into [NavEventNavigator.navigateForResult]
+ * to launch a result request.
+ *
+ * [I] is the type of input that needs to be provided at the time of launching.
+ */
+public sealed interface ResultLauncher<I>
+
+/**
+ * Class returned from [NavEventNavigator.registerForActivityResult].
+ *
+ * This class has two purposes:
+ *  - It exposes a [results] `Flow` that can be used to observe incoming results
+ *  - It can be passed to [NavEventNavigator.navigateForResult] to trigger the execution of a result
+ *    request
+ */
+public class ActivityResultRequest<I, O> internal constructor(
+    public val contract: ActivityResultContract<I, O>
+) : ResultOwner<O>(), ResultLauncher<I>
+
+/**
+ * Class returned from [NavEventNavigator.registerForPermissionsResult].
+ *
+ * This class has two purposes:
+ *  - It exposes a [results] `Flow` that can be used to observe incoming permission results
+ *  - It can be passed to [NavEventNavigator.requestPermissions] to trigger the execution of a
+ *    permissions request
+ *
+ *  This provides extra functionality over [ActivityResultRequest] by also checking
+ *  [android.app.Activity.shouldShowRequestPermissionRationale] for each permission that was denied.
+ *  It returns a [PermissionResult] instead of just a simple boolean. This allows to detect
+ *  permanent denials.
+ */
+public class PermissionsResultRequest internal constructor() :
+    ResultOwner<Map<String, PermissionsResultRequest.PermissionResult>>(),
+    ResultLauncher<List<String>> {
+
+    /**
+     * The status of the requested permission.
+     */
+    public enum class PermissionResult {
+        GRANTED,
+        DENIED,
+        DENIED_PERMANENTLY
+    }
+}

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/ResultOwner.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/ResultOwner.kt
@@ -1,0 +1,29 @@
+package com.freeletics.mad.navigator
+
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.receiveAsFlow
+
+/**
+ * A base class for anything that exposes a [Flow] of [results]. Results will only be delivered
+ * to one collector at a time.
+ */
+public abstract class ResultOwner<O> {
+    private val _results = Channel<O>(capacity = Channel.UNLIMITED)
+
+    /**
+     * Emits any result passed to [onResult]. Results will only be delivered
+     * to one collector at a time.
+     */
+    public val results: Flow<O> = _results.receiveAsFlow()
+
+    /**
+     * Deliver a new [result] to [results]. This method should be called by a
+     * `NavEventNavigationHandler`.
+     */
+    public fun onResult(result: O) {
+        val channelResult = _results.trySendBlocking(result)
+        check(channelResult.isSuccess)
+    }
+}

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/DelegatingOnBackPressedCallback.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/DelegatingOnBackPressedCallback.kt
@@ -1,0 +1,22 @@
+package com.freeletics.mad.navigator.internal
+
+import androidx.activity.OnBackPressedCallback
+
+internal class DelegatingOnBackPressedCallback : OnBackPressedCallback(false) {
+
+    private val callbacks = mutableListOf<() -> Unit>()
+
+    fun addCallback(callback: () -> Unit) {
+        callbacks.add(callback)
+        isEnabled = true
+    }
+
+    fun removeCallback(callback: () -> Unit) {
+        callbacks.remove(callback)
+        isEnabled = callbacks.isNotEmpty()
+    }
+
+    override fun handleOnBackPressed() {
+        callbacks.lastOrNull()?.invoke()
+    }
+}

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/InternalNavigatorApi.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/InternalNavigatorApi.kt
@@ -1,0 +1,8 @@
+package com.freeletics.mad.navigator.internal
+
+/**
+ * Code marked with [InternalNavigatorApi] has no guarantees about API stability and can be changed
+ * at any time.
+ */
+@RequiresOptIn
+public annotation class InternalNavigatorApi

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/RequestPermissionsContract.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/RequestPermissionsContract.kt
@@ -1,0 +1,34 @@
+package com.freeletics.mad.navigator.internal
+
+import android.content.Context
+import android.content.Intent
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.activity.result.contract.ActivityResultContracts
+
+/**
+ * Wrapper for [ActivityResultContracts.RequestMultiplePermissions] so that a [List] is used
+ * as input instead of [Array]. The reason for this is that [Array.equals] does not compare
+ * the contents which makes testing [com.freeletics.mad.navigator.NavEvent.ResultLauncherEvent]
+ * painful.
+ */
+@InternalNavigatorApi
+public class RequestPermissionsContract :
+    ActivityResultContract<List<String>, Map<String, Boolean>>() {
+
+    private val contract = ActivityResultContracts.RequestMultiplePermissions()
+
+    override fun createIntent(context: Context, input: List<String>): Intent {
+        return contract.createIntent(context, input.toTypedArray())
+    }
+
+    override fun getSynchronousResult(
+        context: Context,
+        input: List<String>
+    ): SynchronousResult<Map<String, Boolean>>? {
+        return contract.getSynchronousResult(context, input.toTypedArray())
+    }
+
+    override fun parseResult(resultCode: Int, intent: Intent?): Map<String, Boolean> {
+        return contract.parseResult(resultCode, intent)
+    }
+}

--- a/navigator/runtime/src/test/java/com/freeletics/mad/navigator/NavEventNavigatorTest.kt
+++ b/navigator/runtime/src/test/java/com/freeletics/mad/navigator/NavEventNavigatorTest.kt
@@ -1,0 +1,169 @@
+package com.freeletics.mad.navigator
+
+import androidx.activity.result.contract.ActivityResultContracts
+import app.cash.turbine.test
+import com.freeletics.mad.navigator.NavEvent.NavigateToEvent
+import com.freeletics.mad.navigator.internal.InternalNavigatorApi
+import kotlinx.coroutines.runBlocking
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+public class NavEventNavigatorTest {
+
+    private class TestNavigator : NavEventNavigator()
+    private data class SimpleRoute(override val destinationId: Int) : NavRoute
+
+    @Test
+    public fun `navigateTo event is received`(): Unit = runBlocking {
+        val navigator = TestNavigator()
+
+        navigator.navEvents.test {
+            navigator.navigateTo(SimpleRoute(1))
+
+            assertThat(awaitItem()).isEqualTo(NavigateToEvent(SimpleRoute(1)))
+
+            cancel()
+        }
+    }
+
+    @Test
+    public fun `multiple navigateTo event are received`(): Unit = runBlocking {
+        val navigator = TestNavigator()
+
+        navigator.navEvents.test {
+            navigator.navigateTo(SimpleRoute(1))
+            navigator.navigateTo(SimpleRoute(1))
+            navigator.navigateTo(SimpleRoute(2))
+
+            assertThat(awaitItem()).isEqualTo(NavigateToEvent(SimpleRoute(1)))
+            assertThat(awaitItem()).isEqualTo(NavigateToEvent(SimpleRoute(1)))
+            assertThat(awaitItem()).isEqualTo(NavigateToEvent(SimpleRoute(2)))
+
+            cancel()
+        }
+    }
+
+    @Test
+    public fun `navigateUp event is received`(): Unit = runBlocking {
+        val navigator = TestNavigator()
+
+        navigator.navEvents.test {
+            navigator.navigateUp()
+
+            assertThat(awaitItem()).isEqualTo(NavEvent.UpEvent)
+
+            cancel()
+        }
+    }
+
+    @Test
+    public fun `navigateBack event is received`(): Unit = runBlocking {
+        val navigator = TestNavigator()
+
+        navigator.navEvents.test {
+            navigator.navigateBack()
+
+            assertThat(awaitItem()).isEqualTo(NavEvent.BackEvent)
+
+            cancel()
+        }
+    }
+
+    @Test
+    public fun `navigateBack with popUpTo event is received`(): Unit = runBlocking {
+        val navigator = TestNavigator()
+
+        navigator.navEvents.test {
+            navigator.navigateBack(5, true)
+
+            assertThat(awaitItem()).isEqualTo(NavEvent.BackToEvent(5, true))
+
+            cancel()
+        }
+    }
+
+    @Test
+    public fun `navigateForResult event is received`(): Unit = runBlocking {
+        val navigator = TestNavigator()
+
+        navigator.navEvents.test {
+            val launcher = navigator.registerForActivityResult(ActivityResultContracts.GetContent())
+            navigator.navigateForResult(launcher, "image/*")
+
+            assertThat(awaitItem()).isEqualTo(NavEvent.ResultLauncherEvent(launcher, "image/*"))
+
+            cancel()
+        }
+    }
+
+    @Test
+    public fun `requestPermissions event is received`(): Unit = runBlocking {
+        val navigator = TestNavigator()
+
+        navigator.navEvents.test {
+            val launcher = navigator.registerForPermissionsResult()
+            val permission = "android.permission.READ_CALENDAR"
+            navigator.requestPermissions(launcher, permission)
+
+            assertThat(awaitItem()).isEqualTo(NavEvent.ResultLauncherEvent(launcher, listOf(permission)))
+
+            cancel()
+        }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class, InternalNavigatorApi::class)
+    @Test
+    public fun `backPresses sends out events`(): Unit = runBlocking {
+        val navigator = TestNavigator()
+
+        assertThat(navigator.onBackPressedCallback.isEnabled).isFalse()
+
+        navigator.backPresses().test {
+            assertThat(navigator.onBackPressedCallback.isEnabled).isTrue()
+
+            navigator.onBackPressedCallback.handleOnBackPressed()
+            navigator.onBackPressedCallback.handleOnBackPressed()
+            navigator.onBackPressedCallback.handleOnBackPressed()
+
+            assertThat(awaitItem()).isEqualTo(Unit)
+            assertThat(awaitItem()).isEqualTo(Unit)
+            assertThat(awaitItem()).isEqualTo(Unit)
+
+            cancel()
+        }
+
+        assertThat(navigator.onBackPressedCallback.isEnabled).isFalse()
+    }
+
+    @OptIn(InternalNavigatorApi::class)
+    @Test
+    public fun `registerForActivityResult after read is disallowed`(): Unit = runBlocking {
+        val navigator = TestNavigator()
+
+        navigator.activityResultRequests
+
+        val exception = assertThrows(IllegalStateException::class.java) {
+            navigator.registerForActivityResult(ActivityResultContracts.GetContent())
+        }
+        assertThat(exception).hasMessageThat().isEqualTo("Failed to register for " +
+            "result! You must call this before this navigator gets attached to a " +
+            "fragment, e.g. during initialisation of your navigator subclass.")
+    }
+
+    @OptIn(InternalNavigatorApi::class)
+    @Test
+    public fun `registerForPermissionsResult after read is disallowed`(): Unit = runBlocking {
+        val navigator = TestNavigator()
+
+        navigator.permissionsResultRequests
+
+        val exception = assertThrows(IllegalStateException::class.java) {
+            navigator.registerForPermissionsResult()
+        }
+        assertThat(exception).hasMessageThat().isEqualTo("Failed to register for " +
+            "result! You must call this before this navigator gets attached to a " +
+            "fragment, e.g. during initialisation of your navigator subclass.")
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 include ":navigator:common", ":navigator:common-compose", ":navigator:common-fragment"
+include ":navigator:runtime", ":navigator:runtime-compose", ":navigator:runtime-fragment"
 include ":state-machine"
 include ":text-resource"
 include ":whetstone:compiler"


### PR DESCRIPTION
This provides an implementation of `Navigator` and `NavEventNavigationHandler` using the concept of `NavEvent`. 

Differences to our internal implementation:
- A `Channel` that is exposed as a `Flow` is used to make the events Observable. Compared to `LiveData` this is not multicasting so there is no need for a "single live event" anymore and the events are simple classes. It also means that tests don't need to use `InstantTaskExecutorRule` anymore.
- No DeepLink support as those are still very tied to our app
- A separate `FragmentNavEventNavigator` that contains the fragment result APIs. This way the general implementation stays "pure" and we don't expose fragments to compose only usages.

A README that I will add separately is still missing but the docs in the code are complete.