### PR TITLE
replace custom destination support with default args API that is marked as obsolete

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,7 @@ apiValidation {
     nonPublicMarkers += [
         "androidx.annotation.VisibleForTesting",
         "com.freeletics.mad.navigator.internal.InternalNavigatorApi",
+        "com.freeletics.mad.navigator.internal.ObsoleteNavigatorApi",
         "com.freeletics.mad.whetstone.internal.InternalWhetstoneApi",
     ]
 }

--- a/navigator/runtime-compose/api/runtime-compose.api
+++ b/navigator/runtime-compose/api/runtime-compose.api
@@ -1,41 +1,29 @@
 public abstract interface class com/freeletics/mad/navigator/compose/NavDestination {
-	public abstract fun getDestinationId ()I
-	public abstract fun getRoute ()Lkotlin/reflect/KClass;
 }
 
 public final class com/freeletics/mad/navigator/compose/NavDestination$Activity : com/freeletics/mad/navigator/compose/NavDestination {
 	public static final field $stable I
 	public fun <init> (Lkotlin/reflect/KClass;ILandroid/content/Intent;)V
-	public fun getDestinationId ()I
-	public fun getRoute ()Lkotlin/reflect/KClass;
 }
 
 public final class com/freeletics/mad/navigator/compose/NavDestination$BottomSheet : com/freeletics/mad/navigator/compose/NavDestination {
 	public static final field $stable I
 	public fun <init> (Lkotlin/reflect/KClass;ILkotlin/jvm/functions/Function3;)V
-	public fun getDestinationId ()I
-	public fun getRoute ()Lkotlin/reflect/KClass;
 }
 
 public final class com/freeletics/mad/navigator/compose/NavDestination$Dialog : com/freeletics/mad/navigator/compose/NavDestination {
 	public static final field $stable I
 	public fun <init> (Lkotlin/reflect/KClass;ILkotlin/jvm/functions/Function3;)V
-	public fun getDestinationId ()I
-	public fun getRoute ()Lkotlin/reflect/KClass;
 }
 
 public final class com/freeletics/mad/navigator/compose/NavDestination$RootScreen : com/freeletics/mad/navigator/compose/NavDestination {
 	public static final field $stable I
 	public fun <init> (Lkotlin/reflect/KClass;ILkotlin/jvm/functions/Function3;)V
-	public fun getDestinationId ()I
-	public fun getRoute ()Lkotlin/reflect/KClass;
 }
 
 public final class com/freeletics/mad/navigator/compose/NavDestination$Screen : com/freeletics/mad/navigator/compose/NavDestination {
 	public static final field $stable I
 	public fun <init> (Lkotlin/reflect/KClass;ILkotlin/jvm/functions/Function3;)V
-	public fun getDestinationId ()I
-	public fun getRoute ()Lkotlin/reflect/KClass;
 }
 
 public final class com/freeletics/mad/navigator/compose/NavEventNavigationHandler : com/freeletics/mad/navigator/compose/NavigationHandler {
@@ -46,8 +34,8 @@ public final class com/freeletics/mad/navigator/compose/NavEventNavigationHandle
 }
 
 public final class com/freeletics/mad/navigator/compose/NavHostKt {
-	public static final fun NavHost (Landroidx/navigation/NavHostController;Lcom/freeletics/mad/navigator/NavRoot;Ljava/util/Set;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
-	public static final fun NavHost (Landroidx/navigation/NavHostController;Lcom/freeletics/mad/navigator/NavRoute;Ljava/util/Set;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public static final fun NavHost (Landroidx/navigation/NavHostController;Lcom/freeletics/mad/navigator/NavRoot;Ljava/util/Set;Landroidx/compose/runtime/Composer;I)V
+	public static final fun NavHost (Landroidx/navigation/NavHostController;Lcom/freeletics/mad/navigator/NavRoute;Ljava/util/Set;Landroidx/compose/runtime/Composer;I)V
 	public static final fun NavHost (Lcom/freeletics/mad/navigator/NavRoot;Ljava/util/Set;Landroidx/compose/runtime/Composer;I)V
 	public static final fun NavHost (Lcom/freeletics/mad/navigator/NavRoute;Ljava/util/Set;Landroidx/compose/runtime/Composer;I)V
 }

--- a/navigator/runtime-compose/build.gradle
+++ b/navigator/runtime-compose/build.gradle
@@ -39,6 +39,7 @@ kotlin {
         languageSettings {
             optIn("kotlin.RequiresOptIn")
             optIn("com.freeletics.mad.navigator.internal.InternalNavigatorApi")
+            optIn("com.freeletics.mad.navigator.internal.ObsoleteNavigatorApi")
         }
     }
 }

--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavDestination.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavDestination.kt
@@ -11,6 +11,7 @@ import com.freeletics.mad.navigator.compose.NavDestination.BottomSheet
 import com.freeletics.mad.navigator.compose.NavDestination.Dialog
 import com.freeletics.mad.navigator.compose.NavDestination.RootScreen
 import com.freeletics.mad.navigator.compose.NavDestination.Screen
+import com.freeletics.mad.navigator.internal.ObsoleteNavigatorApi
 import com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi
 import kotlin.reflect.KClass
 
@@ -72,46 +73,61 @@ public inline fun <reified T : NavRoute> ActivityDestination(
 
 /**
  * A destination that can be navigated to. See [NavHost] for how to configure a `NavGraph` with it.
- *
- * [route] will be used as a unique identifier together with [destinationId]. The destination can
- * be reached by navigating using an instance of [route].
  */
-public interface NavDestination {
-    public val route: KClass<*>
-    @get:IdRes public val destinationId: Int
+public sealed interface NavDestination {
+    /**
+     * Represents a full screen. The [route] will be used as a unique identifier together
+     * with [destinationId]. The given [screenContent] will be shown when the screen is being
+     * navigated to using an instance of [route].
+     */
+    public class Screen @ObsoleteNavigatorApi constructor(
+        internal val route: KClass<out NavRoute>,
+        internal val destinationId: Int,
+        internal val defaultArguments: Bundle?,
+        internal val screenContent: @Composable (Bundle) -> Unit,
+    ) : NavDestination {
+        public constructor(
+            route: KClass<out NavRoute>,
+            destinationId: Int,
+            screenContent: @Composable (Bundle) -> Unit,
+        ) : this(route, destinationId, null, screenContent)
+    }
 
     /**
      * Represents a full screen. The [route] will be used as a unique identifier together
      * with [destinationId]. The given [screenContent] will be shown when the screen is being
      * navigated to using an instance of [route].
      */
-    public class Screen(
-        override val route: KClass<out NavRoute>,
-        override val destinationId: Int,
+    public class RootScreen @ObsoleteNavigatorApi constructor(
+        internal val route: KClass<out NavRoot>,
+        internal val destinationId: Int,
+        internal val defaultArguments: Bundle?,
         internal val screenContent: @Composable (Bundle) -> Unit,
-    ) : NavDestination
-
-    /**
-     * Represents a full screen. The [route] will be used as a unique identifier together
-     * with [destinationId]. The given [screenContent] will be shown when the screen is being
-     * navigated to using an instance of [route].
-     */
-    public class RootScreen(
-        override val route: KClass<out NavRoot>,
-        override val destinationId: Int,
-        internal val screenContent: @Composable (Bundle) -> Unit,
-    ) : NavDestination
+    ) : NavDestination {
+        public constructor(
+            route: KClass<out NavRoot>,
+            destinationId: Int,
+            screenContent: @Composable (Bundle) -> Unit,
+        ) : this(route, destinationId, null, screenContent)
+    }
 
     /**
      * Represents a dialog. The [route] will be used as a unique identifier together
      * with [destinationId]. The given [dialogContent] will be shown inside the dialog window
      * when navigating to it by using an instance of [route].
      */
-    public class Dialog(
-        override val route: KClass<out NavRoute>,
-        override val destinationId: Int,
+    public class Dialog @ObsoleteNavigatorApi constructor(
+        internal val route: KClass<out NavRoute>,
+        internal val destinationId: Int,
+        internal val defaultArguments: Bundle?,
         internal val dialogContent: @Composable (Bundle) -> Unit,
-    ) : NavDestination
+    ) : NavDestination {
+        public constructor(
+            route: KClass<out NavRoute>,
+            destinationId: Int,
+            dialogContent: @Composable (Bundle) -> Unit,
+        ) : this(route, destinationId, null, dialogContent)
+    }
 
     /**
      * Represents a bottom sheet. The [route] will be used as a unique identifier together
@@ -119,11 +135,18 @@ public interface NavDestination {
      * when navigating to it by using an instance of [route].
      */
     @ExperimentalMaterialNavigationApi
-    public class BottomSheet(
-        override val route: KClass<out NavRoute>,
-        override val destinationId: Int,
+    public class BottomSheet @ObsoleteNavigatorApi constructor(
+        internal val route: KClass<out NavRoute>,
+        internal val destinationId: Int,
+        internal val defaultArguments: Bundle?,
         internal val bottomSheetContent: @Composable (Bundle) -> Unit,
-    ) : NavDestination
+    ) : NavDestination {
+        public constructor(
+            route: KClass<out NavRoute>,
+            destinationId: Int,
+            bottomSheetContent: @Composable (Bundle) -> Unit,
+        ) : this(route, destinationId, null, bottomSheetContent)
+    }
 
     /**
      * Represents an `Activity`. The [route] will be used as a unique identifier together
@@ -131,8 +154,8 @@ public interface NavDestination {
      * an instance of [route] for navigation.
      */
     public class Activity(
-        override val route: KClass<out NavRoute>,
-        override val destinationId: Int,
+        internal val route: KClass<out NavRoute>,
+        internal val destinationId: Int,
         internal val intent: Intent,
     ) : NavDestination
 }

--- a/navigator/runtime-fragment/api/runtime-fragment.api
+++ b/navigator/runtime-fragment/api/runtime-fragment.api
@@ -9,32 +9,22 @@ public final class com/freeletics/mad/navigator/fragment/FragmentResultRequest :
 }
 
 public abstract interface class com/freeletics/mad/navigator/fragment/NavDestination {
-	public abstract fun getDestinationId ()I
-	public abstract fun getRoute ()Lkotlin/reflect/KClass;
 }
 
 public final class com/freeletics/mad/navigator/fragment/NavDestination$Activity : com/freeletics/mad/navigator/fragment/NavDestination {
 	public fun <init> (Lkotlin/reflect/KClass;ILandroid/content/Intent;)V
-	public fun getDestinationId ()I
-	public fun getRoute ()Lkotlin/reflect/KClass;
 }
 
 public final class com/freeletics/mad/navigator/fragment/NavDestination$Dialog : com/freeletics/mad/navigator/fragment/NavDestination {
 	public fun <init> (Lkotlin/reflect/KClass;ILkotlin/reflect/KClass;)V
-	public fun getDestinationId ()I
-	public fun getRoute ()Lkotlin/reflect/KClass;
 }
 
 public final class com/freeletics/mad/navigator/fragment/NavDestination$RootScreen : com/freeletics/mad/navigator/fragment/NavDestination {
 	public fun <init> (Lkotlin/reflect/KClass;ILkotlin/reflect/KClass;)V
-	public fun getDestinationId ()I
-	public fun getRoute ()Lkotlin/reflect/KClass;
 }
 
 public final class com/freeletics/mad/navigator/fragment/NavDestination$Screen : com/freeletics/mad/navigator/fragment/NavDestination {
 	public fun <init> (Lkotlin/reflect/KClass;ILkotlin/reflect/KClass;)V
-	public fun getDestinationId ()I
-	public fun getRoute ()Lkotlin/reflect/KClass;
 }
 
 public final class com/freeletics/mad/navigator/fragment/NavEventNavigationHandler : com/freeletics/mad/navigator/fragment/NavigationHandler {
@@ -44,9 +34,7 @@ public final class com/freeletics/mad/navigator/fragment/NavEventNavigationHandl
 }
 
 public final class com/freeletics/mad/navigator/fragment/NavHostFragmentKt {
-	public static final fun setGraph (Landroidx/navigation/fragment/NavHostFragment;Lcom/freeletics/mad/navigator/NavRoot;Ljava/util/Set;Lkotlin/jvm/functions/Function1;)V
-	public static final fun setGraph (Landroidx/navigation/fragment/NavHostFragment;Lcom/freeletics/mad/navigator/NavRoute;Ljava/util/Set;Lkotlin/jvm/functions/Function1;)V
-	public static synthetic fun setGraph$default (Landroidx/navigation/fragment/NavHostFragment;Lcom/freeletics/mad/navigator/NavRoot;Ljava/util/Set;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
-	public static synthetic fun setGraph$default (Landroidx/navigation/fragment/NavHostFragment;Lcom/freeletics/mad/navigator/NavRoute;Ljava/util/Set;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun setGraph (Landroidx/navigation/fragment/NavHostFragment;Lcom/freeletics/mad/navigator/NavRoot;Ljava/util/Set;)V
+	public static final fun setGraph (Landroidx/navigation/fragment/NavHostFragment;Lcom/freeletics/mad/navigator/NavRoute;Ljava/util/Set;)V
 }
 

--- a/navigator/runtime-fragment/build.gradle
+++ b/navigator/runtime-fragment/build.gradle
@@ -34,6 +34,7 @@ kotlin {
         languageSettings {
             optIn("kotlin.RequiresOptIn")
             optIn("com.freeletics.mad.navigator.internal.InternalNavigatorApi")
+            optIn("com.freeletics.mad.navigator.internal.ObsoleteNavigatorApi")
         }
     }
 }

--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavDestination.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavDestination.kt
@@ -1,7 +1,7 @@
 package com.freeletics.mad.navigator.fragment
 
 import android.content.Intent
-import androidx.annotation.IdRes
+import android.os.Bundle
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import com.freeletics.mad.navigator.NavRoot
@@ -10,6 +10,7 @@ import com.freeletics.mad.navigator.fragment.NavDestination.Activity
 import com.freeletics.mad.navigator.fragment.NavDestination.Dialog
 import com.freeletics.mad.navigator.fragment.NavDestination.RootScreen
 import com.freeletics.mad.navigator.fragment.NavDestination.Screen
+import com.freeletics.mad.navigator.internal.ObsoleteNavigatorApi
 import kotlin.reflect.KClass
 
 /**
@@ -59,42 +60,60 @@ public inline fun <reified T : NavRoute> ActivityDestination(
  * [route] will be used as a unique identifier together with [destinationId]. The destination can
  * be reached by navigating using an instance of [route].
  */
-public interface NavDestination {
-    public val route: KClass<*>
-    @get:IdRes public val destinationId: Int
+public sealed interface NavDestination {
+    /**
+     * Represents a full screen. The [route] will be used as a unique identifier together
+     * with [destinationId]. The given [fragmentClass] will be shown when the screen is being
+     * navigated to using an instance of [route].
+     */
+    public class Screen @ObsoleteNavigatorApi constructor(
+        internal val route: KClass<out NavRoute>,
+        internal val destinationId: Int,
+        internal val fragmentClass: KClass<out Fragment>,
+        internal val defaultArguments: Bundle?,
+    ) : NavDestination {
+        public constructor(
+            route: KClass<out NavRoute>,
+            destinationId: Int,
+            fragmentClass: KClass<out Fragment>,
+        ) : this(route, destinationId, fragmentClass, null)
+    }
 
     /**
      * Represents a full screen. The [route] will be used as a unique identifier together
      * with [destinationId]. The given [fragmentClass] will be shown when the screen is being
      * navigated to using an instance of [route].
      */
-    public class Screen(
-        override val route: KClass<out NavRoute>,
-        override val destinationId: Int,
+    public class RootScreen @ObsoleteNavigatorApi constructor(
+        internal val route: KClass<out NavRoot>,
+        internal val destinationId: Int,
         internal val fragmentClass: KClass<out Fragment>,
-    ) : NavDestination
-
-    /**
-     * Represents a full screen. The [route] will be used as a unique identifier together
-     * with [destinationId]. The given [fragmentClass] will be shown when the screen is being
-     * navigated to using an instance of [route].
-     */
-    public class RootScreen(
-        override val route: KClass<out NavRoot>,
-        override val destinationId: Int,
-        internal val fragmentClass: KClass<out Fragment>,
-    ) : NavDestination
+        internal val defaultArguments: Bundle?,
+    ) : NavDestination {
+        public constructor(
+            route: KClass<out NavRoot>,
+            destinationId: Int,
+            fragmentClass: KClass<out Fragment>,
+        ) : this(route, destinationId, fragmentClass, null)
+    }
 
     /**
      * Represents a dialog. The [route] will be used as a unique identifier together
      * with [destinationId]. The given [fragmentClass] will be shown when it's being navigated to
      * using an instance of [route].
      */
-    public class Dialog(
-        override val route: KClass<out NavRoute>,
-        override val destinationId: Int,
+    public class Dialog @ObsoleteNavigatorApi constructor(
+        internal val route: KClass<out NavRoute>,
+        internal val destinationId: Int,
         internal val fragmentClass: KClass<out DialogFragment>,
-    ) : NavDestination
+        internal val defaultArguments: Bundle?,
+    ) : NavDestination {
+        public constructor(
+            route: KClass<out NavRoute>,
+            destinationId: Int,
+            fragmentClass: KClass<out DialogFragment>,
+        ) : this(route, destinationId, fragmentClass, null)
+    }
 
     /**
      * Represents an `Activity`. The [route] will be used as a unique identifier together
@@ -102,8 +121,8 @@ public interface NavDestination {
      * an instance of [route] for navigation.
      */
     public class Activity(
-        override val route: KClass<out NavRoute>,
-        override val destinationId: Int,
+        internal val route: KClass<out NavRoute>,
+        internal val destinationId: Int,
         internal val intent: Intent,
     ) : NavDestination
 }

--- a/navigator/runtime/api/runtime.api
+++ b/navigator/runtime/api/runtime.api
@@ -67,3 +67,6 @@ public abstract interface annotation class com/freeletics/mad/navigator/internal
 public final class com/freeletics/mad/navigator/internal/NavigateKt {
 }
 
+public abstract interface annotation class com/freeletics/mad/navigator/internal/ObsoleteNavigatorApi : java/lang/annotation/Annotation {
+}
+

--- a/navigator/runtime/build.gradle
+++ b/navigator/runtime/build.gradle
@@ -34,6 +34,7 @@ kotlin {
         languageSettings {
             optIn("kotlin.RequiresOptIn")
             optIn("com.freeletics.mad.navigator.internal.InternalNavigatorApi")
+            optIn("com.freeletics.mad.navigator.internal.ObsoleteNavigatorApi")
         }
     }
 }

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/ObsoleteNavigatorApi.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/ObsoleteNavigatorApi.kt
@@ -1,0 +1,8 @@
+package com.freeletics.mad.navigator.internal
+
+/**
+ * Code marked with [ObsoleteNavigatorApi] has no guarantees about API stability and will be removed
+ * in a future release.
+ */
+@RequiresOptIn
+public annotation class ObsoleteNavigatorApi


### PR DESCRIPTION
We had the `destinationCreator` lambda that allowed turning a custom `NavDestination` into an AndroidX `NavDestination`. The API existed so that we can support our internal custom destination which receives some extra options. Instead of that the destinations now have a `Bundle` parameter to directly pass in these options (we can still have a higher level API that internally builds the bundle in our codebase). That allows us to lock down `NavDestination` by making it a sealed interface and changing the parameters to internal. Together the following pull request it also completely removes AndroidX navigation from the public API for compose. For Fragments the only remaining part is `NavHostFragment` which we can't replace, but it's also less important to hide AndroidX navigation completely in there (I don't think we would even consider swapping the implementation for fragments). 

The constructors of `NavDestination` that receive a `Bundle` are marked with a new `ObsoleteNavigatorApi` annotation to signify that these only exist for now to enable the Freeletics codebase to work, but will be removed at some point.