### PR TITLE
add NavDestination and graph setup methods

### DIFF
--- a/navigator/runtime-compose/build.gradle
+++ b/navigator/runtime-compose/build.gradle
@@ -53,6 +53,8 @@ dependencies {
     api project(":navigator:runtime")
     api "androidx.activity:activity-compose:1.4.0"
     api "androidx.lifecycle:lifecycle-runtime-ktx:2.4.0"
+    api "androidx.navigation:navigation-compose:2.4.0"
+    api "com.google.accompanist:accompanist-navigation-material:0.22.1-rc"
     api "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0"
     api "androidx.compose.runtime:runtime:1.1.0-rc03"
 }

--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavDestination.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavDestination.kt
@@ -1,0 +1,138 @@
+package com.freeletics.mad.navigator.compose
+
+import android.content.Intent
+import androidx.annotation.IdRes
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavController
+import com.freeletics.mad.navigator.NavRoot
+import com.freeletics.mad.navigator.NavRoute
+import com.freeletics.mad.navigator.compose.NavDestination.Activity
+import com.freeletics.mad.navigator.compose.NavDestination.BottomSheet
+import com.freeletics.mad.navigator.compose.NavDestination.Dialog
+import com.freeletics.mad.navigator.compose.NavDestination.RootScreen
+import com.freeletics.mad.navigator.compose.NavDestination.Screen
+import com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi
+import kotlin.reflect.KClass
+
+/**
+ * Creates a new [NavDestination] that represents a full screen. The class of [T] will be used
+ * as a unique identifier together with [destinationId]. The given [screenContent] will be shown
+ * when the screen is being navigated to using an instance of [T].
+ */
+@Suppress("FunctionName")
+public inline fun <reified T : NavRoute> ScreenDestination(
+    destinationId: Int,
+    noinline screenContent: @Composable (NavController) -> Unit,
+): NavDestination = Screen(T::class, destinationId, screenContent)
+
+/**
+ * Creates a new [NavDestination] that represents a full screen. The class of [T] will be used
+ * as a unique identifier together with [destinationId]. The given [screenContent] will be shown
+ * when the screen is being navigated to using an instance of [T].
+ */
+@Suppress("FunctionName")
+public inline fun <reified T : NavRoot> RootScreenDestination(
+    destinationId: Int,
+    noinline screenContent: @Composable (NavController) -> Unit,
+): NavDestination = RootScreen(T::class, destinationId, screenContent)
+
+/**
+ * Creates a new [NavDestination] that represents a dialog. The class of [T] will be used
+ * as a unique identifier together with [destinationId]. The given [dialogContent] will be shown
+ * inside the dialog window when navigating to it by using an instance of [T].
+ */
+@Suppress("FunctionName")
+public inline fun <reified T : NavRoute> DialogDestination(
+    destinationId: Int,
+    noinline dialogContent: @Composable (NavController) -> Unit,
+): NavDestination = Dialog(T::class, destinationId, dialogContent)
+
+/**
+ * Creates a new [NavDestination] that represents a bottom sheet. The class of [T] will be used
+ * as a unique identifier together with [destinationId]. The given [bottomSheetContent] will be
+ * shown inside the bottom sheet when navigating to it by using an instance of [T].
+ */
+@Suppress("FunctionName")
+@ExperimentalMaterialNavigationApi
+public inline fun <reified T : NavRoute> BottomSheetDestination(
+    destinationId: Int,
+    noinline bottomSheetContent: @Composable (NavController) -> Unit,
+): NavDestination = BottomSheet(T::class, destinationId, bottomSheetContent)
+
+/**
+ * Creates a new [NavDestination] that represents an `Activity`. The class of [T] will be used
+ * as a unique identifier together with [destinationId]. The given [intent] will be
+ * used to launch the `Activity` when using an instance of [T] for navigation.
+ */
+@Suppress("FunctionName")
+public inline fun <reified T : NavRoute> ActivityDestination(
+    destinationId: Int,
+    intent: Intent,
+): NavDestination = Activity(T::class, destinationId, intent)
+
+/**
+ * A destination that can be navigated to. See [NavHost] for how to configure a `NavGraph` with it.
+ *
+ * [route] will be used as a unique identifier together with [destinationId]. The destination can
+ * be reached by navigating using an instance of [route].
+ */
+public abstract class NavDestination {
+    public abstract val route: KClass<*>
+    @get:IdRes public abstract val destinationId: Int
+
+    /**
+     * Represents a full screen. The [route] will be used as a unique identifier together
+     * with [destinationId]. The given [screenContent] will be shown when the screen is being
+     * navigated to using an instance of [route].
+     */
+    public class Screen(
+        override val route: KClass<out NavRoute>,
+        override val destinationId: Int,
+        internal val screenContent: @Composable (NavController) -> Unit,
+    ) : NavDestination()
+
+    /**
+     * Represents a full screen. The [route] will be used as a unique identifier together
+     * with [destinationId]. The given [screenContent] will be shown when the screen is being
+     * navigated to using an instance of [route].
+     */
+    public class RootScreen(
+        override val route: KClass<out NavRoot>,
+        override val destinationId: Int,
+        internal val screenContent: @Composable (NavController) -> Unit,
+    ) : NavDestination()
+
+    /**
+     * Represents a dialog. The [route] will be used as a unique identifier together
+     * with [destinationId]. The given [dialogContent] will be shown inside the dialog window
+     * when navigating to it by using an instance of [route].
+     */
+    public class Dialog(
+        override val route: KClass<out NavRoute>,
+        override val destinationId: Int,
+        internal val dialogContent: @Composable (NavController) -> Unit,
+    ) : NavDestination()
+
+    /**
+     * Represents a bottom sheet. The [route] will be used as a unique identifier together
+     * with [destinationId]. The given [bottomSheetContent] will be shown inside the bottom sheet
+     * when navigating to it by using an instance of [route].
+     */
+    @ExperimentalMaterialNavigationApi
+    public class BottomSheet(
+        override val route: KClass<out NavRoute>,
+        override val destinationId: Int,
+        internal val bottomSheetContent: @Composable (NavController) -> Unit,
+    ) : NavDestination()
+
+    /**
+     * Represents an `Activity`. The [route] will be used as a unique identifier together
+     * with [destinationId]. The given [intent] will be used to launch the `Activity` when using
+     * an instance of [route] for navigation.
+     */
+    public class Activity(
+        override val route: KClass<out NavRoute>,
+        override val destinationId: Int,
+        internal val intent: Intent,
+    ) : NavDestination()
+}

