### PR TITLE
add DestinationType to @NavDestination

### DIFF
--- a/whetstone/runtime-compose/api/runtime-compose.api
+++ b/whetstone/runtime-compose/api/runtime-compose.api
@@ -7,8 +7,18 @@ public abstract interface annotation class com/freeletics/mad/whetstone/compose/
 	public abstract fun stateMachine ()Ljava/lang/Class;
 }
 
+public final class com/freeletics/mad/whetstone/compose/DestinationType : java/lang/Enum {
+	public static final field BOTTOM_SHEET Lcom/freeletics/mad/whetstone/compose/DestinationType;
+	public static final field DIALOG Lcom/freeletics/mad/whetstone/compose/DestinationType;
+	public static final field NONE Lcom/freeletics/mad/whetstone/compose/DestinationType;
+	public static final field SCREEN Lcom/freeletics/mad/whetstone/compose/DestinationType;
+	public static fun valueOf (Ljava/lang/String;)Lcom/freeletics/mad/whetstone/compose/DestinationType;
+	public static fun values ()[Lcom/freeletics/mad/whetstone/compose/DestinationType;
+}
+
 public abstract interface annotation class com/freeletics/mad/whetstone/compose/NavDestination : java/lang/annotation/Annotation {
 	public abstract fun route ()Ljava/lang/Class;
+	public abstract fun type ()Lcom/freeletics/mad/whetstone/compose/DestinationType;
 }
 
 public abstract interface annotation class com/freeletics/mad/whetstone/compose/RootNavDestination : java/lang/annotation/Annotation {

--- a/whetstone/runtime-compose/build.gradle
+++ b/whetstone/runtime-compose/build.gradle
@@ -38,6 +38,8 @@ kotlin {
     sourceSets.all {
         languageSettings {
             optIn("kotlin.RequiresOptIn")
+            optIn("com.freeletics.mad.whetstone.internal.InternalWhetstoneApi")
+            optIn("com.freeletics.mad.whetstone.internal.ObsoleteWhetstoneApi")
         }
     }
 }
@@ -50,6 +52,7 @@ tasks.withType(JavaCompile).configureEach {
 }
 
 dependencies {
+    api project(":whetstone:runtime")
     api "androidx.compose.runtime:runtime:1.1.0-rc03"
 
     implementation project(":state-machine")

--- a/whetstone/runtime-compose/src/main/java/com/freeletics/mad/whetstone/compose/NavDestination.kt
+++ b/whetstone/runtime-compose/src/main/java/com/freeletics/mad/whetstone/compose/NavDestination.kt
@@ -2,6 +2,7 @@ package com.freeletics.mad.whetstone.compose
 
 import com.freeletics.mad.navigator.NavRoot
 import com.freeletics.mad.navigator.NavRoute
+import com.freeletics.mad.whetstone.internal.ObsoleteWhetstoneApi
 import kotlin.reflect.KClass
 
 /**
@@ -16,8 +17,21 @@ import kotlin.reflect.KClass
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
 public annotation class NavDestination(
-    val route: KClass<out NavRoute>
+    val route: KClass<out NavRoute>,
+    val type: DestinationType = DestinationType.NONE,
+    val destinationScope: KClass<*>,
 )
+
+/**
+ * Describing the type of [NavDestination].
+ */
+public enum class DestinationType {
+    @ObsoleteWhetstoneApi
+    NONE,
+    SCREEN,
+    DIALOG,
+    BOTTOM_SHEET,
+}
 
 /**
  * Like [NavDestination] but for a screen represented by a [NavRoot].
@@ -25,5 +39,6 @@ public annotation class NavDestination(
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
 public annotation class RootNavDestination(
-    val route: KClass<out NavRoot>
+    val route: KClass<out NavRoot>,
+    val destinationScope: KClass<*>,
 )

--- a/whetstone/runtime-fragment/api/runtime-fragment.api
+++ b/whetstone/runtime-fragment/api/runtime-fragment.api
@@ -9,8 +9,17 @@ public abstract interface annotation class com/freeletics/mad/whetstone/fragment
 	public abstract fun stateMachine ()Ljava/lang/Class;
 }
 
+public final class com/freeletics/mad/whetstone/fragment/DestinationType : java/lang/Enum {
+	public static final field DIALOG Lcom/freeletics/mad/whetstone/fragment/DestinationType;
+	public static final field NONE Lcom/freeletics/mad/whetstone/fragment/DestinationType;
+	public static final field SCREEN Lcom/freeletics/mad/whetstone/fragment/DestinationType;
+	public static fun valueOf (Ljava/lang/String;)Lcom/freeletics/mad/whetstone/fragment/DestinationType;
+	public static fun values ()[Lcom/freeletics/mad/whetstone/fragment/DestinationType;
+}
+
 public abstract interface annotation class com/freeletics/mad/whetstone/fragment/NavDestination : java/lang/annotation/Annotation {
 	public abstract fun route ()Ljava/lang/Class;
+	public abstract fun type ()Lcom/freeletics/mad/whetstone/fragment/DestinationType;
 }
 
 public abstract interface annotation class com/freeletics/mad/whetstone/fragment/RendererFragment : java/lang/annotation/Annotation {

--- a/whetstone/runtime-fragment/build.gradle
+++ b/whetstone/runtime-fragment/build.gradle
@@ -34,6 +34,7 @@ kotlin {
         languageSettings {
             optIn("kotlin.RequiresOptIn")
             optIn("com.freeletics.mad.whetstone.internal.InternalWhetstoneApi")
+            optIn("com.freeletics.mad.whetstone.internal.ObsoleteWhetstoneApi")
         }
     }
 }

--- a/whetstone/runtime-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/NavDestination.kt
+++ b/whetstone/runtime-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/NavDestination.kt
@@ -2,6 +2,7 @@ package com.freeletics.mad.whetstone.fragment
 
 import com.freeletics.mad.navigator.NavRoot
 import com.freeletics.mad.navigator.NavRoute
+import com.freeletics.mad.whetstone.internal.ObsoleteWhetstoneApi
 import kotlin.reflect.KClass
 
 /**
@@ -17,8 +18,20 @@ import kotlin.reflect.KClass
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
 public annotation class NavDestination(
-    val route: KClass<out NavRoute>
+    val route: KClass<out NavRoute>,
+    val type: DestinationType = DestinationType.NONE,
+    val destinationScope: KClass<*>,
 )
+
+/**
+ * Describing the type of [NavDestination].
+ */
+public enum class DestinationType {
+    @ObsoleteWhetstoneApi
+    NONE,
+    SCREEN,
+    DIALOG,
+}
 
 /**
  * Like [NavDestination] but for a screen represented by a [NavRoot].
@@ -26,5 +39,6 @@ public annotation class NavDestination(
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
 public annotation class RootNavDestination(
-    val route: KClass<out NavRoot>
+    val route: KClass<out NavRoot>,
+    val destinationScope: KClass<*>,
 )

--- a/whetstone/runtime/api/runtime.api
+++ b/whetstone/runtime/api/runtime.api
@@ -25,6 +25,9 @@ public final class com/freeletics/mad/whetstone/internal/CollectAsStateKt {
 public abstract interface annotation class com/freeletics/mad/whetstone/internal/InternalWhetstoneApi : java/lang/annotation/Annotation {
 }
 
+public abstract interface annotation class com/freeletics/mad/whetstone/internal/ObsoleteWhetstoneApi : java/lang/annotation/Annotation {
+}
+
 public final class com/freeletics/mad/whetstone/internal/ViewModelProviderKt {
 }
 

--- a/whetstone/runtime/src/main/java/com/freeletics/mad/whetstone/internal/ObsoleteWhetstoneApi.kt
+++ b/whetstone/runtime/src/main/java/com/freeletics/mad/whetstone/internal/ObsoleteWhetstoneApi.kt
@@ -1,0 +1,8 @@
+package com.freeletics.mad.whetstone.internal
+
+/**
+ * Code marked with [ObsoleteWhetstoneApi] has no guarantees about API stability and will be removed
+ * in a future release.
+ */
+@RequiresOptIn
+public annotation class ObsoleteWhetstoneApi


### PR DESCRIPTION
This will be used in the codegen to provide a `NavDestination` into the given `destinationScope`. The type determines what we generate. `NONE` is a temporary opt out mechanism for cases where a destination with custom default args is needed. Like the default args API it's marked as obsolete.

The codegen itself needs to wait for the destination id removal. I'm opening this now already so that I can already add this info when migrating our codebase to the annotation.