### PR TITLE
move FragmentResultEvent into it's own stream

### DIFF
--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/FragmentResultEvent.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/FragmentResultEvent.kt
@@ -9,6 +9,6 @@ import com.freeletics.mad.navigator.NavEventNavigator
  * [NavEventNavigator.navigateForResult].
  */
 public data class FragmentResultEvent(
-    val requestKey: String,
-    val result: Parcelable
-) : NavEvent
+    internal val requestKey: String,
+    internal val result: Parcelable
+)

--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavEventNavigationHandler.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavEventNavigationHandler.kt
@@ -52,6 +52,13 @@ public open class NavEventNavigationHandler : NavigationHandler<FragmentNavEvent
                 }
             }
         }
+        lifecycle.coroutineScope.launch {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                navigator.resultEvents.collect { event ->
+                    navigate(fragment, event)
+                }
+            }
+        }
     }
 
     private fun <I, O> ActivityResultRequest<I, O>.registerIn(
@@ -88,14 +95,15 @@ public open class NavEventNavigationHandler : NavigationHandler<FragmentNavEvent
             return
         }
 
-        if (event is FragmentResultEvent) {
-            val result = Bundle(1).apply {
-                putParcelable(KEY_FRAGMENT_RESULT, event.result)
-            }
-            fragment.parentFragmentManager.setFragmentResult(event.requestKey, result)
-        } else {
-            navigate(event, fragment.findNavController(), activityLaunchers, permissionLaunchers)
+        navigate(event, fragment.findNavController(), activityLaunchers, permissionLaunchers)
+    }
+
+    private fun navigate(fragment: Fragment, event: FragmentResultEvent) {
+        val result = Bundle(1).apply {
+            putParcelable(KEY_FRAGMENT_RESULT, event.result)
         }
+        fragment.parentFragmentManager.setFragmentResult(event.requestKey, result)
+        fragment.findNavController().popBackStack()
     }
 
     /**

--- a/navigator/runtime-fragment/src/test/java/com/freeletics/mad/navigator/fragment/FragmentNavEventNavigatorTest.kt
+++ b/navigator/runtime-fragment/src/test/java/com/freeletics/mad/navigator/fragment/FragmentNavEventNavigatorTest.kt
@@ -19,12 +19,11 @@ public class FragmentNavEventNavigatorTest {
     public fun `navigateBackWithResult is received`(): Unit = runBlocking {
         val navigator = TestNavigator()
 
-        navigator.navEvents.test {
+        navigator.resultEvents.test {
             val result = Bundle()
             navigator.navigateBackWithResult("test-key", result)
 
             assertThat(awaitItem()).isEqualTo(FragmentResultEvent("test-key", result))
-            assertThat(awaitItem()).isEqualTo(NavEvent.BackEvent)
 
             cancel()
         }


### PR DESCRIPTION
With this `FragmentResultEvent` does not extend `NavEvent` anymore and has it's own `Flow`. Instead of having an extra back event that's being sent the handler for this event will just do both. Since this is a very specific use case there shouldn't be any issues with ordering, delivering a fragment result and going back doesn't make sense to be mixed with other events.

In the next PR I will lock down the APIs that now don't need to be exposed anymore (NavEvent as sealed class, some extension points etc).