--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavHost.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavHost.kt
@@ -1,0 +1,198 @@
+package com.freeletics.mad.navigator.compose
+
+import androidx.annotation.IdRes
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.navigation.ActivityNavigator
+import androidx.navigation.NavController
+import androidx.navigation.NavDestination as AndroidXNavDestination
+import androidx.navigation.compose.NavHost as AndroidXNavHost
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.ComposeNavigator
+import androidx.navigation.compose.DialogNavigator
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.createGraph
+import androidx.navigation.get
+import com.freeletics.mad.navigator.NavRoot
+import com.freeletics.mad.navigator.NavRoute
+import com.freeletics.mad.navigator.compose.NavDestination.Activity
+import com.freeletics.mad.navigator.compose.NavDestination.BottomSheet
+import com.freeletics.mad.navigator.compose.NavDestination.Dialog
+import com.freeletics.mad.navigator.compose.NavDestination.RootScreen
+import com.freeletics.mad.navigator.compose.NavDestination.Screen
+import com.google.accompanist.navigation.material.BottomSheetNavigator
+import com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi
+import com.google.accompanist.navigation.material.rememberBottomSheetNavigator
+
+/**
+ * Create a new [androidx.navigation.compose.NavHost] with a [androidx.navigation.NavGraph]
+ * containing all given [destinations]. [startRoot] will be used as the start destination
+ * of the graph.
+ *
+ * [destinationCreator] can be passed to add support for custom subclasses of [NavDestination].
+ */
+@ExperimentalMaterialNavigationApi
+@Composable
+public fun NavHost(
+    startRoot: NavRoot,
+    destinations: Set<NavDestination>,
+    destinationCreator: (NavDestination) -> AndroidXNavDestination? = { null },
+) {
+    val bottomSheetNavigator = rememberBottomSheetNavigator()
+    val navController = rememberNavController(bottomSheetNavigator)
+    val startDestinationId = startRoot.destinationId
+    NavHost(navController, startDestinationId, destinations, destinationCreator)
+}
+
+/**
+ * Create a new [androidx.navigation.compose.NavHost] with a [androidx.navigation.NavGraph]
+ * containing all given [destinations]. [startRoute] will be used as the start destination
+ * of the graph.
+ *
+ * [destinationCreator] can be passed to add support for custom subclasses of [NavDestination].
+ */
+@ExperimentalMaterialNavigationApi
+@Composable
+public fun NavHost(
+    startRoute: NavRoute,
+    destinations: Set<NavDestination>,
+    destinationCreator: (NavDestination) -> AndroidXNavDestination? = { null },
+) {
+    val bottomSheetNavigator = rememberBottomSheetNavigator()
+    val navController = rememberNavController(bottomSheetNavigator)
+    val startDestinationId = startRoute.destinationId
+    NavHost(navController, startDestinationId, destinations, destinationCreator)
+}
+
+/**
+ * Create a new [androidx.navigation.compose.NavHost] using [navController] with a
+ * [androidx.navigation.NavGraph] containing all given [destinations]. [startRoot] will be used as
+ * the start destination of the graph.
+ *
+ * To support [NavDestination.BottomSheet] the given [navController] needs to contain a navigator
+ * created with [rememberBottomSheetNavigator].
+ *
+ * [destinationCreator] can be passed to add support for custom subclasses of [NavDestination].
+ */
+@Composable
+public fun NavHost(
+    navController: NavHostController,
+    startRoot: NavRoot,
+    destinations: Set<NavDestination>,
+    destinationCreator: (NavDestination) -> AndroidXNavDestination? = { null },
+) {
+    val startDestinationId = startRoot.destinationId
+    NavHost(navController, startDestinationId, destinations, destinationCreator)
+}
+
+/**
+ * Create a new [androidx.navigation.compose.NavHost] using [navController] with a
+ * [androidx.navigation.NavGraph] containing all given [destinations]. [startRoute] will be used as
+ * the start destination of the graph.
+ *
+ * To support [NavDestination.BottomSheet] the given [navController] needs to contain a navigator
+ * created with [rememberBottomSheetNavigator].
+ *
+ * [destinationCreator] can be passed to add support for custom subclasses of [NavDestination].
+ */
+@Composable
+public fun NavHost(
+    navController: NavHostController,
+    startRoute: NavRoute,
+    destinations: Set<NavDestination>,
+    destinationCreator: (NavDestination) -> AndroidXNavDestination? = { null },
+) {
+    val startDestinationId = startRoute.destinationId
+    NavHost(navController, startDestinationId, destinations, destinationCreator)
+}
+
+@Composable
+private fun NavHost(
+    navController: NavHostController,
+    @IdRes startDestinationId: Int,
+    destinations: Set<NavDestination>,
+    destinationCreator: (NavDestination) -> AndroidXNavDestination?,
+) {
+    val graph = remember(navController, startDestinationId, destinations, destinationCreator) {
+        @Suppress("deprecation")
+        navController.createGraph(startDestination = startDestinationId) {
+            destinations.forEach { destination ->
+                addDestination(navController, destination, destinationCreator)
+            }
+        }
+    }
+    AndroidXNavHost(navController, graph)
+}
+
+// the BottomSheet class and creator methods are marked with ExperimentalMaterialNavigationApi
+// if those stay unused the experimental code is never called, so we swallow the warning here
+@OptIn(ExperimentalMaterialNavigationApi::class)
+private fun NavGraphBuilder.addDestination(
+    controller: NavController,
+    destination: NavDestination,
+    destinationCreator: (NavDestination) -> AndroidXNavDestination?,
+) {
+    val newDestination = when (destination) {
+        is Screen -> destination.toDestination(controller)
+        is RootScreen -> destination.toDestination(controller)
+        is Dialog -> destination.toDestination(controller)
+        is BottomSheet -> destination.toDestination(controller)
+        is Activity -> destination.toDestination(controller)
+        else -> destinationCreator(destination)
+    } ?: throw IllegalArgumentException("Unable to create destination for unknown type " +
+        "${destination::class.java}. Handle it in destinationCreator")
+
+    addDestination(newDestination)
+}
+
+private fun Screen.toDestination(
+    controller: NavController,
+): ComposeNavigator.Destination {
+    val navigator = controller.navigatorProvider[ComposeNavigator::class]
+    return ComposeNavigator.Destination(navigator) {
+        screenContent(controller)
+    }.also {
+        it.id = destinationId
+    }
+}
+
+private fun RootScreen.toDestination(
+    controller: NavController,
+): ComposeNavigator.Destination {
+    val navigator = controller.navigatorProvider[ComposeNavigator::class]
+    return ComposeNavigator.Destination(navigator) { screenContent(controller) }.also {
+        it.id = destinationId
+    }
+}
+
+private fun Dialog.toDestination(
+    controller: NavController,
+): DialogNavigator.Destination {
+    val navigator = controller.navigatorProvider[DialogNavigator::class]
+    return DialogNavigator.Destination(navigator) { dialogContent(controller) }.also {
+        it.id = destinationId
+    }
+}
+
+// the BottomSheet class and creator methods are marked with ExperimentalMaterialNavigationApi
+// if those stay unused this method is never called, so we swallow the warning here
+@OptIn(ExperimentalMaterialNavigationApi::class)
+private fun BottomSheet.toDestination(
+    controller: NavController,
+): BottomSheetNavigator.Destination {
+    val navigator = controller.navigatorProvider[BottomSheetNavigator::class]
+    return BottomSheetNavigator.Destination(navigator) { bottomSheetContent(controller) }.also {
+        it.id = destinationId
+    }
+}
+
+private fun Activity.toDestination(
+    controller: NavController,
+): ActivityNavigator.Destination {
+    val navigator = controller.navigatorProvider[ActivityNavigator::class]
+    return ActivityNavigator.Destination(navigator).also {
+        it.id = destinationId
+        it.setIntent(intent)
+    }
+}

