### PR TITLE
remove Parcelable from NavRoute/NavRoot interfaces

### DIFF
--- a/navigator/runtime/api/runtime.api
+++ b/navigator/runtime/api/runtime.api
@@ -27,11 +27,11 @@ public abstract class com/freeletics/mad/navigator/NavEventNavigator : com/freel
 	public final fun requestPermissions (Lcom/freeletics/mad/navigator/PermissionsResultRequest;[Ljava/lang/String;)V
 }
 
-public abstract interface class com/freeletics/mad/navigator/NavRoot : android/os/Parcelable {
+public abstract interface class com/freeletics/mad/navigator/NavRoot {
 	public abstract fun getDestinationId ()I
 }
 
-public abstract interface class com/freeletics/mad/navigator/NavRoute : android/os/Parcelable {
+public abstract interface class com/freeletics/mad/navigator/NavRoute {
 	public abstract fun getDestinationId ()I
 }
 

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavRoot.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavRoot.kt
@@ -6,8 +6,11 @@ import android.os.Parcelable
  * This is similar to a [NavRoute] but represents the route to the start destination used in
  * a backstack. When you navigate to a [NavRoot] the current backstack is saved and removed
  * so that the [NavRoot] is right on top of the start destination.
+ *
+ * When the implementing class is [Parcelable], the instance of route will be put into the
+ * navigation arguments and is then available to the target screens.
  */
-public interface NavRoot : Parcelable {
+public interface NavRoot {
     /**
      * The destination this route leads to.
      */

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavRoute.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavRoute.kt
@@ -4,8 +4,11 @@ import android.os.Parcelable
 
 /**
  * Represents the route to a destination.
+ *
+ * When the implementing class is [Parcelable], the instance of route will be put into the
+ * navigation arguments and is then available to the target screens.
  */
-public interface NavRoute : Parcelable {
+public interface NavRoute {
     /**
      * The destination this route leads to.
      */

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/Navigate.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/Navigate.kt
@@ -1,6 +1,7 @@
 package com.freeletics.mad.navigator.internal
 
 import android.os.Bundle
+import android.os.Parcelable
 import androidx.activity.result.ActivityResultLauncher
 import androidx.navigation.NavController
 import androidx.navigation.NavOptions
@@ -76,11 +77,15 @@ public fun <T : NavRoute> Bundle.toNavRoute(): T = getParcelable(EXTRA_ROUTE)!!
 public fun <T : NavRoot> Bundle.toNavRoot(): T = getParcelable(EXTRA_ROUTE)!!
 
 private fun NavRoute.getArguments(): Bundle = Bundle().also {
-    it.putParcelable(EXTRA_ROUTE, this)
+    if (this is Parcelable) {
+        it.putParcelable(EXTRA_ROUTE, this)
+    }
 }
 
 private fun NavRoot.getArguments(): Bundle = Bundle().also {
-    it.putParcelable(EXTRA_ROUTE, this)
+    if (this is Parcelable) {
+        it.putParcelable(EXTRA_ROUTE, this)
+    }
 }
 
 private const val EXTRA_ROUTE = "com.freeletics.mad.navigation.ROUTE"

--- a/navigator/runtime/src/test/java/com/freeletics/mad/navigator/NavEventNavigatorTest.kt
+++ b/navigator/runtime/src/test/java/com/freeletics/mad/navigator/NavEventNavigatorTest.kt
@@ -13,15 +13,8 @@ import org.junit.Test
 public class NavEventNavigatorTest {
 
     private class TestNavigator : NavEventNavigator()
-    private data class SimpleRoute(override val destinationId: Int) :
-        NavRoute {
-        override fun describeContents(): Int = 0
-        override fun writeToParcel(dest: Parcel?, flags: Int) {}
-    }
-    private data class SimpleNavRoot(override val destinationId: Int) : NavRoot {
-        override fun describeContents(): Int = 0
-        override fun writeToParcel(dest: Parcel?, flags: Int) {}
-    }
+    private data class SimpleRoute(override val destinationId: Int) : NavRoute
+    private data class SimpleNavRoot(override val destinationId: Int) : NavRoot
 
     @Test
     public fun `navigateTo event is received`(): Unit = runBlocking {

--- a/navigator/runtime/src/test/java/com/freeletics/mad/navigator/NavEventNavigatorTest.kt
+++ b/navigator/runtime/src/test/java/com/freeletics/mad/navigator/NavEventNavigatorTest.kt
@@ -4,7 +4,6 @@ import android.os.Parcel
 import androidx.activity.result.contract.ActivityResultContracts
 import app.cash.turbine.test
 import com.freeletics.mad.navigator.NavEvent.NavigateToEvent
-import com.freeletics.mad.navigator.internal.InternalNavigatorApi
 import kotlinx.coroutines.runBlocking
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -14,7 +13,8 @@ import org.junit.Test
 public class NavEventNavigatorTest {
 
     private class TestNavigator : NavEventNavigator()
-    private data class SimpleRoute(override val destinationId: Int) : NavRoute {
+    private data class SimpleRoute(override val destinationId: Int) :
+        NavRoute {
         override fun describeContents(): Int = 0
         override fun writeToParcel(dest: Parcel?, flags: Int) {}
     }


### PR DESCRIPTION
When navigating to a screen in another app the other app will crash if we put our parcelable into the arguments. Previously we were explicitly overriding `getArguments` but that isn't exposed anymore. So I made the interfaces not parcelable and if a route isn't parcelable we will have an empty `Bundle`.  `NavRoot` doesn't really need this change because it should be something internal, but I wanted to keep it in sync.

I was thinking whether there should be a `ParcelableNavRoute`  but that isn't really shorter than writing `NavRoute, Parcelable`.