### PR TITLE
add internal composition local for NavController

### DIFF
--- a/navigator/common-compose/build.gradle
+++ b/navigator/common-compose/build.gradle
@@ -57,5 +57,4 @@ tasks.withType(JavaCompile).configureEach {
 dependencies {
     api project(":navigator:common")
     api "androidx.compose.runtime:runtime:1.1.0-rc03"
-    api "androidx.navigation:navigation-runtime:2.4.0"
 }

--- a/navigator/common-compose/src/main/java/com/freeletics/mad/navigator/compose/NavigationHandler.kt
+++ b/navigator/common-compose/src/main/java/com/freeletics/mad/navigator/compose/NavigationHandler.kt
@@ -1,7 +1,6 @@
 package com.freeletics.mad.navigator.compose
 
 import androidx.compose.runtime.Composable
-import androidx.navigation.NavController
 import com.freeletics.mad.navigator.Navigator
 
 /**
@@ -11,7 +10,7 @@ import com.freeletics.mad.navigator.Navigator
  * An example usage would be that there is an implementation of [Navigator] that exposes a
  * Kotlin Coroutines `Flow` of navigation events. An implementation of `NavigationHandler`
  * could then `collect` that `Flow` in it's `handle` method and then execute the correct navigation
- * methods on the [NavController] based on the received event.
+ * methods on a `NavController` based on the received event.
  *
  * This set up allows to have the general navigation logic (when action x happens navigate to
  * screen y) in your business logic layer, for example as a side effect in your state machine.
@@ -26,5 +25,5 @@ public interface NavigationHandler<N : Navigator> {
      * when it leaves the composition.
      */
     @Composable
-    public fun Navigation(navController: NavController, navigator: N)
+    public fun Navigation(navigator: N)
 }

--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavDestination.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavDestination.kt
@@ -1,9 +1,9 @@
 package com.freeletics.mad.navigator.compose
 
 import android.content.Intent
+import android.os.Bundle
 import androidx.annotation.IdRes
 import androidx.compose.runtime.Composable
-import androidx.navigation.NavController
 import com.freeletics.mad.navigator.NavRoot
 import com.freeletics.mad.navigator.NavRoute
 import com.freeletics.mad.navigator.compose.NavDestination.Activity