--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavDestination.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavDestination.kt
@@ -1,0 +1,109 @@
+package com.freeletics.mad.navigator.fragment
+
+import android.content.Intent
+import androidx.annotation.IdRes
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.Fragment
+import com.freeletics.mad.navigator.NavRoot
+import com.freeletics.mad.navigator.NavRoute
+import com.freeletics.mad.navigator.fragment.NavDestination.Activity
+import com.freeletics.mad.navigator.fragment.NavDestination.Dialog
+import com.freeletics.mad.navigator.fragment.NavDestination.RootScreen
+import com.freeletics.mad.navigator.fragment.NavDestination.Screen
+import kotlin.reflect.KClass
+
+/**
+ * Creates a new [NavDestination] that represents a full screen. The class of [T] will be used
+ * as a unique identifier together with [destinationId]. The given `Fragment` class  [F] will be
+ * shown when the screen is being navigated to using an instance of [T].
+ */
+@Suppress("FunctionName")
+public inline fun <reified T : NavRoute, reified F : Fragment> ScreenDestination(
+    destinationId: Int,
+): NavDestination = Screen(T::class, destinationId, F::class)
+
+/**
+ * Creates a new [NavDestination] that represents a full screen. The class of [T] will be used
+ * as a unique identifier together with [destinationId]. The given `Fragment` class  [F] will be
+ * shown when the screen is being navigated to using an instance of [T].
+ */
+@Suppress("FunctionName")
+public inline fun <reified T : NavRoot, reified F : Fragment> RootScreenDestination(
+    destinationId: Int,
+): NavDestination = RootScreen(T::class, destinationId, F::class)
+
+/**
+ * Creates a new [NavDestination] that represents a dialog. The class of [T] will be used
+ * as a unique identifier together with [destinationId]. The given `Fragment` class  [F] will be
+ * shown when the screen is being navigated to using an instance of [T].
+ */
+@Suppress("FunctionName")
+public inline fun <reified T : NavRoute, reified F : DialogFragment> DialogDestination(
+    destinationId: Int,
+): NavDestination = Dialog(T::class, destinationId, F::class)
+
+/**
+ * Creates a new [NavDestination] that represents an `Activity`. The class of [T] will be used
+ * as a unique identifier together with [destinationId]. The given [intent] will be
+ * used to launch the `Activity` when using an instance of [T] for navigation.
+ */
+@Suppress("FunctionName")
+public inline fun <reified T : NavRoute> ActivityDestination(
+    destinationId: Int,
+    intent: Intent,
+): NavDestination = Activity(T::class, destinationId, intent)
+
+/**
+ * A destination that can be navigated to. See [setGraph] for how to configure a `NavGraph` with it.
+ *
+ * [route] will be used as a unique identifier together with [destinationId]. The destination can
+ * be reached by navigating using an instance of [route].
+ */
+public abstract class NavDestination {
+    public abstract val route: KClass<*>
+    @get:IdRes public abstract val destinationId: Int
+
+    /**
+     * Represents a full screen. The [route] will be used as a unique identifier together
+     * with [destinationId]. The given [fragmentClass] will be shown when the screen is being
+     * navigated to using an instance of [route].
+     */
+    public class Screen(
+        override val route: KClass<out NavRoute>,
+        override val destinationId: Int,
+        internal val fragmentClass: KClass<out Fragment>,
+    ) : NavDestination()
+
+    /**
+     * Represents a full screen. The [route] will be used as a unique identifier together
+     * with [destinationId]. The given [fragmentClass] will be shown when the screen is being
+     * navigated to using an instance of [route].
+     */
+    public class RootScreen(
+        override val route: KClass<out NavRoot>,
+        override val destinationId: Int,
+        internal val fragmentClass: KClass<out Fragment>,
+    ) : NavDestination()
+
+    /**
+     * Represents a dialog. The [route] will be used as a unique identifier together
+     * with [destinationId]. The given [fragmentClass] will be shown when it's being navigated to
+     * using an instance of [route].
+     */
+    public class Dialog(
+        override val route: KClass<out NavRoute>,
+        override val destinationId: Int,
+        internal val fragmentClass: KClass<out DialogFragment>,
+    ) : NavDestination()
+
+    /**
+     * Represents an `Activity`. The [route] will be used as a unique identifier together
+     * with [destinationId]. The given [intent] will be used to launch the `Activity` when using
+     * an instance of [route] for navigation.
+     */
+    public class Activity(
+        override val route: KClass<out NavRoute>,
+        override val destinationId: Int,
+        internal val intent: Intent,
+    ) : NavDestination()
+}

