### PR TITLE
add multi backstack support to nav-events

### DIFF
--- a/navigator/common-compose/build.gradle
+++ b/navigator/common-compose/build.gradle
@@ -57,5 +57,5 @@ tasks.withType(JavaCompile).configureEach {
 dependencies {
     api project(":navigator:common")
     api "androidx.compose.runtime:runtime:1.0.4"
-    api "androidx.navigation:navigation-runtime:2.3.5"
+    api "androidx.navigation:navigation-runtime:2.4.0"
 }

--- a/navigator/common-fragment/build.gradle
+++ b/navigator/common-fragment/build.gradle
@@ -42,5 +42,5 @@ tasks.withType(JavaCompile).configureEach {
 
 dependencies {
     api project(":navigator:common")
-    api "androidx.fragment:fragment:1.3.6"
+    api "androidx.fragment:fragment:1.4.1"
 }

--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavEventNavigationHandler.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavEventNavigationHandler.kt
@@ -126,12 +126,12 @@ public open class NavEventNavigationHandler : NavigationHandler<NavEventNavigato
                     event.options,
                 )
             }
-            is NavEvent.NavigateToTabEvent -> {
+            is NavEvent.NavigateToRootEvent -> {
                 val options = NavOptions.Builder()
                     // save the state of the current root before leaving it
                     .setPopUpTo(controller.graph.startDestinationId, inclusive = false, saveState = true)
                     // restoring the state of the target root
-                    .setRestoreState(event.restoreTabState)
+                    .setRestoreState(event.restoreRootState)
                     // makes sure that if the destination is already on the backstack, it and
                     // everything above it gets removed
                     .setLaunchSingleTop(true)

--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavEventNavigationHandler.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavEventNavigationHandler.kt
@@ -137,8 +137,8 @@ public open class NavEventNavigationHandler : NavigationHandler<NavEventNavigato
                     .setLaunchSingleTop(true)
                     .build()
                 controller.navigate(
-                    event.route.destinationId,
-                    event.route.getArguments(),
+                    event.root.destinationId,
+                    event.root.getArguments(),
                     options
                 )
             }

--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavEventNavigationHandler.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavEventNavigationHandler.kt
@@ -128,7 +128,7 @@ public open class NavEventNavigationHandler : NavigationHandler<NavEventNavigato
             }
             is NavEvent.NavigateToTabEvent -> {
                 val options = NavOptions.Builder()
-                    // save the state of the current tab before leaving it
+                    // save the state of the current root before leaving it
                     .setPopUpTo(controller.graph.startDestinationId, inclusive = false, saveState = true)
                     // restoring the state of the target tab
                     .setRestoreState(event.restoreTabState)

--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavEventNavigationHandler.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavEventNavigationHandler.kt
@@ -130,7 +130,7 @@ public open class NavEventNavigationHandler : NavigationHandler<NavEventNavigato
                 val options = NavOptions.Builder()
                     // save the state of the current root before leaving it
                     .setPopUpTo(controller.graph.startDestinationId, inclusive = false, saveState = true)
-                    // restoring the state of the target tab
+                    // restoring the state of the target root
                     .setRestoreState(event.restoreTabState)
                     // makes sure that if the destination is already on the backstack, it and
                     // everything above it gets removed

--- a/navigator/runtime-fragment/build.gradle
+++ b/navigator/runtime-fragment/build.gradle
@@ -44,9 +44,9 @@ dependencies {
     api project(":navigator:common-fragment")
     api project(":navigator:runtime")
     api "androidx.lifecycle:lifecycle-runtime-ktx:2.4.0"
-    api "androidx.fragment:fragment:1.3.6"
-    api "androidx.navigation:navigation-runtime-ktx:2.3.5"
-    api "androidx.navigation:navigation-fragment-ktx:2.3.5"
+    api "androidx.fragment:fragment:1.4.1"
+    api "androidx.navigation:navigation-runtime-ktx:2.4.0"
+    api "androidx.navigation:navigation-fragment-ktx:2.4.0"
     api "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2"
 
     testImplementation "junit:junit:4.13.2"

--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavEventNavigationHandler.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavEventNavigationHandler.kt
@@ -129,8 +129,8 @@ public open class NavEventNavigationHandler : NavigationHandler<FragmentNavEvent
                     .setLaunchSingleTop(true)
                     .build()
                 controller.navigate(
-                    event.route.destinationId,
-                    event.route.getArguments(),
+                    event.root.destinationId,
+                    event.root.getArguments(),
                     options
                 )
             }

--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavEventNavigationHandler.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavEventNavigationHandler.kt
@@ -117,13 +117,13 @@ public open class NavEventNavigationHandler : NavigationHandler<FragmentNavEvent
                     event.options,
                 )
             }
