### PR TITLE
set arguments bundle for the start destination

### DIFF
--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavHostFragment.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavHostFragment.kt
@@ -13,6 +13,7 @@ import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.get
 import com.freeletics.mad.navigator.NavRoot
 import com.freeletics.mad.navigator.NavRoute
+import com.freeletics.mad.navigator.internal.getArguments
 
 /**
  * Creates and sets a [androidx.navigation.NavGraph] containing all given [destinations].
@@ -23,7 +24,8 @@ public fun NavHostFragment.setGraph(
     destinations: Set<NavDestination>,
 ) {
     val startDestinationId = startRoot.destinationId
-    navController.setGraph(startDestinationId, destinations)
+    val startDestinationArgs = startRoot.getArguments()
+    navController.setGraph(startDestinationId, startDestinationArgs, destinations)
 }
 
 /**
@@ -35,12 +37,14 @@ public fun NavHostFragment.setGraph(
     destinations: Set<NavDestination>,
 ) {
     val startDestinationId = startRoute.destinationId
-    navController.setGraph(startDestinationId, destinations)
+    val startDestinationArgs = startRoute.getArguments()
+    navController.setGraph(startDestinationId, startDestinationArgs, destinations)
 }
 
 
 private fun NavController.setGraph(
     startDestinationId: Int,
+    startDestinationArgs: Bundle,
     destinations: Set<NavDestination>,
 ) {
     @Suppress("deprecation")
@@ -49,7 +53,7 @@ private fun NavController.setGraph(
             addDestination(this@setGraph, destination)
         }
     }
-    setGraph(graph, null)
+    setGraph(graph, startDestinationArgs)
 }
 
 private fun NavGraphBuilder.addDestination(

--- a/navigator/runtime/api/navigator-runtime.api
+++ b/navigator/runtime/api/navigator-runtime.api
@@ -60,10 +60,3 @@ public final class com/freeletics/mad/navigator/internal/NavigateKt {
 public abstract interface annotation class com/freeletics/mad/navigator/internal/ObsoleteNavigatorApi : java/lang/annotation/Annotation {
 }
 
-public final class com/freeletics/mad/navigator/runtime/BuildConfig {
-	public static final field BUILD_TYPE Ljava/lang/String;
-	public static final field DEBUG Z
-	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
-	public fun <init> ()V
-}
-

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/Navigate.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/Navigate.kt
@@ -76,13 +76,15 @@ public fun <T : NavRoute> Bundle.toNavRoute(): T = getParcelable(EXTRA_ROUTE)!!
 @InternalNavigatorApi
 public fun <T : NavRoot> Bundle.toNavRoot(): T = getParcelable(EXTRA_ROUTE)!!
 
-private fun NavRoute.getArguments(): Bundle = Bundle().also {
+@InternalNavigatorApi
+public fun NavRoute.getArguments(): Bundle = Bundle().also {
     if (this is Parcelable) {
         it.putParcelable(EXTRA_ROUTE, this)
     }
 }
 
-private fun NavRoot.getArguments(): Bundle = Bundle().also {
+@InternalNavigatorApi
+public fun NavRoot.getArguments(): Bundle = Bundle().also {
     if (this is Parcelable) {
         it.putParcelable(EXTRA_ROUTE, this)
     }


### PR DESCRIPTION
Since our generated code expects the route in the arguments for each screen (for compose it's even the navigator library itself) we also need to set the arguments for the start destination. For Fragments this is easy, we can just pass them when we call the AndroidX `setGraph` method. For compose it's more complicated. Setting the graph on the controller happens inside their `NavHost` composable and that only accepts args in you are using String routes instead of id + Bundle (the args are then already part of the route that you pass). To work around that we add the start destination args as default args of the destination when building the graph, we can match those base on the route class.