### PR TITLE
fix legacy NavController API

### DIFF
--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavHost.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavHost.kt
@@ -32,6 +32,7 @@ import com.freeletics.mad.navigator.internal.ObsoleteNavigatorApi
 import com.freeletics.mad.navigator.internal.destinationId
 import com.freeletics.mad.navigator.internal.getArguments
 import com.freeletics.mad.navigator.internal.toRoute
+import com.freeletics.mad.navigator.runtime.compose.R
 import com.google.accompanist.navigation.material.BottomSheetNavigator
 import com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi
 import com.google.accompanist.navigation.material.ModalBottomSheetLayout
@@ -175,4 +176,4 @@ private fun Context.findActivity(): android.app.Activity {
     throw IllegalStateException("Permissions should be called in the context of an Activity")
 }
 
-private val navControllerTagId = View.generateViewId()
+private val navControllerTagId = R.id.internal_nav_controller_tag

--- a/navigator/runtime-compose/src/main/res/values/ids.xml
+++ b/navigator/runtime-compose/src/main/res/values/ids.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="internal_nav_controller_tag" type="id" />
+</resources>

--- a/navigator/runtime-compose/src/main/res/values/public.xml
+++ b/navigator/runtime-compose/src/main/res/values/public.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <public type="id" name="id_that_does_not_exist" />
+</resources>


### PR DESCRIPTION
Turns out that `setTag` only wants ids generated by aapt and not the ones generated at runtime.