### PR TITLE
add binary compatibility validator to make reviewing the public api easier

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,10 +11,12 @@ buildscript {
         classpath "com.vanniktech:gradle-maven-publish-plugin:0.18.0"
         classpath "com.autonomousapps.dependency-analysis:com.autonomousapps.dependency-analysis.gradle.plugin:0.80.0"
         classpath "com.github.ben-manes:gradle-versions-plugin:0.41.0"
+        classpath "org.jetbrains.kotlinx:binary-compatibility-validator:0.8.0"
     }
 }
 
 apply plugin: "com.autonomousapps.dependency-analysis"
+apply plugin: "org.jetbrains.kotlinx.binary-compatibility-validator"
 apply plugin: "com.github.ben-manes.versions"
 
 
@@ -41,6 +43,16 @@ dependencyAnalysis {
             }
         }
     }
+}
+
+apiValidation {
+    ignoredProjects += ["compiler"]
+
+    nonPublicMarkers += [
+        "androidx.annotation.VisibleForTesting",
+        "com.freeletics.mad.navigator.internal.InternalNavigatorApi",
+        "com.freeletics.mad.whetstone.internal.InternalWhetstoneApi",
+    ]
 }
 
 def isNonStable = { String version ->

--- a/navigator/common-compose/api/common-compose.api
+++ b/navigator/common-compose/api/common-compose.api
@@ -1,0 +1,4 @@
+public abstract interface class com/freeletics/mad/navigator/compose/NavigationHandler {
+	public abstract fun Navigation (Lcom/freeletics/mad/navigator/Navigator;Landroidx/compose/runtime/Composer;I)V
+}
+

--- a/navigator/common-compose/build.gradle
+++ b/navigator/common-compose/build.gradle
@@ -9,14 +9,15 @@ android {
         minSdkVersion 21
     }
 
+    buildFeatures {
+        compose = true
+        buildConfig = false
+    }
+
     // still needed for Android projects despite toolchain
     compileOptions {
         sourceCompatibility(JavaVersion.VERSION_11)
         targetCompatibility(JavaVersion.VERSION_11)
-    }
-
-    buildFeatures {
-        compose = true
     }
 
     // still needed for Android projects despite toolchain

--- a/navigator/common-fragment/api/common-fragment.api
+++ b/navigator/common-fragment/api/common-fragment.api
@@ -1,0 +1,4 @@
+public abstract interface class com/freeletics/mad/navigator/fragment/NavigationHandler {
+	public abstract fun handle (Landroidx/fragment/app/Fragment;Lcom/freeletics/mad/navigator/Navigator;)V
+}
+

--- a/navigator/common-fragment/build.gradle
+++ b/navigator/common-fragment/build.gradle
@@ -9,6 +9,10 @@ android {
         minSdkVersion 21
     }
 
+    buildFeatures {
+        buildConfig = false
+    }
+
     // still needed for Android projects despite toolchain
     compileOptions {
         sourceCompatibility(JavaVersion.VERSION_11)

--- a/navigator/common/api/common.api
+++ b/navigator/common/api/common.api
@@ -1,0 +1,3 @@
+public abstract interface class com/freeletics/mad/navigator/Navigator {
+}
+

--- a/navigator/common/build.gradle
+++ b/navigator/common/build.gradle
@@ -9,6 +9,10 @@ android {
         minSdkVersion 21
     }
 
+    buildFeatures {
+        buildConfig = false
+    }
+
     // still needed for Android projects despite toolchain
     compileOptions {
         sourceCompatibility(JavaVersion.VERSION_11)

--- a/navigator/runtime-compose/api/runtime-compose.api
+++ b/navigator/runtime-compose/api/runtime-compose.api
@@ -1,0 +1,54 @@
+public abstract interface class com/freeletics/mad/navigator/compose/NavDestination {
+	public abstract fun getDestinationId ()I
+	public abstract fun getRoute ()Lkotlin/reflect/KClass;
+}
+
+public final class com/freeletics/mad/navigator/compose/NavDestination$Activity : com/freeletics/mad/navigator/compose/NavDestination {
+	public static final field $stable I
+	public fun <init> (Lkotlin/reflect/KClass;ILandroid/content/Intent;)V
+	public fun getDestinationId ()I
+	public fun getRoute ()Lkotlin/reflect/KClass;
+}
+
+public final class com/freeletics/mad/navigator/compose/NavDestination$BottomSheet : com/freeletics/mad/navigator/compose/NavDestination {
+	public static final field $stable I
+	public fun <init> (Lkotlin/reflect/KClass;ILkotlin/jvm/functions/Function3;)V
+	public fun getDestinationId ()I
+	public fun getRoute ()Lkotlin/reflect/KClass;
+}
+
+public final class com/freeletics/mad/navigator/compose/NavDestination$Dialog : com/freeletics/mad/navigator/compose/NavDestination {
+	public static final field $stable I
+	public fun <init> (Lkotlin/reflect/KClass;ILkotlin/jvm/functions/Function3;)V
+	public fun getDestinationId ()I
+	public fun getRoute ()Lkotlin/reflect/KClass;
+}
+
+public final class com/freeletics/mad/navigator/compose/NavDestination$RootScreen : com/freeletics/mad/navigator/compose/NavDestination {
+	public static final field $stable I
+	public fun <init> (Lkotlin/reflect/KClass;ILkotlin/jvm/functions/Function3;)V
+	public fun getDestinationId ()I
+	public fun getRoute ()Lkotlin/reflect/KClass;
+}
+
+public final class com/freeletics/mad/navigator/compose/NavDestination$Screen : com/freeletics/mad/navigator/compose/NavDestination {
+	public static final field $stable I
+	public fun <init> (Lkotlin/reflect/KClass;ILkotlin/jvm/functions/Function3;)V
+	public fun getDestinationId ()I
+	public fun getRoute ()Lkotlin/reflect/KClass;
+}
+
+public final class com/freeletics/mad/navigator/compose/NavEventNavigationHandler : com/freeletics/mad/navigator/compose/NavigationHandler {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun Navigation (Lcom/freeletics/mad/navigator/NavEventNavigator;Landroidx/compose/runtime/Composer;I)V
+	public synthetic fun Navigation (Lcom/freeletics/mad/navigator/Navigator;Landroidx/compose/runtime/Composer;I)V
+}
+
+public final class com/freeletics/mad/navigator/compose/NavHostKt {
+	public static final fun NavHost (Landroidx/navigation/NavHostController;Lcom/freeletics/mad/navigator/NavRoot;Ljava/util/Set;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public static final fun NavHost (Landroidx/navigation/NavHostController;Lcom/freeletics/mad/navigator/NavRoute;Ljava/util/Set;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public static final fun NavHost (Lcom/freeletics/mad/navigator/NavRoot;Ljava/util/Set;Landroidx/compose/runtime/Composer;I)V
+	public static final fun NavHost (Lcom/freeletics/mad/navigator/NavRoute;Ljava/util/Set;Landroidx/compose/runtime/Composer;I)V
+}
+

--- a/navigator/runtime-compose/build.gradle
+++ b/navigator/runtime-compose/build.gradle
@@ -11,6 +11,7 @@ android {
 
     buildFeatures {
         compose = true
+        buildConfig = false
     }
 
     // still needed for Android projects despite toolchain
@@ -37,6 +38,7 @@ kotlin {
     sourceSets.all {
         languageSettings {
             optIn("kotlin.RequiresOptIn")
+            optIn("com.freeletics.mad.navigator.internal.InternalNavigatorApi")
         }
     }
 }

--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavEventNavigationHandler.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavEventNavigationHandler.kt
@@ -17,14 +17,12 @@ import com.freeletics.mad.navigator.NavEvent
 import com.freeletics.mad.navigator.NavEventNavigator
 import com.freeletics.mad.navigator.PermissionsResultRequest
 import com.freeletics.mad.navigator.internal.navigate
-import com.freeletics.mad.navigator.internal.InternalNavigatorApi
 import com.freeletics.mad.navigator.internal.RequestPermissionsContract
 import kotlinx.coroutines.flow.collect
 
 /**
  * A [NavigationHandler] that handles [NavEvent] emitted by a [NavEventNavigator].
  */
-@OptIn(InternalNavigatorApi::class)
 public class NavEventNavigationHandler : NavigationHandler<NavEventNavigator> {
 
     @Composable

--- a/navigator/runtime-fragment/api/runtime-fragment.api
+++ b/navigator/runtime-fragment/api/runtime-fragment.api
@@ -1,0 +1,52 @@
+public abstract class com/freeletics/mad/navigator/fragment/FragmentNavEventNavigator : com/freeletics/mad/navigator/NavEventNavigator {
+	public fun <init> ()V
+	public final fun getResultEvents ()Lkotlinx/coroutines/flow/Flow;
+	public final fun navigateBackWithResult (Ljava/lang/String;Landroid/os/Parcelable;)V
+	public final fun registerForFragmentResult (Ljava/lang/String;)Lcom/freeletics/mad/navigator/fragment/FragmentResultRequest;
+}
+
+public final class com/freeletics/mad/navigator/fragment/FragmentResultRequest : com/freeletics/mad/navigator/ResultOwner {
+}
+
+public abstract interface class com/freeletics/mad/navigator/fragment/NavDestination {
+	public abstract fun getDestinationId ()I
+	public abstract fun getRoute ()Lkotlin/reflect/KClass;
+}
+
+public final class com/freeletics/mad/navigator/fragment/NavDestination$Activity : com/freeletics/mad/navigator/fragment/NavDestination {
+	public fun <init> (Lkotlin/reflect/KClass;ILandroid/content/Intent;)V
+	public fun getDestinationId ()I
+	public fun getRoute ()Lkotlin/reflect/KClass;
+}
+
+public final class com/freeletics/mad/navigator/fragment/NavDestination$Dialog : com/freeletics/mad/navigator/fragment/NavDestination {
+	public fun <init> (Lkotlin/reflect/KClass;ILkotlin/reflect/KClass;)V
+	public fun getDestinationId ()I
+	public fun getRoute ()Lkotlin/reflect/KClass;
+}
+
+public final class com/freeletics/mad/navigator/fragment/NavDestination$RootScreen : com/freeletics/mad/navigator/fragment/NavDestination {
+	public fun <init> (Lkotlin/reflect/KClass;ILkotlin/reflect/KClass;)V
+	public fun getDestinationId ()I
+	public fun getRoute ()Lkotlin/reflect/KClass;
+}
+
+public final class com/freeletics/mad/navigator/fragment/NavDestination$Screen : com/freeletics/mad/navigator/fragment/NavDestination {
+	public fun <init> (Lkotlin/reflect/KClass;ILkotlin/reflect/KClass;)V
+	public fun getDestinationId ()I
+	public fun getRoute ()Lkotlin/reflect/KClass;
+}
+
+public final class com/freeletics/mad/navigator/fragment/NavEventNavigationHandler : com/freeletics/mad/navigator/fragment/NavigationHandler {
+	public fun <init> ()V
+	public synthetic fun handle (Landroidx/fragment/app/Fragment;Lcom/freeletics/mad/navigator/Navigator;)V
+	public fun handle (Landroidx/fragment/app/Fragment;Lcom/freeletics/mad/navigator/fragment/FragmentNavEventNavigator;)V
+}
+
+public final class com/freeletics/mad/navigator/fragment/NavHostFragmentKt {
+	public static final fun setGraph (Landroidx/navigation/fragment/NavHostFragment;Lcom/freeletics/mad/navigator/NavRoot;Ljava/util/Set;Lkotlin/jvm/functions/Function1;)V
+	public static final fun setGraph (Landroidx/navigation/fragment/NavHostFragment;Lcom/freeletics/mad/navigator/NavRoute;Ljava/util/Set;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun setGraph$default (Landroidx/navigation/fragment/NavHostFragment;Lcom/freeletics/mad/navigator/NavRoot;Ljava/util/Set;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static synthetic fun setGraph$default (Landroidx/navigation/fragment/NavHostFragment;Lcom/freeletics/mad/navigator/NavRoute;Ljava/util/Set;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+}
+

--- a/navigator/runtime-fragment/build.gradle
+++ b/navigator/runtime-fragment/build.gradle
@@ -9,6 +9,10 @@ android {
         minSdkVersion 21
     }
 
+    buildFeatures {
+        buildConfig = false
+    }
+
     // still needed for Android projects despite toolchain
     compileOptions {
         sourceCompatibility(JavaVersion.VERSION_11)
@@ -29,6 +33,7 @@ kotlin {
     sourceSets.all {
         languageSettings {
             optIn("kotlin.RequiresOptIn")
+            optIn("com.freeletics.mad.navigator.internal.InternalNavigatorApi")
         }
     }
 }

--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavEventNavigationHandler.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavEventNavigationHandler.kt
@@ -16,7 +16,6 @@ import com.freeletics.mad.navigator.NavEvent
 import com.freeletics.mad.navigator.NavEventNavigator
 import com.freeletics.mad.navigator.ActivityResultRequest
 import com.freeletics.mad.navigator.PermissionsResultRequest
-import com.freeletics.mad.navigator.internal.InternalNavigatorApi
 import com.freeletics.mad.navigator.internal.RequestPermissionsContract
 import com.freeletics.mad.navigator.internal.navigate
 import kotlinx.coroutines.flow.collect
@@ -25,7 +24,6 @@ import kotlinx.coroutines.launch
 /**
  * A [NavigationHandler] that handles [NavEvent] emitted by a [NavEventNavigator].
  */
-@OptIn(InternalNavigatorApi::class)
 public class NavEventNavigationHandler : NavigationHandler<FragmentNavEventNavigator> {
 
     override fun handle(fragment: Fragment, navigator: FragmentNavEventNavigator) {

--- a/navigator/runtime-fragment/src/test/java/com/freeletics/mad/navigator/fragment/FragmentNavEventNavigatorTest.kt
+++ b/navigator/runtime-fragment/src/test/java/com/freeletics/mad/navigator/fragment/FragmentNavEventNavigatorTest.kt
@@ -29,7 +29,6 @@ public class FragmentNavEventNavigatorTest {
         }
     }
 
-    @OptIn(InternalNavigatorApi::class)
     @Test
     public fun `registerForActivityResult after read is disallowed`(): Unit = runBlocking {
         val navigator = TestNavigator()

--- a/navigator/runtime/api/runtime.api
+++ b/navigator/runtime/api/runtime.api
@@ -1,0 +1,69 @@
+public final class com/freeletics/mad/navigator/ActivityResultRequest : com/freeletics/mad/navigator/ResultOwner {
+	public final fun getContract ()Landroidx/activity/result/contract/ActivityResultContract;
+}
+
+public abstract class com/freeletics/mad/navigator/NavEventNavigator : com/freeletics/mad/navigator/Navigator {
+	public fun <init> ()V
+	public final fun backPresses ()Lkotlinx/coroutines/flow/Flow;
+	public final fun backPresses (Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public final fun getActivityResultRequests ()Ljava/util/List;
+	public final fun getNavEvents ()Lkotlinx/coroutines/flow/Flow;
+	public final fun getOnBackPressedCallback ()Landroidx/activity/OnBackPressedCallback;
+	public final fun getPermissionsResultRequests ()Ljava/util/List;
+	public final fun navigateBack ()V
+	public final fun navigateBack (IZ)V
+	public static synthetic fun navigateBack$default (Lcom/freeletics/mad/navigator/NavEventNavigator;IZILjava/lang/Object;)V
+	public final fun navigateForResult (Lcom/freeletics/mad/navigator/ActivityResultRequest;)V
+	public final fun navigateForResult (Lcom/freeletics/mad/navigator/ActivityResultRequest;Ljava/lang/Object;)V
+	public final fun navigateTo (Lcom/freeletics/mad/navigator/NavRoute;)V
+	public final fun navigateTo (Lcom/freeletics/mad/navigator/NavRoute;IZ)V
+	public static synthetic fun navigateTo$default (Lcom/freeletics/mad/navigator/NavEventNavigator;Lcom/freeletics/mad/navigator/NavRoute;IZILjava/lang/Object;)V
+	public final fun navigateToRoot (Lcom/freeletics/mad/navigator/NavRoot;Z)V
+	public static synthetic fun navigateToRoot$default (Lcom/freeletics/mad/navigator/NavEventNavigator;Lcom/freeletics/mad/navigator/NavRoot;ZILjava/lang/Object;)V
+	public final fun navigateUp ()V
+	public final fun registerForActivityResult (Landroidx/activity/result/contract/ActivityResultContract;)Lcom/freeletics/mad/navigator/ActivityResultRequest;
+	public final fun registerForPermissionsResult ()Lcom/freeletics/mad/navigator/PermissionsResultRequest;
+	public final fun requestPermissions (Lcom/freeletics/mad/navigator/PermissionsResultRequest;Ljava/util/List;)V
+	public final fun requestPermissions (Lcom/freeletics/mad/navigator/PermissionsResultRequest;[Ljava/lang/String;)V
+}
+
+public abstract interface class com/freeletics/mad/navigator/NavRoot {
+	public abstract fun getArguments ()Landroid/os/Bundle;
+	public abstract fun getDestinationId ()I
+}
+
+public final class com/freeletics/mad/navigator/NavRoot$DefaultImpls {
+	public static fun getArguments (Lcom/freeletics/mad/navigator/NavRoot;)Landroid/os/Bundle;
+}
+
+public abstract interface class com/freeletics/mad/navigator/NavRoute {
+	public abstract fun getArguments ()Landroid/os/Bundle;
+	public abstract fun getDestinationId ()I
+}
+
+public final class com/freeletics/mad/navigator/NavRoute$DefaultImpls {
+	public static fun getArguments (Lcom/freeletics/mad/navigator/NavRoute;)Landroid/os/Bundle;
+}
+
+public final class com/freeletics/mad/navigator/PermissionsResultRequest : com/freeletics/mad/navigator/ResultOwner {
+}
+
+public final class com/freeletics/mad/navigator/PermissionsResultRequest$PermissionResult : java/lang/Enum {
+	public static final field DENIED Lcom/freeletics/mad/navigator/PermissionsResultRequest$PermissionResult;
+	public static final field DENIED_PERMANENTLY Lcom/freeletics/mad/navigator/PermissionsResultRequest$PermissionResult;
+	public static final field GRANTED Lcom/freeletics/mad/navigator/PermissionsResultRequest$PermissionResult;
+	public static fun valueOf (Ljava/lang/String;)Lcom/freeletics/mad/navigator/PermissionsResultRequest$PermissionResult;
+	public static fun values ()[Lcom/freeletics/mad/navigator/PermissionsResultRequest$PermissionResult;
+}
+
+public abstract class com/freeletics/mad/navigator/ResultOwner {
+	public fun <init> ()V
+	public final fun getResults ()Lkotlinx/coroutines/flow/Flow;
+}
+
+public abstract interface annotation class com/freeletics/mad/navigator/internal/InternalNavigatorApi : java/lang/annotation/Annotation {
+}
+
+public final class com/freeletics/mad/navigator/internal/NavigateKt {
+}
+

--- a/navigator/runtime/build.gradle
+++ b/navigator/runtime/build.gradle
@@ -9,6 +9,10 @@ android {
         minSdkVersion 21
     }
 
+    buildFeatures {
+        buildConfig = false
+    }
+
     // still needed for Android projects despite toolchain
     compileOptions {
         sourceCompatibility(JavaVersion.VERSION_11)
@@ -29,6 +33,7 @@ kotlin {
     sourceSets.all {
         languageSettings {
             optIn("kotlin.RequiresOptIn")
+            optIn("com.freeletics.mad.navigator.internal.InternalNavigatorApi")
         }
     }
 }

--- a/navigator/runtime/src/test/java/com/freeletics/mad/navigator/NavEventNavigatorTest.kt
+++ b/navigator/runtime/src/test/java/com/freeletics/mad/navigator/NavEventNavigatorTest.kt
@@ -127,7 +127,7 @@ public class NavEventNavigatorTest {
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class, InternalNavigatorApi::class)
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     public fun `backPresses sends out events`(): Unit = runBlocking {
         val navigator = TestNavigator()
@@ -151,7 +151,6 @@ public class NavEventNavigatorTest {
         assertThat(navigator.onBackPressedCallback.isEnabled).isFalse()
     }
 
-    @OptIn(InternalNavigatorApi::class)
     @Test
     public fun `registerForActivityResult after read is disallowed`(): Unit = runBlocking {
         val navigator = TestNavigator()
@@ -166,7 +165,6 @@ public class NavEventNavigatorTest {
             "fragment, e.g. during initialisation of your navigator subclass.")
     }
 
-    @OptIn(InternalNavigatorApi::class)
     @Test
     public fun `registerForPermissionsResult after read is disallowed`(): Unit = runBlocking {
         val navigator = TestNavigator()

--- a/state-machine/api/state-machine.api
+++ b/state-machine/api/state-machine.api
@@ -1,0 +1,5 @@
+public abstract interface class com/freeletics/mad/statemachine/StateMachine {
+	public abstract fun dispatch (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getState ()Lkotlinx/coroutines/flow/Flow;
+}
+

--- a/text-resource/api/text-resource.api
+++ b/text-resource/api/text-resource.api
@@ -1,0 +1,40 @@
+public final class com/freeletics/mad/text/LoadingTextResource : com/freeletics/mad/text/TextResource {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field INSTANCE Lcom/freeletics/mad/text/LoadingTextResource;
+	public fun describeContents ()I
+	public synthetic fun format (Landroid/content/Context;)Ljava/lang/String;
+	public fun format (Landroid/content/Context;)Ljava/lang/Void;
+	public synthetic fun format (Landroidx/compose/runtime/Composer;I)Ljava/lang/String;
+	public fun format (Landroidx/compose/runtime/Composer;I)Ljava/lang/Void;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public abstract class com/freeletics/mad/text/TextResource : android/os/Parcelable {
+	public static final field $stable I
+	public static final field Companion Lcom/freeletics/mad/text/TextResource$Companion;
+	public abstract fun format (Landroid/content/Context;)Ljava/lang/String;
+	public abstract fun format (Landroidx/compose/runtime/Composer;I)Ljava/lang/String;
+	public static final fun join (Ljava/util/List;)Lcom/freeletics/mad/text/TextResource;
+	public static final fun join (Ljava/util/List;Ljava/lang/String;)Lcom/freeletics/mad/text/TextResource;
+}
+
+public final class com/freeletics/mad/text/TextResource$Companion {
+	public final fun createWithQuantity (II[Ljava/lang/Object;)Lcom/freeletics/mad/text/TextResource;
+	public final fun fromNullableString (Ljava/lang/String;)Lcom/freeletics/mad/text/TextResource;
+	public final fun fromString (Ljava/lang/String;)Lcom/freeletics/mad/text/TextResource;
+	public final fun fromStringResource (I[Ljava/lang/Object;)Lcom/freeletics/mad/text/TextResource;
+	public final fun join (Ljava/util/List;)Lcom/freeletics/mad/text/TextResource;
+	public final fun join (Ljava/util/List;Ljava/lang/String;)Lcom/freeletics/mad/text/TextResource;
+	public static synthetic fun join$default (Lcom/freeletics/mad/text/TextResource$Companion;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lcom/freeletics/mad/text/TextResource;
+}
+
+public final class com/freeletics/mad/text/TextResourcesKt {
+	public static final fun joinToTextResource (Ljava/lang/Iterable;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/freeletics/mad/text/TextResource;
+	public static synthetic fun joinToTextResource$default (Ljava/lang/Iterable;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/freeletics/mad/text/TextResource;
+	public static final fun plus (Lcom/freeletics/mad/text/TextResource;Lcom/freeletics/mad/text/TextResource;)Lcom/freeletics/mad/text/TextResource;
+	public static final fun plus (Lcom/freeletics/mad/text/TextResource;Ljava/lang/String;)Lcom/freeletics/mad/text/TextResource;
+	public static final fun setText (Landroid/widget/TextView;Lcom/freeletics/mad/text/TextResource;)V
+	public static final fun toTextResource (Ljava/lang/String;)Lcom/freeletics/mad/text/TextResource;
+}
+

--- a/text-resource/build.gradle
+++ b/text-resource/build.gradle
@@ -13,6 +13,7 @@ android {
 
     buildFeatures {
         compose = true
+        buildConfig = false
     }
 
     // still needed for Android projects despite toolchain

--- a/whetstone/runtime-compose/api/runtime-compose.api
+++ b/whetstone/runtime-compose/api/runtime-compose.api
@@ -1,0 +1,11 @@
+public abstract interface annotation class com/freeletics/mad/whetstone/ComposeScreen : java/lang/annotation/Annotation {
+	public abstract fun coroutinesEnabled ()Z
+	public abstract fun dependencies ()Ljava/lang/Class;
+	public abstract fun navigationHandler ()Ljava/lang/Class;
+	public abstract fun navigator ()Ljava/lang/Class;
+	public abstract fun parentScope ()Ljava/lang/Class;
+	public abstract fun rxJavaEnabled ()Z
+	public abstract fun scope ()Ljava/lang/Class;
+	public abstract fun stateMachine ()Ljava/lang/Class;
+}
+

--- a/whetstone/runtime-compose/build.gradle
+++ b/whetstone/runtime-compose/build.gradle
@@ -11,6 +11,7 @@ android {
 
     buildFeatures {
         compose = true
+        buildConfig = false
     }
 
     // still needed for Android projects despite toolchain

--- a/whetstone/runtime-fragment/api/runtime-fragment.api
+++ b/whetstone/runtime-fragment/api/runtime-fragment.api
@@ -1,0 +1,29 @@
+public abstract interface annotation class com/freeletics/mad/whetstone/ComposeFragment : java/lang/annotation/Annotation {
+	public abstract fun coroutinesEnabled ()Z
+	public abstract fun dependencies ()Ljava/lang/Class;
+	public abstract fun enableInsetHandling ()Z
+	public abstract fun fragmentBaseClass ()Ljava/lang/Class;
+	public abstract fun navigationHandler ()Ljava/lang/Class;
+	public abstract fun navigator ()Ljava/lang/Class;
+	public abstract fun parentScope ()Ljava/lang/Class;
+	public abstract fun rxJavaEnabled ()Z
+	public abstract fun scope ()Ljava/lang/Class;
+	public abstract fun stateMachine ()Ljava/lang/Class;
+}
+
+public abstract interface annotation class com/freeletics/mad/whetstone/RendererFragment : java/lang/annotation/Annotation {
+	public abstract fun coroutinesEnabled ()Z
+	public abstract fun dependencies ()Ljava/lang/Class;
+	public abstract fun fragmentBaseClass ()Ljava/lang/Class;
+	public abstract fun navigationHandler ()Ljava/lang/Class;
+	public abstract fun navigator ()Ljava/lang/Class;
+	public abstract fun parentScope ()Ljava/lang/Class;
+	public abstract fun rendererFactory ()Ljava/lang/Class;
+	public abstract fun rxJavaEnabled ()Z
+	public abstract fun scope ()Ljava/lang/Class;
+	public abstract fun stateMachine ()Ljava/lang/Class;
+}
+
+public final class com/freeletics/mad/whetstone/fragment/internal/FragmentViewModelProviderKt {
+}
+

--- a/whetstone/runtime-fragment/build.gradle
+++ b/whetstone/runtime-fragment/build.gradle
@@ -9,6 +9,10 @@ android {
         minSdkVersion 21
     }
 
+    buildFeatures {
+        buildConfig = false
+    }
+
     // still needed for Android projects despite toolchain
     compileOptions {
         sourceCompatibility(JavaVersion.VERSION_11)
@@ -29,6 +33,7 @@ kotlin {
     sourceSets.all {
         languageSettings {
             optIn("kotlin.RequiresOptIn")
+            optIn("com.freeletics.mad.whetstone.internal.InternalWhetstoneApi")
         }
     }
 }

--- a/whetstone/runtime/api/runtime.api
+++ b/whetstone/runtime/api/runtime.api
@@ -1,0 +1,30 @@
+public abstract interface annotation class com/freeletics/mad/whetstone/NavEntryComponent : java/lang/annotation/Annotation {
+	public abstract fun coroutinesEnabled ()Z
+	public abstract fun parentScope ()Ljava/lang/Class;
+	public abstract fun rxJavaEnabled ()Z
+	public abstract fun scope ()Ljava/lang/Class;
+}
+
+public final class com/freeletics/mad/whetstone/NavEntryComponents {
+	public static final field $stable I
+	public fun <init> (Ljava/util/Map;)V
+	public final fun get (Ljava/lang/String;Landroid/content/Context;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
+public abstract interface annotation class com/freeletics/mad/whetstone/NavEntryId : java/lang/annotation/Annotation {
+	public abstract fun value ()Ljava/lang/Class;
+}
+
+public abstract interface annotation class com/freeletics/mad/whetstone/ScopeTo : java/lang/annotation/Annotation {
+	public abstract fun marker ()Ljava/lang/Class;
+}
+
+public final class com/freeletics/mad/whetstone/internal/CollectAsStateKt {
+}
+
+public abstract interface annotation class com/freeletics/mad/whetstone/internal/InternalWhetstoneApi : java/lang/annotation/Annotation {
+}
+
+public final class com/freeletics/mad/whetstone/internal/ViewModelProviderKt {
+}
+

--- a/whetstone/runtime/build.gradle
+++ b/whetstone/runtime/build.gradle
@@ -11,6 +11,7 @@ android {
 
     buildFeatures {
         compose = true
+        buildConfig = false
     }
 
     // still needed for Android projects despite toolchain
@@ -37,6 +38,7 @@ kotlin {
     sourceSets.all {
         languageSettings {
             optIn("kotlin.RequiresOptIn")
+            optIn("com.freeletics.mad.whetstone.internal.InternalWhetstoneApi")
         }
     }
 }

--- a/whetstone/runtime/src/main/java/com/freeletics/mad/whetstone/NavEntryComponent.kt
+++ b/whetstone/runtime/src/main/java/com/freeletics/mad/whetstone/NavEntryComponent.kt
@@ -68,7 +68,6 @@ public annotation class NavEntryId(val value: KClass<*>)
 /**
  * Class that allows to retrieve generated [NavEntryComponent] instances.
  */
-@OptIn(InternalWhetstoneApi::class)
 public class NavEntryComponents @Inject constructor(
     getters: @JvmSuppressWildcards Map<Class<*>, NavEntryComponentGetter>
 ) {


### PR DESCRIPTION
For example it's easy to search for `androidx/navigation` to find where we still expose it in the public API. 

I've set it to consider our internal annotations and VisibleForTesting as non public. There is a small bug though that the getters from properties marked as internal are still in the dump https://github.com/Kotlin/binary-compatibility-validator/issues/36