### PR TITLE
remove internal annotation from method that is overridden by anvil

### DIFF
--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/naventry/NavEntrySubcomponentGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/naventry/NavEntrySubcomponentGenerator.kt
@@ -67,7 +67,6 @@ internal class NavEntrySubcomponentGenerator(
     private fun navEntrySubcomponentFactoryParentComponent(): TypeSpec {
         val getterFun = FunSpec.builder(navEntrySubcomponentFactoryProviderGetterName)
             .addModifiers(ABSTRACT)
-            .addAnnotation(internalWhetstoneApi)
             .returns(navEntrySubcomponentFactoryClassName)
             .build()
         return TypeSpec.interfaceBuilder(navEntrySubcomponentFactoryProviderClassName)

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/NavEntryFileGeneratorTest.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/NavEntryFileGeneratorTest.kt
@@ -66,7 +66,6 @@ internal class NavEntryFileGeneratorTest {
 
               @ContributesTo(TestParentScope::class)
               public interface ParentComponent {
-                @InternalWhetstoneApi
                 public fun getNavEntryTestFlowComponent(): Factory
               }
             }
@@ -164,7 +163,6 @@ internal class NavEntryFileGeneratorTest {
 
               @ContributesTo(TestParentScope::class)
               public interface ParentComponent {
-                @InternalWhetstoneApi
                 public fun getNavEntryTestFlowComponent(): Factory
               }
             }
@@ -261,7 +259,6 @@ internal class NavEntryFileGeneratorTest {
 
               @ContributesTo(TestParentScope::class)
               public interface ParentComponent {
-                @InternalWhetstoneApi
                 public fun getNavEntryTestFlowComponent(): Factory
               }
             }


### PR DESCRIPTION
Having it there leads to a compilation error in Anvil's generated code because that won't opt in to it