### PR TITLE
extract methods out of NavEventNavigationHandler classes

### DIFF
--- a/navigator/runtime-compose/api/runtime-compose.api
+++ b/navigator/runtime-compose/api/runtime-compose.api
@@ -33,6 +33,10 @@ public final class com/freeletics/mad/navigator/compose/NavEventNavigationHandle
 	public synthetic fun Navigation (Lcom/freeletics/mad/navigator/Navigator;Landroidx/compose/runtime/Composer;I)V
 }
 
+public final class com/freeletics/mad/navigator/compose/NavEventNavigationHandlerKt {
+	public static final fun NavigationSetup (Lcom/freeletics/mad/navigator/NavEventNavigator;Landroidx/compose/runtime/Composer;I)V
+}
+
 public final class com/freeletics/mad/navigator/compose/NavHostKt {
 	public static final fun NavHost (Lcom/freeletics/mad/navigator/NavRoot;Ljava/util/Set;Landroidx/compose/runtime/Composer;I)V
 	public static final fun NavHost (Lcom/freeletics/mad/navigator/NavRoute;Ljava/util/Set;Landroidx/compose/runtime/Composer;I)V

--- a/navigator/runtime-fragment/api/runtime-fragment.api
+++ b/navigator/runtime-fragment/api/runtime-fragment.api
@@ -33,6 +33,10 @@ public final class com/freeletics/mad/navigator/fragment/NavEventNavigationHandl
 	public fun handle (Landroidx/fragment/app/Fragment;Lcom/freeletics/mad/navigator/fragment/FragmentNavEventNavigator;)V
 }
 
+public final class com/freeletics/mad/navigator/fragment/NavEventNavigationHandlerKt {
+	public static final fun handleNavigation (Landroidx/fragment/app/Fragment;Lcom/freeletics/mad/navigator/fragment/FragmentNavEventNavigator;)V
+}
+
 public final class com/freeletics/mad/navigator/fragment/NavHostFragmentKt {
 	public static final fun setGraph (Landroidx/navigation/fragment/NavHostFragment;Lcom/freeletics/mad/navigator/NavRoot;Ljava/util/Set;)V
 	public static final fun setGraph (Landroidx/navigation/fragment/NavHostFragment;Lcom/freeletics/mad/navigator/NavRoute;Ljava/util/Set;)V


### PR DESCRIPTION
The logic of the handlers is now available as standalone methods. This allows to integrate the navigation library more nicely without using whetstone (for compose you just throw a `NavigationSetup(navigator)` into your composable instead of instantiating the class and then calling the method on it. At the same time I'm also planning to get rid of the handler classes themselves. They exists so that you can hook other navigation systems into it, but I think we can be more opinionated. The integration stays optional (whetstone and navigator can both be uses without each other) but if you want integrated navigation you'll have to use them together. It's still possible to build custom navigation solutions without having them in the generated code.