### PR TITLE
replace getArguments() by making NavRoute Parcelable and convert it internally

### DIFF
--- a/navigator/runtime/api/runtime.api
+++ b/navigator/runtime/api/runtime.api
@@ -27,22 +27,12 @@ public abstract class com/freeletics/mad/navigator/NavEventNavigator : com/freel
 	public final fun requestPermissions (Lcom/freeletics/mad/navigator/PermissionsResultRequest;[Ljava/lang/String;)V
 }
 
-public abstract interface class com/freeletics/mad/navigator/NavRoot {
-	public abstract fun getArguments ()Landroid/os/Bundle;
+public abstract interface class com/freeletics/mad/navigator/NavRoot : android/os/Parcelable {
 	public abstract fun getDestinationId ()I
 }
 
-public final class com/freeletics/mad/navigator/NavRoot$DefaultImpls {
-	public static fun getArguments (Lcom/freeletics/mad/navigator/NavRoot;)Landroid/os/Bundle;
-}
-
-public abstract interface class com/freeletics/mad/navigator/NavRoute {
-	public abstract fun getArguments ()Landroid/os/Bundle;
+public abstract interface class com/freeletics/mad/navigator/NavRoute : android/os/Parcelable {
 	public abstract fun getDestinationId ()I
-}
-
-public final class com/freeletics/mad/navigator/NavRoute$DefaultImpls {
-	public static fun getArguments (Lcom/freeletics/mad/navigator/NavRoute;)Landroid/os/Bundle;
 }
 
 public final class com/freeletics/mad/navigator/PermissionsResultRequest : com/freeletics/mad/navigator/ResultOwner {

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavRoot.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavRoot.kt
@@ -1,22 +1,15 @@
 package com.freeletics.mad.navigator
 
-import android.os.Bundle
+import android.os.Parcelable
 
 /**
  * This is similar to a [NavRoute] but represents the route to the start destination used in
  * a backstack. When you navigate to a [NavRoot] the current backstack is saved and removed
  * so that the [NavRoot] is right on top of the start destination.
- *
- * [getArguments] can optionally be overridden to provide extra information to the destination.
  */
-public interface NavRoot {
+public interface NavRoot : Parcelable {
     /**
      * The destination this route leads to.
      */
     public val destinationId: Int
-
-    /**
-     * Arguments provided to the destination. For example an id.
-     */
-    public fun getArguments(): Bundle = Bundle.EMPTY
 }

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavRoute.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavRoute.kt
@@ -1,19 +1,13 @@
 package com.freeletics.mad.navigator
 
-import android.os.Bundle
+import android.os.Parcelable
 
 /**
- * Represents the route to a destination represented by [destinationId]. [getArguments] can
- * optionally be overridden to provide extra information to the destination.
+ * Represents the route to a destination.
  */
-public interface NavRoute {
+public interface NavRoute : Parcelable {
     /**
      * The destination this route leads to.
      */
     public val destinationId: Int
-
-    /**
-     * Arguments provided to the destination. For example an id.
-     */
-    public fun getArguments(): Bundle = Bundle.EMPTY
 }

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/Navigate.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/Navigate.kt
@@ -1,10 +1,13 @@
 package com.freeletics.mad.navigator.internal
 
+import android.os.Bundle
 import androidx.activity.result.ActivityResultLauncher
 import androidx.navigation.NavController
 import androidx.navigation.NavOptions
 import com.freeletics.mad.navigator.ActivityResultRequest
 import com.freeletics.mad.navigator.NavEvent
+import com.freeletics.mad.navigator.NavRoot
+import com.freeletics.mad.navigator.NavRoute
 import com.freeletics.mad.navigator.PermissionsResultRequest
 
 @InternalNavigatorApi
@@ -65,3 +68,19 @@ public fun navigate(
         }
     }
 }
+
+@ObsoleteNavigatorApi
+public fun <T : NavRoute> Bundle.toNavRoute(): T = getParcelable(EXTRA_ROUTE)!!
+
+@ObsoleteNavigatorApi
+public fun <T : NavRoot> Bundle.toNavRoot(): T = getParcelable(EXTRA_ROUTE)!!
+
+private fun NavRoute.getArguments(): Bundle = Bundle().also {
+    it.putParcelable(EXTRA_ROUTE, this)
+}
+
+private fun NavRoot.getArguments(): Bundle = Bundle().also {
+    it.putParcelable(EXTRA_ROUTE, this)
+}
+
+private const val EXTRA_ROUTE = "com.freeletics.mad.navigation.ROUTE"

--- a/navigator/runtime/src/test/java/com/freeletics/mad/navigator/NavEventNavigatorTest.kt
+++ b/navigator/runtime/src/test/java/com/freeletics/mad/navigator/NavEventNavigatorTest.kt
@@ -1,5 +1,6 @@
 package com.freeletics.mad.navigator
 
+import android.os.Parcel
 import androidx.activity.result.contract.ActivityResultContracts
 import app.cash.turbine.test
 import com.freeletics.mad.navigator.NavEvent.NavigateToEvent
@@ -13,8 +14,14 @@ import org.junit.Test
 public class NavEventNavigatorTest {
 
     private class TestNavigator : NavEventNavigator()
-    private data class SimpleRoute(override val destinationId: Int) : NavRoute
-    private data class SimpleNavRoot(override val destinationId: Int) : NavRoot
+    private data class SimpleRoute(override val destinationId: Int) : NavRoute {
+        override fun describeContents(): Int = 0
+        override fun writeToParcel(dest: Parcel?, flags: Int) {}
+    }
+    private data class SimpleNavRoot(override val destinationId: Int) : NavRoot {
+        override fun describeContents(): Int = 0
+        override fun writeToParcel(dest: Parcel?, flags: Int) {}
+    }
 
     @Test
     public fun `navigateTo event is received`(): Unit = runBlocking {


### PR DESCRIPTION
We now turn the routes into arguments internally. For now the methods to turn them back are exposed as obsolete. It's one of the next steps to turn them internal instead. For that whetstone needs to become aware of the route class though. Then we can convert the bundle back internally. For compose this would happen in the destination lambda, so your composable gets a route instance instead of the bundle. For fragments we can add a higher level `Fragment.requireRoute<T>()` method that hides the bundle.