### PR TITLE
share NavEvent handling and permission result logic

### DIFF
--- a/navigator/runtime/build.gradle
+++ b/navigator/runtime/build.gradle
@@ -45,6 +45,8 @@ dependencies {
     api "androidx.activity:activity:1.4.0"
     api "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0"
 
+    implementation "androidx.navigation:navigation-runtime:2.4.0"
+
     testImplementation "junit:junit:4.13.2"
     testImplementation "com.google.truth:truth:1.1.3"
     testImplementation "app.cash.turbine:turbine:0.7.0"

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEvent.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEvent.kt
@@ -16,7 +16,7 @@ public interface NavEvent {
      * Navigates to the given [route].
      */
     public data class NavigateToEvent(
-        val route: NavRoute,
+        internal val route: NavRoute,
     ) : NavEvent
 
     /**
@@ -24,9 +24,9 @@ public interface NavEvent {
      * itself will also be popped of the back stack. Then navigates to the given [route].
      */
     public data class NavigateBackAndThenToEvent(
-        val route: NavRoute,
-        @IdRes val popUpToDestinationId: Int,
-        val inclusive: Boolean,
+        internal val route: NavRoute,
+        internal val popUpToDestinationId: Int,
+        internal val inclusive: Boolean,
     ) : NavEvent
 
     /**
@@ -34,8 +34,8 @@ public interface NavEvent {
      * Whether the backstack of the given route is restored depends on [restoreRootState].
      */
     public data class NavigateToRootEvent(
-        val root: NavRoot,
-        val restoreRootState: Boolean,
+        internal val root: NavRoot,
+        internal val restoreRootState: Boolean,
     ) : NavEvent
 
     /**
@@ -53,23 +53,23 @@ public interface NavEvent {
      * will also be popped of the back stack.
      */
     public data class BackToEvent(
-        @IdRes val destinationId: Int,
-        val inclusive: Boolean,
+        internal val destinationId: Int,
+        internal val inclusive: Boolean,
     ) : NavEvent
 
     /**
      * Launches the [request] to retrieve an event.
      */
     public data class ActivityResultEvent<I>(
-        val request: ActivityResultRequest<I, *>,
-        val input: I,
+        internal val request: ActivityResultRequest<I, *>,
+        internal val input: I,
     ) : NavEvent
 
     /**
      * Launches the [request] to retrieve an event.
      */
     public data class PermissionsResultEvent(
-        val request: PermissionsResultRequest,
-        val permissions: List<String>,
+        internal val request: PermissionsResultRequest,
+        internal val permissions: List<String>,
     ) : NavEvent
 }

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/Navigate.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/Navigate.kt
@@ -1,0 +1,69 @@
+package com.freeletics.mad.navigator.internal
+
+import androidx.activity.result.ActivityResultLauncher
+import androidx.navigation.NavController
+import androidx.navigation.NavOptions
+import com.freeletics.mad.navigator.ActivityResultRequest
+import com.freeletics.mad.navigator.NavEvent
+import com.freeletics.mad.navigator.PermissionsResultRequest
+import java.lang.IllegalArgumentException
+
+@InternalNavigatorApi
+public fun navigate(
+    event: NavEvent,
+    controller: NavController,
+    activityLaunchers: Map<ActivityResultRequest<*, *>, ActivityResultLauncher<*>>,
+    permissionLaunchers: Map<PermissionsResultRequest, ActivityResultLauncher<List<String>>>
+) {
+    when (event) {
+        is NavEvent.NavigateToEvent -> {
+            controller.navigate(event.route.destinationId, event.route.getArguments())
+        }
+        is NavEvent.NavigateBackAndThenToEvent -> {
+            val options = NavOptions.Builder()
+                .setPopUpTo(event.popUpToDestinationId, inclusive = event.inclusive)
+                .build()
+            controller.navigate(event.route.destinationId, event.route.getArguments(), options)
+        }
+        is NavEvent.NavigateToRootEvent -> {
+            val options = NavOptions.Builder()
+                // save the state of the current root before leaving it
+                .setPopUpTo(controller.graph.startDestinationId, inclusive = false, saveState = true)
+                // restoring the state of the target root
+                .setRestoreState(event.restoreRootState)
+                // makes sure that if the destination is already on the backstack, it and
+                // everything above it gets removed
+                .setLaunchSingleTop(true)
+                .build()
+            controller.navigate(event.root.destinationId, event.root.getArguments(), options)
+        }
+        is NavEvent.UpEvent -> {
+            controller.navigateUp()
+        }
+        is NavEvent.BackEvent -> {
+            controller.popBackStack()
+        }
+        is NavEvent.BackToEvent -> {
+            controller.popBackStack(event.destinationId, event.inclusive)
+        }
+        is NavEvent.ActivityResultEvent<*> -> {
+            val request = event.request
+            val launcher = activityLaunchers[request] ?: throw IllegalStateException(
+                "No launcher registered for $request!\nMake sure you called the appropriate " +
+                    "AbstractNavigator.registerFor... method"
+            )
+            @Suppress("UNCHECKED_CAST")
+            (launcher as ActivityResultLauncher<Any?>).launch(event.input)
+        }
+        is NavEvent.PermissionsResultEvent -> {
+            val request = event.request
+            val launcher = permissionLaunchers[request] ?: throw IllegalStateException(
+                "No launcher registered for $request!\nMake sure you called the appropriate " +
+                    "AbstractNavigator.registerFor... method"
+            )
+            @Suppress("UNCHECKED_CAST")
+            (launcher as ActivityResultLauncher<Any?>).launch(event.permissions)
+        }
+        else -> throw IllegalArgumentException("Unknown NavEvent $event")
+    }
+}


### PR DESCRIPTION
Removes the duplicate logic that we had in the 2 navigation handlers. With this we can also mark all the fields inside the nav event classes as `internal`. The classes themselves and their constructors stay public so that it is possible to instantiate them to test emitted events by comparison. 

Until https://youtrack.jetbrains.com/issue/KT-22284 is done the shared methods are only marked with `InternalNavigatorApi` and are technically public.