### PR TITLE
add an API to obtain the NavController outside of compose (marked as obsolete)

### DIFF
--- a/navigator/runtime-compose/api/runtime-compose.api
+++ b/navigator/runtime-compose/api/runtime-compose.api
@@ -34,8 +34,6 @@ public final class com/freeletics/mad/navigator/compose/NavEventNavigationHandle
 }
 
 public final class com/freeletics/mad/navigator/compose/NavHostKt {
-	public static final fun NavHost (Landroidx/navigation/NavHostController;Lcom/freeletics/mad/navigator/NavRoot;Ljava/util/Set;Landroidx/compose/runtime/Composer;I)V
-	public static final fun NavHost (Landroidx/navigation/NavHostController;Lcom/freeletics/mad/navigator/NavRoute;Ljava/util/Set;Landroidx/compose/runtime/Composer;I)V
 	public static final fun NavHost (Lcom/freeletics/mad/navigator/NavRoot;Ljava/util/Set;Landroidx/compose/runtime/Composer;I)V
 	public static final fun NavHost (Lcom/freeletics/mad/navigator/NavRoute;Ljava/util/Set;Landroidx/compose/runtime/Composer;I)V
 }


### PR DESCRIPTION
With how the nav entry lookup in whetstone currently works we need access to the `NavController` outside of compose. This adds an API that lets you do that for now until we change how whetstone works. It's still a bit hacky but generally this is the same thing that AndroidX navigation does for fragment navigation to enable looking up nav controllers from views and activities. 

AndroidX Navigation is now completely gone from the public api for compose users.