### PR TITLE
split fragment NavEventNavigationHandler to support plain NavEventNavigator

### DIFF
--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavEventNavigationHandler.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavEventNavigationHandler.kt
@@ -32,17 +32,16 @@ import com.freeletics.mad.navigator.PermissionsResultRequest.PermissionResult.DE
 import com.freeletics.mad.navigator.PermissionsResultRequest.PermissionResult.DENIED
 import com.freeletics.mad.navigator.ResultLauncher
 import java.lang.IllegalArgumentException
-import kotlinx.coroutines.flow.collect
 
 /**
  * A [NavigationHandler] that handles [NavEvent] emitted by a [NavEventNavigator].
  */
-public open class NavEventNavigationHandler : NavigationHandler<NavEventNavigator> {
+public open class NavEventNavigationHandler<T : NavEventNavigator> : NavigationHandler<T> {
 
     @Composable
     @OptIn(InternalNavigatorApi::class)
     @CallSuper
-    override fun Navigation(navController: NavController, navigator: NavEventNavigator) {
+    override fun Navigation(navController: NavController, navigator: T) {
         val lifecycleOwner = LocalLifecycleOwner.current
 
         val activityLaunchers = navigator.activityResultRequests.associateWith {
@@ -114,7 +113,7 @@ public open class NavEventNavigationHandler : NavigationHandler<NavEventNavigato
         resultLaunchers: Map<ResultLauncher<*>, ActivityResultLauncher<*>>,
         event: NavEvent
     ) {
-        if (handleNavEvent(event)) {
+        if (handleNavEvent(controller, event)) {
             return
         }
 
@@ -170,7 +169,7 @@ public open class NavEventNavigationHandler : NavigationHandler<NavEventNavigato
      *
      * @return `true` if event was handled, `false` otherwise
      */
-    protected open fun handleNavEvent(event: NavEvent): Boolean {
+    protected open fun handleNavEvent(controller: NavController, event: NavEvent): Boolean {
         return false
     }
 }

--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/FragmentNavEventNavigationHandler.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/FragmentNavEventNavigationHandler.kt
@@ -1,0 +1,59 @@
+package com.freeletics.mad.navigator.fragment
+
+import android.os.Bundle
+import androidx.annotation.CallSuper
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentResultOwner
+import androidx.lifecycle.LifecycleOwner
+import com.freeletics.mad.navigator.NavEvent
+import com.freeletics.mad.navigator.NavEventNavigator
+import com.freeletics.mad.navigator.fragment.result.FragmentResultRequest
+import com.freeletics.mad.navigator.internal.InternalNavigatorApi
+
+/**
+ * A [NavigationHandler] that handles [NavEvent] emitted by a [FragmentNavEventNavigator].
+ */
+public open class FragmentNavEventNavigationHandler<T : FragmentNavEventNavigator>
+    : NavEventNavigationHandler<T>() {
+
+    @OptIn(InternalNavigatorApi::class)
+    @CallSuper
+    public override fun handle(fragment: Fragment, navigator: T) {
+        navigator.fragmentResultRequests.forEach {
+            it.registerIn(fragment.parentFragmentManager, fragment)
+        }
+
+        super.handle(fragment, navigator)
+    }
+
+    private fun <O> FragmentResultRequest<O>.registerIn(
+        fragmentResultOwner: FragmentResultOwner,
+        lifecycleOwner: LifecycleOwner
+    ) {
+        fragmentResultOwner.setFragmentResultListener(requestKey, lifecycleOwner) { _, bundle ->
+            onResult(bundle.getParcelable(KEY_FRAGMENT_RESULT)!!)
+        }
+    }
+    
+    /**
+     * This method can be overridden to handle custom [NavEvent] implementations or handle
+     * the standard events in a different way.
+     *
+     * @return `true` if event was handled, `false` otherwise
+     */
+    protected override fun handleNavEvent(fragment: Fragment, event: NavEvent): Boolean {
+        if (event is FragmentResultEvent) {
+            val result = Bundle(1).apply {
+                putParcelable(KEY_FRAGMENT_RESULT, event.result)
+            }
+            fragment.parentFragmentManager.setFragmentResult(event.requestKey, result)
+            return true
+        }
+       return false
+    }
+}
+
+/**
+ * Internal key used to store the result data in the result [Bundle].
+ */
+private const val KEY_FRAGMENT_RESULT = "fragment_result"


### PR DESCRIPTION
- `NavEventNavigationHandler` now only takes a `NavEventNavigator`
- moved `FragmentNavEventNavigator` related parts to `FragmentNavEventNavigationHandler`
- to make this extensibility possible there is now a generic parameter on these classes
- added `Fragment` parameter to `handleEvent` to allow full handling of all events
- applied the last 2 changes also to the compose version of `NavEventNavigationHandler` for parity

This makes migrating to compose easier because you first replace `FragmentNavEventNavigator` with `NavEventNavigator` while still staying in fragment land and then the migration to compose only needs to swap to the compose navigation handler which is an import change.