-            is NavEvent.NavigateToTabEvent -> {
+            is NavEvent.NavigateToRootEvent -> {
                 val controller = fragment.findNavController()
                 val options = NavOptions.Builder()
-                    // save the state of the current tab before leaving it
+                    // save the state of the current root before leaving it
                     .setPopUpTo(controller.graph.startDestinationId, inclusive = false, saveState = true)
-                    // restoring the state of the target tab
-                    .setRestoreState(event.restoreTabState)
+                    // restoring the state of the target root
+                    .setRestoreState(event.restoreRootState)
                     // makes sure that if the destination is already on the backstack, it and
                     // everything above it gets removed
                     .setLaunchSingleTop(true)

--- a/navigator/runtime-fragment/src/test/java/com/freeletics/mad/navigator/fragment/FragmentNavEventNavigatorTest.kt
+++ b/navigator/runtime-fragment/src/test/java/com/freeletics/mad/navigator/fragment/FragmentNavEventNavigatorTest.kt
@@ -14,7 +14,6 @@ import org.junit.Test
 public class FragmentNavEventNavigatorTest {
 
     private class TestNavigator : FragmentNavEventNavigator()
-    private data class SimpleRoute(override val destinationId: Int) : NavRoute
 
     @Test
     public fun `navigateBackWithResult is received`(): Unit = runBlocking {

--- a/navigator/runtime/build.gradle
+++ b/navigator/runtime/build.gradle
@@ -43,8 +43,8 @@ tasks.withType(JavaCompile).configureEach {
 dependencies {
     api project(":navigator:common")
     api "androidx.activity:activity:1.4.0"
-    api "androidx.navigation:navigation-runtime:2.3.5"
-    api "androidx.navigation:navigation-runtime-ktx:2.3.5"
+    api "androidx.navigation:navigation-runtime:2.4.0"
+    api "androidx.navigation:navigation-runtime-ktx:2.4.0"
     api "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2"
 
     testImplementation "junit:junit:4.13.2"

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEvent.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEvent.kt
@@ -22,11 +22,11 @@ public interface NavEvent {
     ) : NavEvent
 
     /**
-     * Navigates to the given [route]. The current back stack will be popped and saved.
+     * Navigates to the given [root]. The current back stack will be popped and saved.
      * Whether the backstack of the given route is restored depends on [restoreTabState].
      */
     public data class NavigateToTabEvent(
-        val route: TabRoute,
+        val root: NavRoot,
         val restoreTabState: Boolean,
     ) : NavEvent
 

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEvent.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEvent.kt
@@ -23,11 +23,11 @@ public interface NavEvent {
 
     /**
      * Navigates to the given [root]. The current back stack will be popped and saved.
-     * Whether the backstack of the given route is restored depends on [restoreTabState].
+     * Whether the backstack of the given route is restored depends on [restoreRootState].
      */
     public data class NavigateToRootEvent(
         val root: NavRoot,
-        val restoreTabState: Boolean,
+        val restoreRootState: Boolean,
     ) : NavEvent
 
     /**

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEvent.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEvent.kt
@@ -14,11 +14,20 @@ import androidx.navigation.NavOptions
 public interface NavEvent {
 
     /**
-     * Navigates to the given [navRoute] using the optionally passed [navOptions].
+     * Navigates to the given [route] using the optionally passed [options].
      */
     public data class NavigateToEvent(
-        val navRoute: NavRoute,
-        val navOptions: NavOptions? = null,
+        val route: NavRoute,
+        val options: NavOptions? = null,
+    ) : NavEvent
+
+    /**
+     * Navigates to the given [route]. The current back stack will be popped and saved.
+     * Whether the backstack of the given route is restored depends on [restoreTabState].
+     */
+    public data class NavigateToTabEvent(
+        val route: TabRoute,
+        val restoreTabState: Boolean,
     ) : NavEvent
 
     /**

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEvent.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEvent.kt
@@ -25,7 +25,7 @@ public interface NavEvent {
      * Navigates to the given [root]. The current back stack will be popped and saved.
      * Whether the backstack of the given route is restored depends on [restoreTabState].
      */
-    public data class NavigateToTabEvent(
+    public data class NavigateToRootEvent(
         val root: NavRoot,
         val restoreTabState: Boolean,
     ) : NavEvent

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
@@ -121,7 +121,7 @@ public abstract class NavEventNavigator : Navigator {
     /**
      * Triggers a new [NavEvent] to navigate to the given [root]. The current back stack will
      * be popped and saved. Whether the backstack of the given root is restored depends
-     * on [restoreTabState].
+     * on [restoreRootState].
      */
     public fun navigateToRoot(
         root: NavRoot,

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
@@ -119,15 +119,15 @@ public abstract class NavEventNavigator : Navigator {
     }
 
     /**
-     * Triggers a new [NavEvent] to navigate to the given [route]. The current back stack will
-     * be popped and saved. Whether the backstack of the given route is restored depends
+     * Triggers a new [NavEvent] to navigate to the given [root]. The current back stack will
+     * be popped and saved. Whether the backstack of the given root is restored depends
      * on [restoreTabState].
      */
-    public fun navigateToTab(
-        route: TabRoute,
+    public fun navigateToRoot(
+        root: NavRoot,
         restoreTabState: Boolean = false,
     ) {
-        val event = NavEvent.NavigateToTabEvent(route, restoreTabState)
+        val event = NavEvent.NavigateToTabEvent(root, restoreTabState)
         sendNavEvent(event)
     }
 

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
@@ -125,7 +125,7 @@ public abstract class NavEventNavigator : Navigator {
      */
     public fun navigateToRoot(
         root: NavRoot,
-        restoreTabState: Boolean = false,
+        restoreRootState: Boolean = false,
     ) {
         val event = NavEvent.NavigateToTabEvent(root, restoreTabState)
         sendNavEvent(event)

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
@@ -119,6 +119,19 @@ public abstract class NavEventNavigator : Navigator {
     }
 
     /**
+     * Triggers a new [NavEvent] to navigate to the given [route]. The current back stack will
+     * be popped and saved. Whether the backstack of the given route is restored depends
+     * on [restoreTabState].
+     */
+    public fun navigateToTab(
+        route: TabRoute,
+        restoreTabState: Boolean = false,
+    ) {
+        val event = NavEvent.NavigateToTabEvent(route, restoreTabState)
+        sendNavEvent(event)
+    }
+
+    /**
      * Triggers a new [NavEvent] that causes up navigation.
      */
     public fun navigateUp() {
@@ -144,21 +157,21 @@ public abstract class NavEventNavigator : Navigator {
     }
 
     /**
-     * Triggers a new [NavEvent] that launches the given [resultLauncher].
+     * Triggers a new [NavEvent] that launches the given [launcher].
      *
-     * The [resultLauncher] can be obtained by calling [registerForActivityResult].
+     * The [launcher] can be obtained by calling [registerForActivityResult].
      */
-    public fun navigateForResult(resultLauncher: ResultLauncher<Void?>) {
-        navigateForResult(resultLauncher, null)
+    public fun navigateForResult(launcher: ResultLauncher<Void?>) {
+        navigateForResult(launcher, null)
     }
 
     /**
-     * Triggers a new [NavEvent] that launches the given [resultLauncher] with the given [input].
+     * Triggers a new [NavEvent] that launches the given [launcher] with the given [input].
      *
-     * The [resultLauncher] can be obtained by calling [registerForActivityResult].
+     * The [launcher] can be obtained by calling [registerForActivityResult].
      */
-    public fun <I> navigateForResult(resultLauncher: ResultLauncher<I>, input: I) {
-        val event = ResultLauncherEvent(resultLauncher, input)
+    public fun <I> navigateForResult(launcher: ResultLauncher<I>, input: I) {
+        val event = ResultLauncherEvent(launcher, input)
         sendNavEvent(event)
     }
 

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
@@ -127,7 +127,7 @@ public abstract class NavEventNavigator : Navigator {
         root: NavRoot,
         restoreRootState: Boolean = false,
     ) {
-        val event = NavEvent.NavigateToTabEvent(root, restoreTabState)
+        val event = NavEvent.NavigateToRootEvent(root, restoreRootState)
         sendNavEvent(event)
     }
 

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavRoot.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavRoot.kt
@@ -4,12 +4,12 @@ import android.os.Bundle
 
 /**
  * This is similar to a [NavRoute] but represents the route to the start destination used in
- * a backstack. When you navigate to a [TabRoute] the current backstack is saved and removed
- * so that the [TabRoute] is right on top of the start destination.
+ * a backstack. When you navigate to a [NavRoot] the current backstack is saved and removed
+ * so that the [NavRoot] is right on top of the start destination.
  *
  * [getArguments] can optionally be overridden to provide extra information to the destination.
  */
-public interface TabRoute {
+public interface NavRoot {
     /**
      * The destination this route leads to.
      */

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/TabRoute.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/TabRoute.kt
@@ -1,0 +1,22 @@
+package com.freeletics.mad.navigator
+
+import android.os.Bundle
+
+/**
+ * This is similar to a [NavRoute] but represents the route to the start destination used in
+ * a backstack. When you navigate to a [TabRoute] the current backstack is saved and removed
+ * so that the [TabRoute] is right on top of the start destination.
+ *
+ * [getArguments] can optionally be overridden to provide extra information to the destination.
+ */
+public interface TabRoute {
+    /**
+     * The destination this route leads to.
+     */
+    public val destinationId: Int
+
+    /**
+     * Arguments provided to the destination. For example an id.
+     */
+    public fun getArguments(): Bundle = Bundle.EMPTY
+}

--- a/navigator/runtime/src/test/java/com/freeletics/mad/navigator/NavEventNavigatorTest.kt
+++ b/navigator/runtime/src/test/java/com/freeletics/mad/navigator/NavEventNavigatorTest.kt
@@ -14,6 +14,7 @@ public class NavEventNavigatorTest {
 
     private class TestNavigator : NavEventNavigator()
     private data class SimpleRoute(override val destinationId: Int) : NavRoute
+    private data class SimpleTabRoute(override val destinationId: Int) : TabRoute
 
     @Test
     public fun `navigateTo event is received`(): Unit = runBlocking {
@@ -40,6 +41,19 @@ public class NavEventNavigatorTest {
             assertThat(awaitItem()).isEqualTo(NavigateToEvent(SimpleRoute(1)))
             assertThat(awaitItem()).isEqualTo(NavigateToEvent(SimpleRoute(1)))
             assertThat(awaitItem()).isEqualTo(NavigateToEvent(SimpleRoute(2)))
+
+            cancel()
+        }
+    }
+
+    @Test
+    public fun `navigateToTab event is received`(): Unit = runBlocking {
+        val navigator = TestNavigator()
+
+        navigator.navEvents.test {
+            navigator.navigateToTab(SimpleTabRoute(1), true)
+
+            assertThat(awaitItem()).isEqualTo(NavEvent.NavigateToTabEvent(SimpleTabRoute(1), true))
 
             cancel()
         }

--- a/navigator/runtime/src/test/java/com/freeletics/mad/navigator/NavEventNavigatorTest.kt
+++ b/navigator/runtime/src/test/java/com/freeletics/mad/navigator/NavEventNavigatorTest.kt
@@ -14,7 +14,7 @@ public class NavEventNavigatorTest {
 
     private class TestNavigator : NavEventNavigator()
     private data class SimpleRoute(override val destinationId: Int) : NavRoute
-    private data class SimpleTabRoute(override val destinationId: Int) : TabRoute
+    private data class SimpleNavRoot(override val destinationId: Int) : NavRoot
 
     @Test
     public fun `navigateTo event is received`(): Unit = runBlocking {
@@ -51,9 +51,9 @@ public class NavEventNavigatorTest {
         val navigator = TestNavigator()
 
         navigator.navEvents.test {
-            navigator.navigateToTab(SimpleTabRoute(1), true)
+            navigator.navigateToRoot(SimpleNavRoot(1), true)
 
-            assertThat(awaitItem()).isEqualTo(NavEvent.NavigateToTabEvent(SimpleTabRoute(1), true))
+            assertThat(awaitItem()).isEqualTo(NavEvent.NavigateToTabEvent(SimpleNavRoot(1), true))
 
             cancel()
         }

--- a/navigator/runtime/src/test/java/com/freeletics/mad/navigator/NavEventNavigatorTest.kt
+++ b/navigator/runtime/src/test/java/com/freeletics/mad/navigator/NavEventNavigatorTest.kt
@@ -47,7 +47,7 @@ public class NavEventNavigatorTest {
     }
 
     @Test
-    public fun `navigateToTab event is received`(): Unit = runBlocking {
+    public fun `navigateToRoot event is received`(): Unit = runBlocking {
         val navigator = TestNavigator()
 
         navigator.navEvents.test {

--- a/navigator/runtime/src/test/java/com/freeletics/mad/navigator/NavEventNavigatorTest.kt
+++ b/navigator/runtime/src/test/java/com/freeletics/mad/navigator/NavEventNavigatorTest.kt
@@ -53,7 +53,7 @@ public class NavEventNavigatorTest {
         navigator.navEvents.test {
             navigator.navigateToRoot(SimpleNavRoot(1), true)
 
-            assertThat(awaitItem()).isEqualTo(NavEvent.NavigateToTabEvent(SimpleNavRoot(1), true))
+            assertThat(awaitItem()).isEqualTo(NavEvent.NavigateToRootEvent(SimpleNavRoot(1), true))
 
             cancel()
         }

--- a/whetstone/runtime-compose/build.gradle
+++ b/whetstone/runtime-compose/build.gradle
@@ -54,5 +54,5 @@ dependencies {
 
     implementation project(":navigator:common-compose")
     implementation project(":state-machine")
-    implementation "androidx.navigation:navigation-runtime:2.3.5"
+    implementation "androidx.navigation:navigation-runtime:2.4.0"
 }

--- a/whetstone/runtime-fragment/build.gradle
+++ b/whetstone/runtime-fragment/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     api project(":whetstone:runtime")
     api "androidx.lifecycle:lifecycle-viewmodel:2.4.0"
     api "androidx.lifecycle:lifecycle-viewmodel-savedstate:2.4.0"
-    api "androidx.fragment:fragment:1.3.6"
+    api "androidx.fragment:fragment:1.4.1"
 
     implementation project(":navigator:common-fragment")
     implementation project(":state-machine")

--- a/whetstone/runtime/build.gradle
+++ b/whetstone/runtime/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     api "androidx.savedstate:savedstate:1.1.0"
     api "androidx.lifecycle:lifecycle-viewmodel:2.4.0"
     api "androidx.lifecycle:lifecycle-viewmodel-savedstate:2.4.0"
-    api "androidx.navigation:navigation-runtime:2.3.5"
+    api "androidx.navigation:navigation-runtime:2.4.0"
     api project(":state-machine")
 
     implementation "androidx.compose.ui:ui:1.0.4"


### PR DESCRIPTION
Adds a new `TabRoute` interface to represents routes to a tab. This can then be used with `navigateToTab` which triggers a `NavigateToTab` event. The event will be handled by navigating to the destination using nav options with `popUpTo(..., saveState = true)` and `restoreState(...)`, leveraging the multi backstack support that was added in AndroidX Navigation 2.4