### PR TITLE
lock down NavEvent and Navigator APIs

### DIFF
--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavDestination.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavDestination.kt
@@ -76,9 +76,9 @@ public inline fun <reified T : NavRoute> ActivityDestination(
  * [route] will be used as a unique identifier together with [destinationId]. The destination can
  * be reached by navigating using an instance of [route].
  */
-public abstract class NavDestination {
-    public abstract val route: KClass<*>
-    @get:IdRes public abstract val destinationId: Int
+public interface NavDestination {
+    public val route: KClass<*>
+    @get:IdRes public val destinationId: Int
 
     /**
      * Represents a full screen. The [route] will be used as a unique identifier together
@@ -89,7 +89,7 @@ public abstract class NavDestination {
         override val route: KClass<out NavRoute>,
         override val destinationId: Int,
         internal val screenContent: @Composable (Bundle) -> Unit,
-    ) : NavDestination()
+    ) : NavDestination
 
     /**
      * Represents a full screen. The [route] will be used as a unique identifier together
@@ -100,7 +100,7 @@ public abstract class NavDestination {
         override val route: KClass<out NavRoot>,
         override val destinationId: Int,
         internal val screenContent: @Composable (Bundle) -> Unit,
-    ) : NavDestination()
+    ) : NavDestination
 
     /**
      * Represents a dialog. The [route] will be used as a unique identifier together
@@ -111,7 +111,7 @@ public abstract class NavDestination {
         override val route: KClass<out NavRoute>,
         override val destinationId: Int,
         internal val dialogContent: @Composable (Bundle) -> Unit,
-    ) : NavDestination()
+    ) : NavDestination
 
     /**
      * Represents a bottom sheet. The [route] will be used as a unique identifier together
@@ -123,7 +123,7 @@ public abstract class NavDestination {
         override val route: KClass<out NavRoute>,
         override val destinationId: Int,
         internal val bottomSheetContent: @Composable (Bundle) -> Unit,
-    ) : NavDestination()
+    ) : NavDestination
 
     /**
      * Represents an `Activity`. The [route] will be used as a unique identifier together
@@ -134,5 +134,5 @@ public abstract class NavDestination {
         override val route: KClass<out NavRoute>,
         override val destinationId: Int,
         internal val intent: Intent,
-    ) : NavDestination()
+    ) : NavDestination
 }

--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavEventNavigationHandler.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavEventNavigationHandler.kt
@@ -6,14 +6,12 @@ import android.content.ContextWrapper
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.ActivityResultLauncher
-import androidx.annotation.CallSuper
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.flowWithLifecycle
-import androidx.navigation.NavController
 import com.freeletics.mad.navigator.ActivityResultRequest
 import com.freeletics.mad.navigator.NavEvent
 import com.freeletics.mad.navigator.NavEventNavigator
@@ -27,10 +25,9 @@ import kotlinx.coroutines.flow.collect
  * A [NavigationHandler] that handles [NavEvent] emitted by a [NavEventNavigator].
  */
 @OptIn(InternalNavigatorApi::class)
-public open class NavEventNavigationHandler : NavigationHandler<NavEventNavigator> {
+public class NavEventNavigationHandler : NavigationHandler<NavEventNavigator> {
 
     @Composable
-    @CallSuper
     override fun Navigation(navigator: NavEventNavigator) {
         val controller = LocalNavController.current
         val lifecycleOwner = LocalLifecycleOwner.current

--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavEventNavigationHandler.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavEventNavigationHandler.kt
@@ -55,7 +55,7 @@ public open class NavEventNavigationHandler : NavigationHandler<NavEventNavigato
             navigator.navEvents
                 .flowWithLifecycle(lifecycleOwner.lifecycle)
                 .collect { event ->
-                    navigate(controller, activityLaunchers, permissionLaunchers, event)
+                    navigate(event, controller, activityLaunchers, permissionLaunchers)
                 }
         }
     }
@@ -84,28 +84,5 @@ public open class NavEventNavigationHandler : NavigationHandler<NavEventNavigato
             context = context.baseContext
         }
         throw IllegalStateException("Permissions should be called in the context of an Activity")
-    }
-
-    private fun navigate(
-        controller: NavController,
-        activityLaunchers: Map<ActivityResultRequest<*, *>, ActivityResultLauncher<*>>,
-        permissionLaunchers: Map<PermissionsResultRequest, ActivityResultLauncher<List<String>>>,
-        event: NavEvent
-    ) {
-        if (handleNavEvent(event)) {
-            return
-        }
-
-        navigate(event, controller, activityLaunchers, permissionLaunchers)
-    }
-
-    /**
-     * This method can be overridden to handle custom [NavEvent] implementations or handle
-     * the standard events in a different way.
-     *
-     * @return `true` if event was handled, `false` otherwise
-     */
-    protected open fun handleNavEvent(event: NavEvent): Boolean {
-        return false
     }
 }

--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/FragmentNavEventNavigator.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/FragmentNavEventNavigator.kt
@@ -1,6 +1,8 @@
 package com.freeletics.mad.navigator.fragment
 
 import android.os.Parcelable
+import androidx.annotation.VisibleForTesting
+import androidx.annotation.VisibleForTesting.PACKAGE_PRIVATE
 import com.freeletics.mad.navigator.NavEvent
 import com.freeletics.mad.navigator.NavEventNavigator
 import com.freeletics.mad.navigator.internal.InternalNavigatorApi
@@ -13,7 +15,6 @@ import kotlinx.coroutines.flow.receiveAsFlow
  * An extension to [NavEventNavigator] that adds support for `Fragment` result APIs. See
  * [registerForFragmentResult] and [navigateBackWithResult].
  */
-@Suppress("MemberVisibilityCanBePrivate", "unused")
 public abstract class FragmentNavEventNavigator : NavEventNavigator() {
 
     private val _resultEvents = Channel<FragmentResultEvent>(Channel.UNLIMITED)
@@ -21,6 +22,7 @@ public abstract class FragmentNavEventNavigator : NavEventNavigator() {
     /**
      * A [Flow] to collect [FragmentResultEvents][FragmentResultEvent] produced by this navigator.
      */
+    @VisibleForTesting(otherwise = PACKAGE_PRIVATE)
     public val resultEvents: Flow<FragmentResultEvent> = _resultEvents.receiveAsFlow()
 
     private val _fragmentResultRequests = mutableListOf<FragmentResultRequest<*>>()
@@ -64,8 +66,7 @@ public abstract class FragmentNavEventNavigator : NavEventNavigator() {
      * [registerForFragmentResult]. A `NavEventNavigationHandler` can use these to register
      * the requests during setup so that results are delivered to them.
      */
-    @InternalNavigatorApi
-    public val fragmentResultRequests: List<FragmentResultRequest<*>>
+    internal val fragmentResultRequests: List<FragmentResultRequest<*>>
         get() {
             allowedToAddRequests = false
             return _fragmentResultRequests.toList()

--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/FragmentResultEvent.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/FragmentResultEvent.kt
@@ -1,13 +1,15 @@
 package com.freeletics.mad.navigator.fragment
 
 import android.os.Parcelable
-import com.freeletics.mad.navigator.NavEvent
+import androidx.annotation.VisibleForTesting
+import androidx.annotation.VisibleForTesting.PACKAGE_PRIVATE
 import com.freeletics.mad.navigator.NavEventNavigator
 
 /**
  * Delivers a `Fragment` result to a requester that started this `Fragment` with
  * [NavEventNavigator.navigateForResult].
  */
+@VisibleForTesting(otherwise = PACKAGE_PRIVATE)
 public data class FragmentResultEvent(
     internal val requestKey: String,
     internal val result: Parcelable

--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavDestination.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavDestination.kt
@@ -59,9 +59,9 @@ public inline fun <reified T : NavRoute> ActivityDestination(
  * [route] will be used as a unique identifier together with [destinationId]. The destination can
  * be reached by navigating using an instance of [route].
  */
-public abstract class NavDestination {
-    public abstract val route: KClass<*>
-    @get:IdRes public abstract val destinationId: Int
+public interface NavDestination {
+    public val route: KClass<*>
+    @get:IdRes public val destinationId: Int
 
     /**
      * Represents a full screen. The [route] will be used as a unique identifier together
@@ -72,7 +72,7 @@ public abstract class NavDestination {
         override val route: KClass<out NavRoute>,
         override val destinationId: Int,
         internal val fragmentClass: KClass<out Fragment>,
-    ) : NavDestination()
+    ) : NavDestination
 
     /**
      * Represents a full screen. The [route] will be used as a unique identifier together
@@ -83,7 +83,7 @@ public abstract class NavDestination {
         override val route: KClass<out NavRoot>,
         override val destinationId: Int,
         internal val fragmentClass: KClass<out Fragment>,
-    ) : NavDestination()
+    ) : NavDestination
 
     /**
      * Represents a dialog. The [route] will be used as a unique identifier together
@@ -94,7 +94,7 @@ public abstract class NavDestination {
         override val route: KClass<out NavRoute>,
         override val destinationId: Int,
         internal val fragmentClass: KClass<out DialogFragment>,
-    ) : NavDestination()
+    ) : NavDestination
 
     /**
      * Represents an `Activity`. The [route] will be used as a unique identifier together
@@ -105,5 +105,5 @@ public abstract class NavDestination {
         override val route: KClass<out NavRoute>,
         override val destinationId: Int,
         internal val intent: Intent,
-    ) : NavDestination()
+    ) : NavDestination
 }

--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavEventNavigationHandler.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavEventNavigationHandler.kt
@@ -1,10 +1,10 @@
 package com.freeletics.mad.navigator.fragment
 
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.os.Bundle
 import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
-import androidx.annotation.CallSuper
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentResultOwner
 import androidx.lifecycle.Lifecycle
@@ -26,9 +26,8 @@ import kotlinx.coroutines.launch
  * A [NavigationHandler] that handles [NavEvent] emitted by a [NavEventNavigator].
  */
 @OptIn(InternalNavigatorApi::class)
-public open class NavEventNavigationHandler : NavigationHandler<FragmentNavEventNavigator> {
+public class NavEventNavigationHandler : NavigationHandler<FragmentNavEventNavigator> {
 
-    @CallSuper
     override fun handle(fragment: Fragment, navigator: FragmentNavEventNavigator) {
         val activityLaunchers = navigator.activityResultRequests.associateWith {
             it.registerIn(fragment)
@@ -76,6 +75,7 @@ public open class NavEventNavigationHandler : NavigationHandler<FragmentNavEvent
         }
     }
 
+    @SuppressLint("VisibleForTests") // it's ok to use onResult internally
     private fun <O> FragmentResultRequest<O>.registerIn(
         fragmentResultOwner: FragmentResultOwner,
         lifecycleOwner: LifecycleOwner

--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavEventNavigationHandler.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavEventNavigationHandler.kt
@@ -48,7 +48,7 @@ public open class NavEventNavigationHandler : NavigationHandler<FragmentNavEvent
         lifecycle.coroutineScope.launch {
             lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 navigator.navEvents.collect { event ->
-                    navigate(fragment, activityLaunchers, permissionLaunchers, event)
+                    navigate(event, fragment.findNavController(), activityLaunchers, permissionLaunchers)
                 }
             }
         }
@@ -85,35 +85,12 @@ public open class NavEventNavigationHandler : NavigationHandler<FragmentNavEvent
         }
     }
 
-    private fun navigate(
-        fragment: Fragment,
-        activityLaunchers: Map<ActivityResultRequest<*, *>, ActivityResultLauncher<*>>,
-        permissionLaunchers: Map<PermissionsResultRequest, ActivityResultLauncher<List<String>>>,
-        event: NavEvent
-    ) {
-        if (handleNavEvent(event)) {
-            return
-        }
-
-        navigate(event, fragment.findNavController(), activityLaunchers, permissionLaunchers)
-    }
-
     private fun navigate(fragment: Fragment, event: FragmentResultEvent) {
         val result = Bundle(1).apply {
             putParcelable(KEY_FRAGMENT_RESULT, event.result)
         }
         fragment.parentFragmentManager.setFragmentResult(event.requestKey, result)
         fragment.findNavController().popBackStack()
-    }
-
-    /**
-     * This method can be overridden to handle custom [NavEvent] implementations or handle
-     * the standard events in a different way.
-     *
-     * @return `true` if event was handled, `false` otherwise
-     */
-    protected open fun handleNavEvent(event: NavEvent): Boolean {
-       return false
     }
 }
 

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEvent.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEvent.kt
@@ -8,7 +8,7 @@ package com.freeletics.mad.navigator
  * Custom subclasses of `NavEvent` can be sent using [NavEventNavigator.sendNavEvent] but require
  * providing a custom `NavEventNavigationHandler` that supports handling those events.
  */
-public interface NavEvent {
+public sealed interface NavEvent {
 
     /**
      * Navigates to the given [route].

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEvent.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEvent.kt
@@ -1,5 +1,8 @@
 package com.freeletics.mad.navigator
 
+import androidx.annotation.VisibleForTesting
+import androidx.annotation.VisibleForTesting.PACKAGE_PRIVATE
+
 /**
  * Represents a navigation event that is being sent by a [NavEventNavigator] and handled by
  * a `NavEventNavigationHandler` implementation. Default implementations of such a handler are
@@ -8,11 +11,13 @@ package com.freeletics.mad.navigator
  * Custom subclasses of `NavEvent` can be sent using [NavEventNavigator.sendNavEvent] but require
  * providing a custom `NavEventNavigationHandler` that supports handling those events.
  */
+@VisibleForTesting(otherwise = PACKAGE_PRIVATE)
 public sealed interface NavEvent {
 
     /**
      * Navigates to the given [route].
      */
+    @VisibleForTesting(otherwise = PACKAGE_PRIVATE)
     public data class NavigateToEvent(
         internal val route: NavRoute,
     ) : NavEvent
@@ -21,6 +26,7 @@ public sealed interface NavEvent {
      * Navigates back to the given [popUpToDestinationId]. If [inclusive] is `true` the destination
      * itself will also be popped of the back stack. Then navigates to the given [route].
      */
+    @VisibleForTesting(otherwise = PACKAGE_PRIVATE)
     public data class NavigateBackAndThenToEvent(
         internal val route: NavRoute,
         internal val popUpToDestinationId: Int,
@@ -31,6 +37,7 @@ public sealed interface NavEvent {
      * Navigates to the given [root]. The current back stack will be popped and saved.
      * Whether the backstack of the given route is restored depends on [restoreRootState].
      */
+    @VisibleForTesting(otherwise = PACKAGE_PRIVATE)
     public data class NavigateToRootEvent(
         internal val root: NavRoot,
         internal val restoreRootState: Boolean,
@@ -39,17 +46,20 @@ public sealed interface NavEvent {
     /**
      * Navigates up.
      */
+    @VisibleForTesting(otherwise = PACKAGE_PRIVATE)
     public object UpEvent : NavEvent
 
     /**
      * Navigates back.
      */
+    @VisibleForTesting(otherwise = PACKAGE_PRIVATE)
     public object BackEvent : NavEvent
 
     /**
      * Navigates back to the given [destinationId]. If [inclusive] is `true` the destination itself
      * will also be popped of the back stack.
      */
+    @VisibleForTesting(otherwise = PACKAGE_PRIVATE)
     public data class BackToEvent(
         internal val destinationId: Int,
         internal val inclusive: Boolean,
@@ -58,6 +68,7 @@ public sealed interface NavEvent {
     /**
      * Launches the [request] to retrieve an event.
      */
+    @VisibleForTesting(otherwise = PACKAGE_PRIVATE)
     public data class ActivityResultEvent<I>(
         internal val request: ActivityResultRequest<I, *>,
         internal val input: I,
@@ -66,6 +77,7 @@ public sealed interface NavEvent {
     /**
      * Launches the [request] to retrieve an event.
      */
+    @VisibleForTesting(otherwise = PACKAGE_PRIVATE)
     public data class PermissionsResultEvent(
         internal val request: PermissionsResultRequest,
         internal val permissions: List<String>,

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
@@ -90,14 +90,6 @@ public abstract class NavEventNavigator : Navigator {
     }
 
     /**
-     * Sends the given new [NavEvent] to the `NavigationHandler` connected to this navigator.
-     */
-    protected fun sendNavEvent(event: NavEvent) {
-        val result = _navEvents.trySendBlocking(event)
-        check(result.isSuccess)
-    }
-
-    /**
      * Triggers a new [NavEvent] to navigate to the given [route].
      */
     public fun navigateTo(route: NavRoute) {
@@ -202,6 +194,11 @@ public abstract class NavEventNavigator : Navigator {
     public fun requestPermissions(request: PermissionsResultRequest, permissions: List<String>) {
         val event = PermissionsResultEvent(request, permissions)
         sendNavEvent(event)
+    }
+
+    private fun sendNavEvent(event: NavEvent) {
+        val result = _navEvents.trySendBlocking(event)
+        check(result.isSuccess)
     }
 
     /**

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
@@ -3,6 +3,8 @@ package com.freeletics.mad.navigator
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.annotation.IdRes
+import androidx.annotation.VisibleForTesting
+import androidx.annotation.VisibleForTesting.PACKAGE_PRIVATE
 import com.freeletics.mad.navigator.NavEvent.ActivityResultEvent
 import com.freeletics.mad.navigator.NavEvent.BackEvent
 import com.freeletics.mad.navigator.NavEvent.BackToEvent
@@ -32,7 +34,6 @@ import kotlinx.coroutines.flow.receiveAsFlow
  * permission requests can be handled through [registerForActivityResult]/[navigateForResult]
  * and [registerForPermissionsResult]/[requestPermissions] respectively.
  */
-@Suppress("MemberVisibilityCanBePrivate", "unused")
 public abstract class NavEventNavigator : Navigator {
 
     private val _navEvents = Channel<NavEvent>(Channel.UNLIMITED)
@@ -40,6 +41,7 @@ public abstract class NavEventNavigator : Navigator {
     /**
      * A [Flow] to collect [NavEvents][NavEvent] produced by this navigator.
      */
+    @VisibleForTesting(otherwise = PACKAGE_PRIVATE)
     public val navEvents: Flow<NavEvent> = _navEvents.receiveAsFlow()
 
     private val _activityResultRequests = mutableListOf<ActivityResultRequest<*, *>>()

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/ResultOwner.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/ResultOwner.kt
@@ -1,5 +1,7 @@
 package com.freeletics.mad.navigator
 
+import androidx.annotation.VisibleForTesting
+import androidx.annotation.VisibleForTesting.PACKAGE_PRIVATE
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.Flow
@@ -22,6 +24,7 @@ public abstract class ResultOwner<O> {
      * Deliver a new [result] to [results]. This method should be called by a
      * `NavEventNavigationHandler`.
      */
+    @VisibleForTesting(otherwise = PACKAGE_PRIVATE)
     public fun onResult(result: O) {
         val channelResult = _results.trySendBlocking(result)
         check(channelResult.isSuccess)

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/ResultRequest.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/ResultRequest.kt
@@ -18,7 +18,7 @@ import com.freeletics.mad.navigator.internal.InternalNavigatorApi
  *    request
  */
 public class ActivityResultRequest<I, O> internal constructor(
-    public val contract: ActivityResultContract<I, O>
+    @property:InternalNavigatorApi public val contract: ActivityResultContract<I, O>
 ) : ResultOwner<O>() {
 
     @InternalNavigatorApi

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/Navigate.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/Navigate.kt
@@ -64,6 +64,5 @@ public fun navigate(
             @Suppress("UNCHECKED_CAST")
             (launcher as ActivityResultLauncher<Any?>).launch(event.permissions)
         }
-        else -> throw IllegalArgumentException("Unknown NavEvent $event")
     }
 }

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/Navigate.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/Navigate.kt
@@ -6,7 +6,6 @@ import androidx.navigation.NavOptions
 import com.freeletics.mad.navigator.ActivityResultRequest
 import com.freeletics.mad.navigator.NavEvent
 import com.freeletics.mad.navigator.PermissionsResultRequest
-import java.lang.IllegalArgumentException
 
 @InternalNavigatorApi
 public fun navigate(


### PR DESCRIPTION
Following the previous changes `NavEvent` is now a sealed class. With this the handlers don't need to be `open` anymore and don't need `handleEvent` methods and `sendNavEvent` in the navigator is now private. While going through the public API I've also added `VisibleForTesting` to `NavEvent`, the Flows and other APIs that are only public for test purposes. If we decide on doing an extra testing artifact it's easier to find these.