--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavHostFragment.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavHostFragment.kt
@@ -1,0 +1,115 @@
+package com.freeletics.mad.navigator.fragment
+
+import androidx.navigation.NavDestination as AndroidXNavDestination
+import androidx.navigation.ActivityNavigator
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.createGraph
+import androidx.navigation.fragment.DialogFragmentNavigator
+import androidx.navigation.fragment.FragmentNavigator
+import androidx.navigation.fragment.NavHostFragment
+import androidx.navigation.get
+import com.freeletics.mad.navigator.NavRoot
+import com.freeletics.mad.navigator.NavRoute
+
+/**
+ * Creates and sets a [androidx.navigation.NavGraph] containing all given [destinations].
+ * [startRoot] will be used as the start destination of the graph.
+ *
+ * [destinationCreator] can be passed to add support for custom subclasses of [NavDestination].
+ */
+public fun NavHostFragment.setGraph(
+    startRoot: NavRoot,
+    destinations: Set<NavDestination>,
+    destinationCreator: (NavDestination) -> AndroidXNavDestination? = { null },
+) {
+    val startDestinationId = startRoot.destinationId
+    navController.setGraph(startDestinationId, destinations, destinationCreator)
+}
+
+/**
+ * Creates and sets a [androidx.navigation.NavGraph] containing all given [destinations].
+ * [startRoute] will be used as the start destination of the graph.
+ *
+ * [destinationCreator] can be passed to add support for custom subclasses of [NavDestination].
+ */
+public fun NavHostFragment.setGraph(
+    startRoute: NavRoute,
+    destinations: Set<NavDestination>,
+    destinationCreator: (NavDestination) -> AndroidXNavDestination? = { null },
+) {
+    val startDestinationId = startRoute.destinationId
+    navController.setGraph(startDestinationId, destinations, destinationCreator)
+}
+
+
+private fun NavController.setGraph(
+    startDestinationId: Int,
+    destinations: Set<NavDestination>,
+    destinationCreator: (NavDestination) -> AndroidXNavDestination?,
+) {
+    @Suppress("deprecation")
+    val graph = createGraph(startDestination = startDestinationId) {
+        destinations.forEach { destination ->
+            addDestination(this@setGraph, destination, destinationCreator)
+        }
+    }
+    setGraph(graph, null)
+}
+
+private fun NavGraphBuilder.addDestination(
+    controller: NavController,
+    destination: NavDestination,
+    destinationCreator: (NavDestination) -> AndroidXNavDestination?,
+) {
+    val newDestination = when (destination) {
+        is NavDestination.Screen -> destination.toDestination(controller)
+        is NavDestination.RootScreen -> destination.toDestination(controller)
+        is NavDestination.Dialog -> destination.toDestination(controller)
+        is NavDestination.Activity -> destination.toDestination(controller)
+        else -> destinationCreator(destination)
+    } ?: throw IllegalArgumentException("Unable to create destination for unknown type " +
+        "${destination::class.java}. Handle it in destinationCreator")
+
+    addDestination(newDestination)
+}
+
+private fun NavDestination.Screen.toDestination(
+    controller: NavController,
+): FragmentNavigator.Destination {
+    val navigator = controller.navigatorProvider[FragmentNavigator::class]
+    return FragmentNavigator.Destination(navigator).also {
+        it.id = destinationId
+        it.setClassName(fragmentClass.java.name)
+    }
+}
+
+private fun NavDestination.RootScreen.toDestination(
+    controller: NavController,
+): FragmentNavigator.Destination {
+    val navigator = controller.navigatorProvider[FragmentNavigator::class]
+    return FragmentNavigator.Destination(navigator).also {
+        it.id = destinationId
+        it.setClassName(fragmentClass.java.name)
+    }
+}
+
+private fun NavDestination.Dialog.toDestination(
+    controller: NavController,
+): DialogFragmentNavigator.Destination {
+    val navigator = controller.navigatorProvider[DialogFragmentNavigator::class]
+    return DialogFragmentNavigator.Destination(navigator).also {
+        it.id = destinationId
+        it.setClassName(fragmentClass.java.name)
+    }
+}
+
+private fun NavDestination.Activity.toDestination(
+    controller: NavController,
+): ActivityNavigator.Destination {
+    val navigator = controller.navigatorProvider[ActivityNavigator::class]
+    return ActivityNavigator.Destination(navigator).also {
+        it.id = destinationId
+        it.setIntent(intent)
+    }
+}


### PR DESCRIPTION
This defines nav destinations for both fragments and compose screens that can be used to build a graph without xml. Currently a destination has both a `KClass<NavRoute>` and a `destinationId` as identifier, the latter will probably removed. The methods to build a graph from destinations have a `destinationCreator: (NavDestination) -> AndroidXNavDestination?` that can be used to define custom destinations. We can use that internally to still support our old destinations for a bit.