### PR TITLE
remove NavOptions from navigateTo

### DIFF
--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavEventNavigationHandler.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavEventNavigationHandler.kt
@@ -120,11 +120,13 @@ public open class NavEventNavigationHandler : NavigationHandler<NavEventNavigato
 
         when (event) {
             is NavigateToEvent -> {
-                controller.navigate(
-                    event.route.destinationId,
-                    event.route.getArguments(),
-                    event.options,
-                )
+                controller.navigate(event.route.destinationId, event.route.getArguments())
+            }
+            is NavEvent.NavigateBackAndThenToEvent -> {
+                val options = NavOptions.Builder()
+                    .setPopUpTo(event.popUpToDestinationId, inclusive = event.inclusive)
+                    .build()
+                controller.navigate(event.route.destinationId, event.route.getArguments(), options)
             }
             is NavEvent.NavigateToRootEvent -> {
                 val options = NavOptions.Builder()
@@ -136,11 +138,7 @@ public open class NavEventNavigationHandler : NavigationHandler<NavEventNavigato
                     // everything above it gets removed
                     .setLaunchSingleTop(true)
                     .build()
-                controller.navigate(
-                    event.root.destinationId,
-                    event.root.getArguments(),
-                    options
-                )
+                controller.navigate(event.root.destinationId, event.root.getArguments(), options)
             }
             is UpEvent -> {
                 controller.navigateUp()

--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavEventNavigationHandler.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavEventNavigationHandler.kt
@@ -31,7 +31,6 @@ import com.freeletics.mad.navigator.PermissionsResultRequest.PermissionResult.DE
 import com.freeletics.mad.navigator.ResultLauncher
 import com.freeletics.mad.navigator.internal.RequestPermissionsContract
 import java.lang.IllegalArgumentException
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 
 /**
@@ -111,11 +110,14 @@ public open class NavEventNavigationHandler : NavigationHandler<FragmentNavEvent
         when (event) {
             is NavigateToEvent -> {
                 val controller = fragment.findNavController()
-                controller.navigate(
-                    event.route.destinationId,
-                    event.route.getArguments(),
-                    event.options,
-                )
+                controller.navigate(event.route.destinationId, event.route.getArguments())
+            }
+            is NavEvent.NavigateBackAndThenToEvent -> {
+                val controller = fragment.findNavController()
+                val options = NavOptions.Builder()
+                    .setPopUpTo(event.popUpToDestinationId, inclusive = event.inclusive)
+                    .build()
+                controller.navigate(event.route.destinationId, event.route.getArguments(), options)
             }
             is NavEvent.NavigateToRootEvent -> {
                 val controller = fragment.findNavController()
@@ -128,11 +130,7 @@ public open class NavEventNavigationHandler : NavigationHandler<FragmentNavEvent
                     // everything above it gets removed
                     .setLaunchSingleTop(true)
                     .build()
-                controller.navigate(
-                    event.root.destinationId,
-                    event.root.getArguments(),
-                    options
-                )
+                controller.navigate(event.root.destinationId, event.root.getArguments(), options)
             }
             is UpEvent -> {
                 val controller = fragment.findNavController()

--- a/navigator/runtime/build.gradle
+++ b/navigator/runtime/build.gradle
@@ -43,8 +43,6 @@ tasks.withType(JavaCompile).configureEach {
 dependencies {
     api project(":navigator:common")
     api "androidx.activity:activity:1.4.0"
-    api "androidx.navigation:navigation-runtime:2.4.0"
-    api "androidx.navigation:navigation-runtime-ktx:2.4.0"
     api "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0"
 
     testImplementation "junit:junit:4.13.2"

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEvent.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEvent.kt
@@ -1,7 +1,6 @@
 package com.freeletics.mad.navigator
 
 import androidx.annotation.IdRes
-import androidx.navigation.NavOptions
 
 /**
  * Represents a navigation event that is being sent by a [NavEventNavigator] and handled by
@@ -14,11 +13,20 @@ import androidx.navigation.NavOptions
 public interface NavEvent {
 
     /**
-     * Navigates to the given [route] using the optionally passed [options].
+     * Navigates to the given [route].
      */
     public data class NavigateToEvent(
         val route: NavRoute,
-        val options: NavOptions? = null,
+    ) : NavEvent
+
+    /**
+     * Navigates back to the given [popUpToDestinationId]. If [inclusive] is `true` the destination
+     * itself will also be popped of the back stack. Then navigates to the given [route].
+     */
+    public data class NavigateBackAndThenToEvent(
+        val route: NavRoute,
+        @IdRes val popUpToDestinationId: Int,
+        val inclusive: Boolean,
     ) : NavEvent
 
     /**

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
@@ -3,11 +3,9 @@ package com.freeletics.mad.navigator
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.annotation.IdRes
-import androidx.navigation.NavOptions
-import androidx.navigation.NavOptionsBuilder
-import androidx.navigation.navOptions
 import com.freeletics.mad.navigator.NavEvent.BackEvent
 import com.freeletics.mad.navigator.NavEvent.BackToEvent
+import com.freeletics.mad.navigator.NavEvent.NavigateBackAndThenToEvent
 import com.freeletics.mad.navigator.NavEvent.ResultLauncherEvent
 import com.freeletics.mad.navigator.NavEvent.NavigateToEvent
 import com.freeletics.mad.navigator.NavEvent.UpEvent
@@ -107,14 +105,15 @@ public abstract class NavEventNavigator : Navigator {
     }
 
     /**
-     * Triggers a new [NavEvent] to navigate to the given [route], using [NavOptions]
-     * built with [optionsBuilder].
+     * Triggers a new [NavEvent] that pops the back stack to [popUpTo]. If [inclusive] is `true`
+     * [popUpTo] destination itself will also be popped. Afterwards it will navigate to [route].
      */
     public fun navigateTo(
         route: NavRoute,
-        optionsBuilder: NavOptionsBuilder.() -> Unit
+        @IdRes popUpTo: Int,
+        inclusive: Boolean = false
     ) {
-        val event = NavigateToEvent(route, navOptions(optionsBuilder))
+        val event = NavigateBackAndThenToEvent(route, popUpTo, inclusive)
         sendNavEvent(event)
     }
 
@@ -148,11 +147,11 @@ public abstract class NavEventNavigator : Navigator {
     }
 
     /**
-     * Triggers a new [NavEvent] that pops the back stack to [actionId]. If [inclusive] is `true`
-     * [actionId] itself will also be popped.
+     * Triggers a new [NavEvent] that pops the back stack to [destinationId]. If [inclusive] is
+     * `true` [destinationId] itself will also be popped.
      */
-    public fun navigateBack(@IdRes actionId: Int, inclusive: Boolean = false) {
-        val event = BackToEvent(actionId, inclusive)
+    public fun navigateBack(@IdRes destinationId: Int, inclusive: Boolean = false) {
+        val event = BackToEvent(destinationId, inclusive)
         sendNavEvent(event)
     }
 


### PR DESCRIPTION
Instead of accepting a full `NavOptions` object we only take the `popUpTo` id and whether it's inclusive. The motivation here are 2 things:
- together with #25 we limit exposing `androidx.navigation` APIs to creating the graphs (`NavHost` composable and `NavHostFragment.setGraph(...)`)
- when we remove `destinationId` we need to replace the `popUpTo` arg and if our API takes an already built `NavOptions` object that is not possible

Currently we don't use any other available options so I limited to these but we could add more if needed.