### PR TITLE
generate NavDestinations based on @NavDestination

### DIFF
--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/Data.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/Data.kt
@@ -1,6 +1,14 @@
 package com.freeletics.mad.whetstone
 
+import com.freeletics.mad.whetstone.codegen.util.composeBottomSheetDestination
+import com.freeletics.mad.whetstone.codegen.util.composeDestination
+import com.freeletics.mad.whetstone.codegen.util.composeDialogDestination
+import com.freeletics.mad.whetstone.codegen.util.composeScreenDestination
+import com.freeletics.mad.whetstone.codegen.util.fragmentDestination
+import com.freeletics.mad.whetstone.codegen.util.fragmentDialogDestination
+import com.freeletics.mad.whetstone.codegen.util.fragmentScreenDestination
 import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.MemberName
 
 internal sealed interface BaseData {
     val baseName: String
@@ -23,20 +31,40 @@ internal sealed interface CommonData : BaseData {
 
 internal sealed interface Navigation {
     val route: ClassName
-    val destinationType: String
+    val destinationClass: ClassName
     val destinationScope: ClassName
+    val destinationMethod: MemberName?
 
     data class Compose(
         override val route: ClassName,
-        override val destinationType: String,
+        private val destinationType: String,
         override val destinationScope: ClassName,
-    ) : Navigation
+    ) : Navigation {
+        override val destinationClass: ClassName = composeDestination
+
+        override val destinationMethod = when(destinationType) {
+            "NONE" -> null
+            "SCREEN" -> composeScreenDestination
+            "DIALOG" -> composeDialogDestination
+            "BOTTOM_SHEET" -> composeBottomSheetDestination
+            else -> throw IllegalArgumentException("Unknown destinationType $destinationType")
+        }
+    }
 
     data class Fragment(
         override val route: ClassName,
-        override  val destinationType: String,
+        private val destinationType: String,
         override val destinationScope: ClassName,
-    ) : Navigation
+    ) : Navigation {
+        override val destinationClass: ClassName = fragmentDestination
+
+        override val destinationMethod = when(destinationType) {
+            "NONE" -> null
+            "SCREEN" -> fragmentScreenDestination
+            "DIALOG" -> fragmentDialogDestination
+            else -> throw IllegalArgumentException("Unknown destinationType $destinationType")
+        }
+    }
 }
 
 internal data class ComposeScreenData(

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/FileGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/FileGenerator.kt
@@ -4,6 +4,7 @@ import com.freeletics.mad.whetstone.ComposeFragmentData
 import com.freeletics.mad.whetstone.ComposeScreenData
 import com.freeletics.mad.whetstone.NavEntryData
 import com.freeletics.mad.whetstone.RendererFragmentData
+import com.freeletics.mad.whetstone.codegen.common.NavDestinationModuleGenerator
 import com.freeletics.mad.whetstone.codegen.common.RetainedComponentGenerator
 import com.freeletics.mad.whetstone.codegen.common.ViewModelGenerator
 import com.freeletics.mad.whetstone.codegen.compose.ComposeFragmentGenerator
@@ -20,11 +21,17 @@ internal class FileGenerator{
         val retainedComponentGenerator = RetainedComponentGenerator(data)
         val viewModelGenerator = ViewModelGenerator(data)
         val composeGenerator = ComposeGenerator(data)
+        val navDestinationGenerator = NavDestinationModuleGenerator(data)
 
         return FileSpec.builder(data.packageName, "Whetstone${data.baseName}")
             .addType(retainedComponentGenerator.generate())
             .addType(viewModelGenerator.generate())
             .addFunction(composeGenerator.generate(disableNavigation = false))
+            .also {
+                if (data.navigation?.destinationMethod != null) {
+                    it.addType(navDestinationGenerator.generate())
+                }
+            }
             .build()
     }
 
@@ -33,12 +40,18 @@ internal class FileGenerator{
         val viewModelGenerator = ViewModelGenerator(data)
         val composeFragmentGenerator = ComposeFragmentGenerator(data)
         val composeGenerator = ComposeGenerator(data)
+        val navDestinationGenerator = NavDestinationModuleGenerator(data)
 
         return FileSpec.builder(data.packageName, "Whetstone${data.baseName}")
             .addType(retainedComponentGenerator.generate())
             .addType(viewModelGenerator.generate())
             .addFunction(composeGenerator.generate(disableNavigation = true))
             .addType(composeFragmentGenerator.generate())
+            .also {
+                if (data.navigation?.destinationMethod != null) {
+                    it.addType(navDestinationGenerator.generate())
+                }
+            }
             .build()
     }
 
@@ -46,11 +59,17 @@ internal class FileGenerator{
         val retainedComponentGenerator = RetainedComponentGenerator(data)
         val viewModelGenerator = ViewModelGenerator(data)
         val rendererFragmentGenerator = RendererFragmentGenerator(data)
+        val navDestinationGenerator = NavDestinationModuleGenerator(data)
 
         return FileSpec.builder(data.packageName, "Whetstone${data.baseName}")
             .addType(retainedComponentGenerator.generate())
             .addType(viewModelGenerator.generate())
             .addType(rendererFragmentGenerator.generate())
+            .also {
+                if (data.navigation?.destinationMethod != null) {
+                    it.addType(navDestinationGenerator.generate())
+                }
+            }
             .build()
     }
 

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/NavDestinationModuleGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/NavDestinationModuleGenerator.kt
@@ -1,0 +1,56 @@
+package com.freeletics.mad.whetstone.codegen.common
+
+import com.freeletics.mad.whetstone.CommonData
+import com.freeletics.mad.whetstone.Navigation
+import com.freeletics.mad.whetstone.codegen.Generator
+import com.freeletics.mad.whetstone.codegen.compose.composableName
+import com.freeletics.mad.whetstone.codegen.compose.fragmentName
+import com.freeletics.mad.whetstone.codegen.util.contributesToAnnotation
+import com.freeletics.mad.whetstone.codegen.util.intoSet
+import com.freeletics.mad.whetstone.codegen.util.module
+import com.freeletics.mad.whetstone.codegen.util.provides
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.TypeSpec
+
+internal class NavDestinationModuleGenerator(
+    override val data: CommonData,
+) : Generator<CommonData>() {
+
+    private val moduleClassName = ClassName("Whetstone${data.baseName}NavDestinationModule")
+
+    internal fun generate(): TypeSpec {
+        return TypeSpec.objectBuilder(moduleClassName)
+            .addAnnotation(module)
+            .addAnnotation(contributesToAnnotation(data.navigation!!.destinationScope))
+            .addFunction(providesFunction())
+            .build()
+    }
+
+    private fun providesFunction(): FunSpec {
+        return FunSpec.builder("provideNavDestination")
+            .addAnnotation(provides)
+            .addAnnotation(intoSet)
+            .returns(data.navigation!!.destinationClass)
+            .addCode(providesCode())
+            .build()
+    }
+
+    private fun providesCode(): CodeBlock {
+        val navigation = data.navigation!!
+        return when(data.navigation!!) {
+             is Navigation.Compose -> {
+                CodeBlock.builder()
+                    .beginControlFlow("return %M<%T>",
+                        navigation.destinationMethod, navigation.route)
+                    .addStatement("%L(it)", composableName)
+                    .endControlFlow()
+                    .build()
+            }
+            is Navigation.Fragment -> {
+                CodeBlock.of("return %M<%T, %T>()",
+                    navigation.destinationMethod, navigation.route, ClassName(fragmentName))
+            }
+        }
+    }
+}

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/compose/ComposeFragmentGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/compose/ComposeFragmentGenerator.kt
@@ -1,5 +1,6 @@
 package com.freeletics.mad.whetstone.codegen.compose
 
+import com.freeletics.mad.whetstone.CommonData
 import com.freeletics.mad.whetstone.ComposeFragmentData
 import com.freeletics.mad.whetstone.codegen.common.viewModelClassName
 import com.freeletics.mad.whetstone.codegen.common.viewModelComponentName
@@ -29,15 +30,16 @@ import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 
+internal val Generator<out CommonData>.fragmentName
+    get() = "${data.baseName}Fragment"
+
 internal class ComposeFragmentGenerator(
     override val data: ComposeFragmentData,
 ) : Generator<ComposeFragmentData>() {
 
-    private val composeFragmentClassName = ClassName("${data.baseName}Fragment")
-
     internal fun generate(): TypeSpec {
         val argumentsParameter = data.navigation.asParameter()
-        return TypeSpec.classBuilder(composeFragmentClassName)
+        return TypeSpec.classBuilder(fragmentName)
             .addAnnotation(optInAnnotation())
             .superclass(data.fragmentBaseClass)
             .addFunction(composeOnCreateViewFun(argumentsParameter))

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/renderer/RendererFragmentGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/renderer/RendererFragmentGenerator.kt
@@ -3,6 +3,7 @@ package com.freeletics.mad.whetstone.codegen.renderer
 import com.freeletics.mad.whetstone.RendererFragmentData
 import com.freeletics.mad.whetstone.codegen.common.viewModelClassName
 import com.freeletics.mad.whetstone.codegen.common.viewModelComponentName
+import com.freeletics.mad.whetstone.codegen.compose.fragmentName
 import com.freeletics.mad.whetstone.codegen.Generator
 import com.freeletics.mad.whetstone.codegen.util.asParameter
 import com.freeletics.mad.whetstone.codegen.util.bundle
@@ -28,11 +29,9 @@ internal class RendererFragmentGenerator(
     override val data: RendererFragmentData,
 ) : Generator<RendererFragmentData>() {
 
-    private val rendererFragmentClassName = ClassName("${data.baseName}Fragment")
-
     internal fun generate(): TypeSpec {
         val argumentsParameter = data.navigation.asParameter()
-        return TypeSpec.classBuilder(rendererFragmentClassName)
+        return TypeSpec.classBuilder(fragmentName)
             .addAnnotation(optInAnnotation())
             .superclass(data.fragmentBaseClass)
             .addProperty(lateinitPropertySpec(data.factory))

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
@@ -37,7 +37,14 @@ internal val composeProviderValueModule = ClassName("com.freeletics.mad.whetston
 // Navigator
 internal val navEventNavigator = ClassName("com.freeletics.mad.navigator", "NavEventNavigator")
 internal val composeNavigationHandler = MemberName("com.freeletics.mad.navigator.compose", "NavigationSetup")
+internal val composeDestination = ClassName("com.freeletics.mad.navigator.compose", "NavDestination")
+internal val composeScreenDestination = MemberName("com.freeletics.mad.navigator.compose", "ScreenDestination")
+internal val composeDialogDestination = MemberName("com.freeletics.mad.navigator.compose", "DialogDestination")
+internal val composeBottomSheetDestination = MemberName("com.freeletics.mad.navigator.compose", "BottomSheetDestination")
 internal val fragmentNavigationHandler = MemberName("com.freeletics.mad.navigator.fragment", "handleNavigation")
+internal val fragmentDestination = ClassName("com.freeletics.mad.navigator.fragment", "NavDestination")
+internal val fragmentScreenDestination = MemberName("com.freeletics.mad.navigator.fragment", "ScreenDestination")
+internal val fragmentDialogDestination = MemberName("com.freeletics.mad.navigator.fragment", "DialogDestination")
 internal val requireRoute = MemberName("com.freeletics.mad.navigator.fragment", "requireRoute")
 
 // Renderer

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
@@ -191,6 +191,183 @@ internal class FileGeneratorTestComposeFragment {
     }
 
     @Test
+    fun `generates code for ComposeFragmentData with destination`() {
+        val withDestination = full.copy(navigation = navigation.copy(destinationType = "SCREEN"))
+
+        FileGenerator().generate(withDestination).toString() shouldBe """
+            package com.test
+
+            import android.os.Bundle
+            import android.view.LayoutInflater
+            import android.view.View
+            import android.view.ViewGroup
+            import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.CompositionLocalProvider
+            import androidx.compose.runtime.ProvidedValue
+            import androidx.compose.runtime.rememberCoroutineScope
+            import androidx.compose.ui.platform.ComposeView
+            import androidx.compose.ui.platform.ViewCompositionStrategy
+            import androidx.fragment.app.Fragment
+            import androidx.lifecycle.SavedStateHandle
+            import androidx.lifecycle.ViewModel
+            import com.freeletics.mad.navigator.NavEventNavigator
+            import com.freeletics.mad.navigator.fragment.NavDestination
+            import com.freeletics.mad.navigator.fragment.ScreenDestination
+            import com.freeletics.mad.navigator.fragment.handleNavigation
+            import com.freeletics.mad.navigator.fragment.requireRoute
+            import com.freeletics.mad.whetstone.ScopeTo
+            import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
+            import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
+            import com.freeletics.mad.whetstone.`internal`.asComposeState
+            import com.freeletics.mad.whetstone.`internal`.rememberViewModelProvider
+            import com.freeletics.mad.whetstone.fragment.`internal`.viewModelProvider
+            import com.google.accompanist.insets.LocalWindowInsets
+            import com.google.accompanist.insets.ViewWindowInsetObserver
+            import com.squareup.anvil.annotations.ContributesTo
+            import com.squareup.anvil.annotations.MergeComponent
+            import com.test.destination.TestDestinationScope
+            import com.test.parent.TestParentScope
+            import dagger.BindsInstance
+            import dagger.Component
+            import dagger.Module
+            import dagger.Provides
+            import dagger.multibindings.IntoSet
+            import io.reactivex.disposables.CompositeDisposable
+            import kotlin.Boolean
+            import kotlin.OptIn
+            import kotlin.Unit
+            import kotlin.collections.Set
+            import kotlinx.coroutines.CoroutineScope
+            import kotlinx.coroutines.MainScope
+            import kotlinx.coroutines.cancel
+            import kotlinx.coroutines.launch
+
+            @InternalWhetstoneApi
+            @ScopeTo(TestScreen::class)
+            @MergeComponent(
+              scope = TestScreen::class,
+              dependencies = [TestDependencies::class],
+              modules = [ComposeProviderValueModule::class]
+            )
+            internal interface RetainedTestComponent {
+              public val testStateMachine: TestStateMachine
+
+              public val navEventNavigator: NavEventNavigator
+
+              public val providedValues: Set<ProvidedValue<*>>
+
+              @Component.Factory
+              public interface Factory {
+                public fun create(
+                  dependencies: TestDependencies,
+                  @BindsInstance savedStateHandle: SavedStateHandle,
+                  @BindsInstance testRoute: TestRoute,
+                  @BindsInstance compositeDisposable: CompositeDisposable,
+                  @BindsInstance coroutineScope: CoroutineScope
+                ): RetainedTestComponent
+              }
+            }
+
+            @InternalWhetstoneApi
+            internal class TestViewModel(
+              dependencies: TestDependencies,
+              savedStateHandle: SavedStateHandle,
+              testRoute: TestRoute
+            ) : ViewModel() {
+              private val disposable: CompositeDisposable = CompositeDisposable()
+
+              private val scope: CoroutineScope = MainScope()
+
+              public val component: RetainedTestComponent =
+                  DaggerRetainedTestComponent.factory().create(dependencies, savedStateHandle, testRoute,
+                  disposable, scope)
+
+              public override fun onCleared(): Unit {
+                disposable.clear()
+                scope.cancel()
+              }
+            }
+
+            @Composable
+            @OptIn(InternalWhetstoneApi::class)
+            public fun TestScreen(testRoute: TestRoute): Unit {
+              val viewModelProvider = rememberViewModelProvider<TestDependencies>(TestParentScope::class) {
+                  dependencies, handle -> 
+                TestViewModel(dependencies, handle, testRoute)
+              }
+              val viewModel = viewModelProvider[TestViewModel::class.java]
+              val component = viewModel.component
+
+              val providedValues = component.providedValues
+              CompositionLocalProvider(*providedValues.toTypedArray()) {
+                val stateMachine = component.testStateMachine
+                val state = stateMachine.asComposeState()
+                val currentState = state.value
+                if (currentState != null) {
+                  val scope = rememberCoroutineScope()
+                  Test(currentState) { action ->
+                    scope.launch { stateMachine.dispatch(action) }
+                  }
+                }
+              }
+            }
+            
+            @OptIn(InternalWhetstoneApi::class)
+            public class TestFragment : Fragment() {
+              private var navigationSetup: Boolean = false
+            
+              public override fun onCreateView(
+                inflater: LayoutInflater,
+                container: ViewGroup?,
+                savedInstanceState: Bundle?
+              ): View {
+                val testRoute = requireRoute<TestRoute>()
+                if (!navigationSetup) {
+                  navigationSetup = true
+                  setupNavigation(testRoute)
+                }
+            
+                return ComposeView(requireContext()).apply {
+                  setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnLifecycleDestroyed(viewLifecycleOwner))
+
+                  layoutParams = ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
+                      ViewGroup.LayoutParams.MATCH_PARENT)
+                  val observer = ViewWindowInsetObserver(this)
+                  val windowInsets = observer.start()
+
+                  setContent {
+                    CompositionLocalProvider(LocalWindowInsets provides windowInsets) {
+                      TestScreen(testRoute)
+                    }
+                  }
+                }
+              }
+            
+              private fun setupNavigation(testRoute: TestRoute): Unit {
+                val viewModelProvider = viewModelProvider<TestDependencies>(this, TestParentScope::class) {
+                    dependencies, handle -> 
+                  TestViewModel(dependencies, handle, testRoute)
+                }
+                val viewModel = viewModelProvider[TestViewModel::class.java]
+                val component = viewModel.component
+            
+                val navigator = component.navEventNavigator
+                handleNavigation(this, navigator)
+              }
+            }
+            
+            @Module
+            @ContributesTo(TestDestinationScope::class)
+            public object WhetstoneTestNavDestinationModule {
+              @Provides
+              @IntoSet
+              public fun provideNavDestination(): NavDestination = ScreenDestination<TestRoute, TestFragment>()
+            }
+            
+        """.trimIndent()
+    }
+
+    @Test
     fun `generates code for ComposeFragmentData, dialog fragment`() {
         val dialogFragment = full.copy(
             fragmentBaseClass = dialogFragment

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestRendererFragment.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestRendererFragment.kt
@@ -144,6 +144,138 @@ internal class FileGeneratorTestRendererFragment {
     }
 
     @Test
+    fun `generates code for RendererFragmentData with destination`() {
+        val withDestination = full.copy(navigation = navigation.copy(destinationType = "SCREEN"))
+
+        FileGenerator().generate(withDestination).toString() shouldBe """
+            package com.test
+
+            import android.os.Bundle
+            import android.view.LayoutInflater
+            import android.view.View
+            import android.view.ViewGroup
+            import androidx.fragment.app.Fragment
+            import androidx.lifecycle.SavedStateHandle
+            import androidx.lifecycle.ViewModel
+            import com.freeletics.mad.navigator.NavEventNavigator
+            import com.freeletics.mad.navigator.fragment.NavDestination
+            import com.freeletics.mad.navigator.fragment.ScreenDestination
+            import com.freeletics.mad.navigator.fragment.handleNavigation
+            import com.freeletics.mad.navigator.fragment.requireRoute
+            import com.freeletics.mad.whetstone.ScopeTo
+            import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
+            import com.freeletics.mad.whetstone.fragment.`internal`.viewModelProvider
+            import com.gabrielittner.renderer.connect.connect
+            import com.squareup.anvil.annotations.ContributesTo
+            import com.squareup.anvil.annotations.MergeComponent
+            import com.test.destination.TestDestinationScope
+            import com.test.parent.TestParentScope
+            import dagger.BindsInstance
+            import dagger.Component
+            import dagger.Module
+            import dagger.Provides
+            import dagger.multibindings.IntoSet
+            import io.reactivex.disposables.CompositeDisposable
+            import kotlin.OptIn
+            import kotlin.Unit
+            import kotlinx.coroutines.CoroutineScope
+            import kotlinx.coroutines.MainScope
+            import kotlinx.coroutines.cancel
+
+            @InternalWhetstoneApi
+            @ScopeTo(TestScreen::class)
+            @MergeComponent(
+              scope = TestScreen::class,
+              dependencies = [TestDependencies::class]
+            )
+            internal interface RetainedTestComponent {
+              public val testStateMachine: TestStateMachine
+
+              public val navEventNavigator: NavEventNavigator
+            
+              public val rendererFactory: RendererFactory
+
+              @Component.Factory
+              public interface Factory {
+                public fun create(
+                  dependencies: TestDependencies,
+                  @BindsInstance savedStateHandle: SavedStateHandle,
+                  @BindsInstance testRoute: TestRoute,
+                  @BindsInstance compositeDisposable: CompositeDisposable,
+                  @BindsInstance coroutineScope: CoroutineScope
+                ): RetainedTestComponent
+              }
+            }
+
+            @InternalWhetstoneApi
+            internal class TestViewModel(
+              dependencies: TestDependencies,
+              savedStateHandle: SavedStateHandle,
+              testRoute: TestRoute
+            ) : ViewModel() {
+              private val disposable: CompositeDisposable = CompositeDisposable()
+
+              private val scope: CoroutineScope = MainScope()
+
+              public val component: RetainedTestComponent =
+                  DaggerRetainedTestComponent.factory().create(dependencies, savedStateHandle, testRoute,
+                  disposable, scope)
+
+              public override fun onCleared(): Unit {
+                disposable.clear()
+                scope.cancel()
+              }
+            }
+            
+            @OptIn(InternalWhetstoneApi::class)
+            public class TestFragment : Fragment() {
+              private lateinit var rendererFactory: RendererFactory
+
+              private lateinit var testStateMachine: TestStateMachine
+
+              public override fun onCreateView(
+                inflater: LayoutInflater,
+                container: ViewGroup?,
+                savedInstanceState: Bundle?
+              ): View {
+                if (!::testStateMachine.isInitialized) {
+                  val testRoute = requireRoute<TestRoute>()
+                  inject(testRoute)
+                }
+            
+                val renderer = rendererFactory.inflate(inflater, container)
+                connect(renderer, testStateMachine)
+                return renderer.rootView
+              }
+
+              private fun inject(testRoute: TestRoute): Unit {
+                val viewModelProvider = viewModelProvider<TestDependencies>(this, TestParentScope::class) {
+                    dependencies, handle -> 
+                  TestViewModel(dependencies, handle, testRoute)
+                }
+                val viewModel = viewModelProvider[TestViewModel::class.java]
+                val component = viewModel.component
+
+                rendererFactory = component.rendererFactory
+                testStateMachine = component.testStateMachine
+
+                val navigator = component.navEventNavigator
+                handleNavigation(this, navigator)
+              }
+            }
+            
+            @Module
+            @ContributesTo(TestDestinationScope::class)
+            public object WhetstoneTestNavDestinationModule {
+              @Provides
+              @IntoSet
+              public fun provideNavDestination(): NavDestination = ScreenDestination<TestRoute, TestFragment>()
+            }
+            
+        """.trimIndent()
+    }
+
+    @Test
     fun `generates code for RendererFragmentData, no navigation`() {
         val noNavigation = full.copy(navigation = null)
 

--- a/whetstone/runtime-compose/src/main/java/com/freeletics/mad/whetstone/compose/NavDestination.kt
+++ b/whetstone/runtime-compose/src/main/java/com/freeletics/mad/whetstone/compose/NavDestination.kt
@@ -18,7 +18,7 @@ import kotlin.reflect.KClass
 @Retention(AnnotationRetention.RUNTIME)
 public annotation class NavDestination(
     val route: KClass<out NavRoute>,
-    val type: DestinationType = DestinationType.NONE,
+    val type: DestinationType,
     val destinationScope: KClass<*>,
 )
 

--- a/whetstone/runtime-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/NavDestination.kt
+++ b/whetstone/runtime-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/NavDestination.kt
@@ -19,7 +19,7 @@ import kotlin.reflect.KClass
 @Retention(AnnotationRetention.RUNTIME)
 public annotation class NavDestination(
     val route: KClass<out NavRoute>,
-    val type: DestinationType = DestinationType.NONE,
+    val type: DestinationType,
     val destinationScope: KClass<*>,
 )
 


### PR DESCRIPTION
Generates a nav destination that is provided into a set for all `@NavDestination` annotations that did not set their `type` to `NONE`. I've removed the default value from the annotations because it's weird to have the obsolete value as default.