@@ -22,7 +22,7 @@ import kotlin.reflect.KClass
 @Suppress("FunctionName")
 public inline fun <reified T : NavRoute> ScreenDestination(
     destinationId: Int,
-    noinline screenContent: @Composable (NavController) -> Unit,
+    noinline screenContent: @Composable (Bundle) -> Unit,
 ): NavDestination = Screen(T::class, destinationId, screenContent)
 
 /**
@@ -33,7 +33,7 @@ public inline fun <reified T : NavRoute> ScreenDestination(
 @Suppress("FunctionName")
 public inline fun <reified T : NavRoot> RootScreenDestination(
     destinationId: Int,
-    noinline screenContent: @Composable (NavController) -> Unit,
+    noinline screenContent: @Composable (Bundle) -> Unit,
 ): NavDestination = RootScreen(T::class, destinationId, screenContent)
 
 /**
@@ -44,7 +44,7 @@ public inline fun <reified T : NavRoot> RootScreenDestination(
 @Suppress("FunctionName")
 public inline fun <reified T : NavRoute> DialogDestination(
     destinationId: Int,
-    noinline dialogContent: @Composable (NavController) -> Unit,
+    noinline dialogContent: @Composable (Bundle) -> Unit,
 ): NavDestination = Dialog(T::class, destinationId, dialogContent)
 
 /**
@@ -56,7 +56,7 @@ public inline fun <reified T : NavRoute> DialogDestination(
 @ExperimentalMaterialNavigationApi
 public inline fun <reified T : NavRoute> BottomSheetDestination(
     destinationId: Int,
-    noinline bottomSheetContent: @Composable (NavController) -> Unit,
+    noinline bottomSheetContent: @Composable (Bundle) -> Unit,
 ): NavDestination = BottomSheet(T::class, destinationId, bottomSheetContent)
 
 /**
@@ -88,7 +88,7 @@ public abstract class NavDestination {
     public class Screen(
         override val route: KClass<out NavRoute>,
         override val destinationId: Int,
-        internal val screenContent: @Composable (NavController) -> Unit,
+        internal val screenContent: @Composable (Bundle) -> Unit,
     ) : NavDestination()
 
     /**
@@ -99,7 +99,7 @@ public abstract class NavDestination {
     public class RootScreen(
         override val route: KClass<out NavRoot>,
         override val destinationId: Int,
-        internal val screenContent: @Composable (NavController) -> Unit,
+        internal val screenContent: @Composable (Bundle) -> Unit,
     ) : NavDestination()
 
     /**
@@ -110,7 +110,7 @@ public abstract class NavDestination {
     public class Dialog(
         override val route: KClass<out NavRoute>,
         override val destinationId: Int,
-        internal val dialogContent: @Composable (NavController) -> Unit,
+        internal val dialogContent: @Composable (Bundle) -> Unit,
     ) : NavDestination()
 
     /**
@@ -122,7 +122,7 @@ public abstract class NavDestination {
     public class BottomSheet(
         override val route: KClass<out NavRoute>,
         override val destinationId: Int,
-        internal val bottomSheetContent: @Composable (NavController) -> Unit,
+        internal val bottomSheetContent: @Composable (Bundle) -> Unit,
     ) : NavDestination()
 
     /**

--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavEventNavigationHandler.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavEventNavigationHandler.kt
@@ -32,7 +32,6 @@ import com.freeletics.mad.navigator.PermissionsResultRequest.PermissionResult.DE
 import com.freeletics.mad.navigator.PermissionsResultRequest.PermissionResult.DENIED
 import com.freeletics.mad.navigator.ResultLauncher
 import java.lang.IllegalArgumentException
-import kotlinx.coroutines.flow.collect
 
 /**
  * A [NavigationHandler] that handles [NavEvent] emitted by a [NavEventNavigator].
@@ -42,7 +41,8 @@ public open class NavEventNavigationHandler : NavigationHandler<NavEventNavigato
     @Composable
     @OptIn(InternalNavigatorApi::class)
     @CallSuper
-    override fun Navigation(navController: NavController, navigator: NavEventNavigator) {
+    override fun Navigation(navigator: NavEventNavigator) {
+        val controller = LocalNavController.current
         val lifecycleOwner = LocalLifecycleOwner.current
 
         val activityLaunchers = navigator.activityResultRequests.associateWith {
@@ -62,11 +62,11 @@ public open class NavEventNavigationHandler : NavigationHandler<NavEventNavigato
             }
         }
 
-        LaunchedEffect(lifecycleOwner, navController, navigator) {
+        LaunchedEffect(lifecycleOwner, controller, navigator) {
             navigator.navEvents
                 .flowWithLifecycle(lifecycleOwner.lifecycle)
                 .collect { navEvent ->
-                    navigate(navController, launchers, navEvent)
+                    navigate(controller, launchers, navEvent)
                 }
         }
     }

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/compose/ComposeFragmentGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/compose/ComposeFragmentGenerator.kt
@@ -8,7 +8,6 @@ import com.freeletics.mad.whetstone.codegen.util.bundle
 import com.freeletics.mad.whetstone.codegen.util.composeView
 import com.freeletics.mad.whetstone.codegen.util.compositionLocalProvider
 import com.freeletics.mad.whetstone.codegen.util.disposeOnLifecycleDestroyed
-import com.freeletics.mad.whetstone.codegen.util.findNavController
 import com.freeletics.mad.whetstone.codegen.util.layoutInflater
 import com.freeletics.mad.whetstone.codegen.util.layoutParams
 import com.freeletics.mad.whetstone.codegen.util.localWindowInsets
@@ -63,7 +62,6 @@ internal class ComposeFragmentGenerator(
                     addCode("\n")
                 }
             }
-            .addStatement("val navController = %M()", findNavController)
             // requireContext: external method
             .beginControlFlow("return %T(requireContext()).apply {", composeView)
             // setViewCompositionStrategy: external method
@@ -86,7 +84,8 @@ internal class ComposeFragmentGenerator(
                     beginControlFlow("%T(%T provides windowInsets) {", compositionLocalProvider, localWindowInsets)
                 }
             }
-            .addStatement("%L(navController)", composableName)
+            // requireArguments: external method
+            .addStatement("%L(requireArguments())", composableName)
             .apply {
                 if (data.enableInsetHandling) {
                     endControlFlow()

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/compose/ComposeGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/compose/ComposeGenerator.kt
@@ -11,7 +11,6 @@ import com.freeletics.mad.whetstone.codegen.util.asComposeState
 import com.freeletics.mad.whetstone.codegen.util.composable
 import com.freeletics.mad.whetstone.codegen.util.compositionLocalProvider
 import com.freeletics.mad.whetstone.codegen.util.launch
-import com.freeletics.mad.whetstone.codegen.util.navController
 import com.freeletics.mad.whetstone.codegen.util.navigationHandlerNavigation
 import com.freeletics.mad.whetstone.codegen.util.optInAnnotation
 import com.freeletics.mad.whetstone.codegen.util.rememberCoroutineScope
@@ -29,11 +28,8 @@ internal class ComposeGenerator(
         return FunSpec.builder(composableName)
             .addAnnotation(composable)
             .addAnnotation(optInAnnotation())
-            .addParameter("navController", navController)
+            .addParameter("arguments", bundle)
             .beginControlFlow("val viewModelProvider = %M<%T>(%T::class) { dependencies, handle -> ", rememberViewModelProvider, data.dependencies, data.parentScope)
-            // currentBackStackEntry: external method
-            // arguments: external method
-            .addStatement("val arguments = navController.currentBackStackEntry!!.arguments ?: %T.EMPTY", bundle)
             .addStatement("%T(dependencies, handle, arguments)", viewModelClassName)
             .endControlFlow()
             .addStatement("val viewModel = viewModelProvider[%T::class.java]", viewModelClassName)
@@ -64,7 +60,7 @@ internal class ComposeGenerator(
         return CodeBlock.builder()
             .addStatement("val handler = component.%L", data.navigation!!.navigationHandler.propertyName)
             .addStatement("val navigator = component.%L", data.navigation!!.navigator.propertyName)
-            .addStatement("handler.%N(navController, navigator)", navigationHandlerNavigation)
+            .addStatement("handler.%N(navigator)", navigationHandlerNavigation)
             .add("\n")
             .build()
     }

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
@@ -74,9 +74,7 @@ internal val dialogFragment = ClassName("androidx.fragment.app", "DialogFragment
 internal val viewModel = ClassName("androidx.lifecycle", "ViewModel")
 internal val savedStateHandle = ClassName("androidx.lifecycle", "SavedStateHandle")
 
-internal val navController = ClassName("androidx.navigation", "NavController")
 internal val navBackStackEntry = ClassName("androidx.navigation", "NavBackStackEntry")
-internal val findNavController = MemberName("androidx.navigation.fragment", "findNavController")
 
 // Compose
 internal val composable = ClassName("androidx.compose.runtime", "Composable")

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
@@ -35,7 +35,6 @@ class FileGeneratorTestCompose {
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
-            import androidx.navigation.NavController
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
@@ -105,10 +104,9 @@ class FileGeneratorTestCompose {
 
             @Composable
             @OptIn(InternalWhetstoneApi::class)
-            public fun TestScreen(navController: NavController): Unit {
+            public fun TestScreen(arguments: Bundle): Unit {
               val viewModelProvider = rememberViewModelProvider<TestDependencies>(TestParentScope::class) {
                   dependencies, handle -> 
-                val arguments = navController.currentBackStackEntry!!.arguments ?: Bundle.EMPTY
                 TestViewModel(dependencies, handle, arguments)
               }
               val viewModel = viewModelProvider[TestViewModel::class.java]
@@ -116,7 +114,7 @@ class FileGeneratorTestCompose {
 
               val handler = component.testNavigationHandler
               val navigator = component.testNavigator
-              handler.Navigation(navController, navigator)
+              handler.Navigation(navigator)
 
               val providedValues = component.providedValues
               CompositionLocalProvider(*providedValues.toTypedArray()) {
@@ -149,7 +147,6 @@ class FileGeneratorTestCompose {
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
-            import androidx.navigation.NavController
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
@@ -214,10 +211,9 @@ class FileGeneratorTestCompose {
 
             @Composable
             @OptIn(InternalWhetstoneApi::class)
-            public fun TestScreen(navController: NavController): Unit {
+            public fun TestScreen(arguments: Bundle): Unit {
               val viewModelProvider = rememberViewModelProvider<TestDependencies>(TestParentScope::class) {
                   dependencies, handle -> 
-                val arguments = navController.currentBackStackEntry!!.arguments ?: Bundle.EMPTY
                 TestViewModel(dependencies, handle, arguments)
               }
               val viewModel = viewModelProvider[TestViewModel::class.java]
@@ -254,7 +250,6 @@ class FileGeneratorTestCompose {
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
-            import androidx.navigation.NavController
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
@@ -317,10 +312,9 @@ class FileGeneratorTestCompose {
 
             @Composable
             @OptIn(InternalWhetstoneApi::class)
-            public fun TestScreen(navController: NavController): Unit {
+            public fun TestScreen(arguments: Bundle): Unit {
               val viewModelProvider = rememberViewModelProvider<TestDependencies>(TestParentScope::class) {
                   dependencies, handle -> 
-                val arguments = navController.currentBackStackEntry!!.arguments ?: Bundle.EMPTY
                 TestViewModel(dependencies, handle, arguments)
               }
               val viewModel = viewModelProvider[TestViewModel::class.java]
@@ -328,7 +322,7 @@ class FileGeneratorTestCompose {
 
               val handler = component.testNavigationHandler
               val navigator = component.testNavigator
-              handler.Navigation(navController, navigator)
+              handler.Navigation(navigator)
 
               val providedValues = component.providedValues
               CompositionLocalProvider(*providedValues.toTypedArray()) {
@@ -361,7 +355,6 @@ class FileGeneratorTestCompose {
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
-            import androidx.navigation.NavController
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
@@ -425,10 +418,9 @@ class FileGeneratorTestCompose {
 
             @Composable
             @OptIn(InternalWhetstoneApi::class)
-            public fun TestScreen(navController: NavController): Unit {
+            public fun TestScreen(arguments: Bundle): Unit {
               val viewModelProvider = rememberViewModelProvider<TestDependencies>(TestParentScope::class) {
                   dependencies, handle -> 
-                val arguments = navController.currentBackStackEntry!!.arguments ?: Bundle.EMPTY
                 TestViewModel(dependencies, handle, arguments)
               }
               val viewModel = viewModelProvider[TestViewModel::class.java]
@@ -436,7 +428,7 @@ class FileGeneratorTestCompose {
 
               val handler = component.testNavigationHandler
               val navigator = component.testNavigator
-              handler.Navigation(navController, navigator)
+              handler.Navigation(navigator)
 
               val providedValues = component.providedValues
               CompositionLocalProvider(*providedValues.toTypedArray()) {

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
@@ -45,8 +45,6 @@ class FileGeneratorTestComposeFragment {
             import androidx.fragment.app.Fragment
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
-            import androidx.navigation.NavController
-            import androidx.navigation.fragment.findNavController
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
@@ -120,10 +118,9 @@ class FileGeneratorTestComposeFragment {
 
             @Composable
             @OptIn(InternalWhetstoneApi::class)
-            public fun TestScreen(navController: NavController): Unit {
+            public fun TestScreen(arguments: Bundle): Unit {
               val viewModelProvider = rememberViewModelProvider<TestDependencies>(TestParentScope::class) {
                   dependencies, handle -> 
-                val arguments = navController.currentBackStackEntry!!.arguments ?: Bundle.EMPTY
                 TestViewModel(dependencies, handle, arguments)
               }
               val viewModel = viewModelProvider[TestViewModel::class.java]
@@ -157,7 +154,6 @@ class FileGeneratorTestComposeFragment {
                   setupNavigation()
                 }
             
-                val navController = findNavController()
                 return ComposeView(requireContext()).apply {
                   setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnLifecycleDestroyed(viewLifecycleOwner))
 
@@ -168,7 +164,7 @@ class FileGeneratorTestComposeFragment {
 
                   setContent {
                     CompositionLocalProvider(LocalWindowInsets provides windowInsets) {
-                      TestScreen(navController)
+                      TestScreen(requireArguments())
                     }
                   }
                 }
@@ -214,8 +210,6 @@ class FileGeneratorTestComposeFragment {
             import androidx.fragment.app.DialogFragment
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
-            import androidx.navigation.NavController
-            import androidx.navigation.fragment.findNavController
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
@@ -289,10 +283,9 @@ class FileGeneratorTestComposeFragment {
 
             @Composable
             @OptIn(InternalWhetstoneApi::class)
-            public fun TestScreen(navController: NavController): Unit {
+            public fun TestScreen(arguments: Bundle): Unit {
               val viewModelProvider = rememberViewModelProvider<TestDependencies>(TestParentScope::class) {
                   dependencies, handle -> 
-                val arguments = navController.currentBackStackEntry!!.arguments ?: Bundle.EMPTY
                 TestViewModel(dependencies, handle, arguments)
               }
               val viewModel = viewModelProvider[TestViewModel::class.java]
@@ -326,7 +319,6 @@ class FileGeneratorTestComposeFragment {
                   setupNavigation()
                 }
             
-                val navController = findNavController()
                 return ComposeView(requireContext()).apply {
                   setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnLifecycleDestroyed(viewLifecycleOwner))
 
@@ -337,7 +329,7 @@ class FileGeneratorTestComposeFragment {
 
                   setContent {
                     CompositionLocalProvider(LocalWindowInsets provides windowInsets) {
-                      TestScreen(navController)
+                      TestScreen(requireArguments())
                     }
                   }
                 }
@@ -381,8 +373,6 @@ class FileGeneratorTestComposeFragment {
             import androidx.fragment.app.Fragment
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
-            import androidx.navigation.NavController
-            import androidx.navigation.fragment.findNavController
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
@@ -454,10 +444,9 @@ class FileGeneratorTestComposeFragment {
 
             @Composable
             @OptIn(InternalWhetstoneApi::class)
-            public fun TestScreen(navController: NavController): Unit {
+            public fun TestScreen(arguments: Bundle): Unit {
               val viewModelProvider = rememberViewModelProvider<TestDependencies>(TestParentScope::class) {
                   dependencies, handle -> 
-                val arguments = navController.currentBackStackEntry!!.arguments ?: Bundle.EMPTY
                 TestViewModel(dependencies, handle, arguments)
               }
               val viewModel = viewModelProvider[TestViewModel::class.java]
@@ -491,12 +480,11 @@ class FileGeneratorTestComposeFragment {
                   setupNavigation()
                 }
             
-                val navController = findNavController()
                 return ComposeView(requireContext()).apply {
                   setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnLifecycleDestroyed(viewLifecycleOwner))
 
                   setContent {
-                    TestScreen(navController)
+                    TestScreen(requireArguments())
                   }
                 }
               }
@@ -539,8 +527,6 @@ class FileGeneratorTestComposeFragment {
             import androidx.fragment.app.Fragment
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
-            import androidx.navigation.NavController
-            import androidx.navigation.fragment.findNavController
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
@@ -607,10 +593,9 @@ class FileGeneratorTestComposeFragment {
 
             @Composable
             @OptIn(InternalWhetstoneApi::class)
-            public fun TestScreen(navController: NavController): Unit {
+            public fun TestScreen(arguments: Bundle): Unit {
               val viewModelProvider = rememberViewModelProvider<TestDependencies>(TestParentScope::class) {
                   dependencies, handle -> 
-                val arguments = navController.currentBackStackEntry!!.arguments ?: Bundle.EMPTY
                 TestViewModel(dependencies, handle, arguments)
               }
               val viewModel = viewModelProvider[TestViewModel::class.java]
@@ -636,20 +621,17 @@ class FileGeneratorTestComposeFragment {
                 inflater: LayoutInflater,
                 container: ViewGroup?,
                 savedInstanceState: Bundle?
-              ): View {
-                val navController = findNavController()
-                return ComposeView(requireContext()).apply {
-                  setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnLifecycleDestroyed(viewLifecycleOwner))
+              ): View = ComposeView(requireContext()).apply {
+                setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnLifecycleDestroyed(viewLifecycleOwner))
 
-                  layoutParams = ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
-                      ViewGroup.LayoutParams.MATCH_PARENT)
-                  val observer = ViewWindowInsetObserver(this)
-                  val windowInsets = observer.start()
+                layoutParams = ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT)
+                val observer = ViewWindowInsetObserver(this)
+                val windowInsets = observer.start()
 
-                  setContent {
-                    CompositionLocalProvider(LocalWindowInsets provides windowInsets) {
-                      TestScreen(navController)
-                    }
+                setContent {
+                  CompositionLocalProvider(LocalWindowInsets provides windowInsets) {
+                    TestScreen(requireArguments())
                   }
                 }
               }

--- a/whetstone/runtime-compose/src/main/java/com/freeletics/mad/whetstone/compose/internal/EmptyNavigationHandler.kt
+++ b/whetstone/runtime-compose/src/main/java/com/freeletics/mad/whetstone/compose/internal/EmptyNavigationHandler.kt
@@ -18,7 +18,7 @@ internal class EmptyNavigationHandler : NavigationHandler<EmptyNavigator> {
     }
 
     @Composable
-    override fun Navigation(navController: NavController, navigator: EmptyNavigator) {
+    override fun Navigation(navigator: EmptyNavigator) {
         throw UnsupportedOperationException("This is a marker class that should never be used")
     }
 }


### PR DESCRIPTION
With this we don't need to pass a `NavController` to the generated composables anymore. Instead our `NavHost` method will provide it through an internal composition local that the navigation handler can then find. One side effect is that it's now required to create the graph for compose navigation through our `NavHost` composables, but since that provides extension functionality I don't see that as a problem.

The screen composables now get a `Bundle` with the arguments for the destination instead. The nice thing here is that we also don't rely on `navController.currentBackStackEntry` to retrieve them anymore. That method generally works fine but there are some edge cases were our screen isn't the current entry. For pure compose we get the arguments from the `NavBackStackEntry` that is passed to us from the navigation library when the destination gets created on the backstack.  Composables inside Fragments directly get the `Fragment` arguments. I think we might be able to go one step further in the future and directly replace the `Bundle` with the `NavDirections` class but for that we need the type info in whetstone. I'll look into that when I also look into generating the provides for `NavDestination`.