### PR TITLE
fix missing import for handleNavigation in generated code

### DIFF
--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/compose/ComposeFragmentGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/compose/ComposeFragmentGenerator.kt
@@ -126,7 +126,7 @@ internal class ComposeFragmentGenerator(
             .addStatement("val component = viewModel.%L", viewModelComponentName)
             .addCode("\n")
             .addStatement("val navigator = component.%L", data.navigation!!.navigator.propertyName)
-            .addStatement("%N(this, navigator)", fragmentNavigationHandler)
+            .addStatement("%M(this, navigator)", fragmentNavigationHandler)
             .build()
     }
 }

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/renderer/RendererFragmentGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/renderer/RendererFragmentGenerator.kt
@@ -89,7 +89,7 @@ internal class RendererFragmentGenerator(
         return CodeBlock.builder()
             .add("\n")
             .addStatement("val navigator = component.%L", navigator.propertyName)
-            .addStatement("%N(this, navigator)", fragmentNavigationHandler)
+            .addStatement("%M(this, navigator)", fragmentNavigationHandler)
             .build()
     }
 }

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
@@ -48,6 +48,7 @@ internal class FileGeneratorTestComposeFragment {
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
             import com.freeletics.mad.navigator.fragment.FragmentNavEventNavigator
+            import com.freeletics.mad.navigator.fragment.handleNavigation
             import com.freeletics.mad.navigator.fragment.requireNavRoute
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
@@ -211,6 +212,7 @@ internal class FileGeneratorTestComposeFragment {
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
             import com.freeletics.mad.navigator.fragment.FragmentNavEventNavigator
+            import com.freeletics.mad.navigator.fragment.handleNavigation
             import com.freeletics.mad.navigator.fragment.requireNavRoute
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
@@ -372,6 +374,7 @@ internal class FileGeneratorTestComposeFragment {
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
             import com.freeletics.mad.navigator.fragment.FragmentNavEventNavigator
+            import com.freeletics.mad.navigator.fragment.handleNavigation
             import com.freeletics.mad.navigator.fragment.requireNavRoute
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestRendererFragment.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestRendererFragment.kt
@@ -40,6 +40,7 @@ internal class FileGeneratorTestRendererFragment {
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
             import com.freeletics.mad.navigator.fragment.FragmentNavEventNavigator
+            import com.freeletics.mad.navigator.fragment.handleNavigation
             import com.freeletics.mad.navigator.fragment.requireNavRoute
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
@@ -267,6 +268,7 @@ internal class FileGeneratorTestRendererFragment {
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
             import com.freeletics.mad.navigator.fragment.FragmentNavEventNavigator
+            import com.freeletics.mad.navigator.fragment.handleNavigation
             import com.freeletics.mad.navigator.fragment.requireNavRoute
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi


### PR DESCRIPTION
`%N` just uses the name while `%M` actually imports the member