### PR TITLE
remove obsolete destination APIs

### DIFF
--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavDestination.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavDestination.kt
@@ -1,7 +1,6 @@
 package com.freeletics.mad.navigator.compose
 
 import android.content.Intent
-import android.os.Bundle
 import androidx.compose.runtime.Composable
 import com.freeletics.mad.navigator.BaseRoute
 import com.freeletics.mad.navigator.NavRoute
@@ -9,7 +8,6 @@ import com.freeletics.mad.navigator.compose.NavDestination.Activity
 import com.freeletics.mad.navigator.compose.NavDestination.BottomSheet
 import com.freeletics.mad.navigator.compose.NavDestination.Dialog
 import com.freeletics.mad.navigator.compose.NavDestination.Screen
-import com.freeletics.mad.navigator.internal.ObsoleteNavigatorApi
 import com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi
 import kotlin.reflect.KClass
 
@@ -63,32 +61,20 @@ public sealed interface NavDestination {
      * The given [screenContent] will be shown when the screen is being
      * navigated to using an instance of [route].
      */
-    public class Screen<T : BaseRoute> @ObsoleteNavigatorApi constructor(
+    public class Screen<T : BaseRoute>(
         internal val route: KClass<T>,
-        internal val defaultArguments: Bundle?,
         internal val screenContent: @Composable (T) -> Unit,
-    ) : NavDestination {
-        public constructor(
-            route: KClass<T>,
-            screenContent: @Composable (T) -> Unit,
-        ) : this(route, null, screenContent)
-    }
+    ) : NavDestination
 
     /**
      * Represents a dialog. The [route] will be used as a unique identifier together.
      * The given [dialogContent] will be shown inside the dialog window
      * when navigating to it by using an instance of [route].
      */
-    public class Dialog<T : NavRoute> @ObsoleteNavigatorApi constructor(
+    public class Dialog<T : NavRoute>(
         internal val route: KClass<T>,
-        internal val defaultArguments: Bundle?,
         internal val dialogContent: @Composable (T) -> Unit,
-    ) : NavDestination {
-        public constructor(
-            route: KClass<T>,
-            dialogContent: @Composable (T) -> Unit,
-        ) : this(route, null, dialogContent)
-    }
+    ) : NavDestination
 
     /**
      * Represents a bottom sheet. The [route] will be used as a unique identifier.
@@ -96,16 +82,10 @@ public sealed interface NavDestination {
      * when navigating to it by using an instance of [route].
      */
     @ExperimentalMaterialNavigationApi
-    public class BottomSheet<T : NavRoute> @ObsoleteNavigatorApi constructor(
+    public class BottomSheet<T : NavRoute>(
         internal val route: KClass<T>,
-        internal val defaultArguments: Bundle?,
         internal val bottomSheetContent: @Composable (T) -> Unit,
-    ) : NavDestination {
-        public constructor(
-            route: KClass<T>,
-            bottomSheetContent: @Composable (T) -> Unit,
-        ) : this(route, null, bottomSheetContent)
-    }
+    ) : NavDestination
 
     /**
      * Represents an `Activity`. The [route] will be used as a unique identifier.

--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavHost.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavHost.kt
@@ -1,11 +1,9 @@
 package com.freeletics.mad.navigator.compose
 
 import android.app.Activity as AndroidActivity
-import androidx.navigation.NavDestination as AndroidxNavDestination
 import androidx.navigation.compose.NavHost as AndroidXNavHost
 import android.content.Context
 import android.content.ContextWrapper
-import android.os.Bundle
 import android.view.View
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -37,7 +35,6 @@ import com.google.accompanist.navigation.material.BottomSheetNavigator
 import com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi
 import com.google.accompanist.navigation.material.ModalBottomSheetLayout
 import com.google.accompanist.navigation.material.rememberBottomSheetNavigator
-import kotlin.reflect.KClass
 
 /**
  * Create a new [androidx.navigation.compose.NavHost] with a [androidx.navigation.NavGraph]
@@ -95,9 +92,15 @@ private fun <T : BaseRoute> Screen<T>.toDestination(
     val navigator = controller.navigatorProvider[ComposeNavigator::class]
     return ComposeNavigator.Destination(navigator) { screenContent(it.arguments!!.toRoute()) }.also {
         it.id = route.destinationId()
-        it.addDefaultArguments(defaultArguments)
         if (startRoute::class == route) {
-            it.addDefaultArguments(startRoute.getArguments())
+            val arguments = startRoute.getArguments()
+            arguments.keySet().forEach { key ->
+                val argument = NavArgument.Builder()
+                    .setDefaultValue(arguments.get(key))
+                    .setIsNullable(false)
+                    .build()
+                it.addArgument(key, argument)
+            }
         }
     }
 }
@@ -108,7 +111,6 @@ private fun <T : NavRoute> Dialog<T>.toDestination(
     val navigator = controller.navigatorProvider[DialogNavigator::class]
     return DialogNavigator.Destination(navigator) { dialogContent(it.arguments!!.toRoute()) }.also {
         it.id = route.destinationId()
-        it.addDefaultArguments(defaultArguments)
     }
 }
 
@@ -121,7 +123,6 @@ private fun <T : NavRoute> BottomSheet<T>.toDestination(
     val navigator = controller.navigatorProvider[BottomSheetNavigator::class]
     return BottomSheetNavigator.Destination(navigator) { bottomSheetContent(it.arguments!!.toRoute()) }.also {
         it.id = route.destinationId()
-        it.addDefaultArguments(defaultArguments)
     }
 }
 
@@ -137,16 +138,6 @@ private fun Activity.toDestination(
 
 internal val LocalNavController = staticCompositionLocalOf<NavController> {
     throw IllegalStateException("Can't use NavEventNavigationHandler outside of a navigator NavHost")
-}
-
-private fun AndroidxNavDestination.addDefaultArguments(extras: Bundle?) {
-    extras?.keySet()?.forEach { key ->
-        val argument = NavArgument.Builder()
-            .setDefaultValue(extras.get(key))
-            .setIsNullable(false)
-            .build()
-        addArgument(key, argument)
-    }
 }
 
 @ObsoleteNavigatorApi

--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavDestination.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavDestination.kt
@@ -1,7 +1,6 @@
 package com.freeletics.mad.navigator.fragment
 
 import android.content.Intent
-import android.os.Bundle
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import com.freeletics.mad.navigator.BaseRoute
@@ -9,7 +8,6 @@ import com.freeletics.mad.navigator.NavRoute
 import com.freeletics.mad.navigator.fragment.NavDestination.Activity
 import com.freeletics.mad.navigator.fragment.NavDestination.Dialog
 import com.freeletics.mad.navigator.fragment.NavDestination.Screen
-import com.freeletics.mad.navigator.internal.ObsoleteNavigatorApi
 import kotlin.reflect.KClass
 
 /**
@@ -52,31 +50,19 @@ public sealed interface NavDestination {
      * [fragmentClass] will be shown when the screen is being
      * navigated to using an instance of [route].
      */
-    public class Screen<T : BaseRoute> @ObsoleteNavigatorApi constructor(
+    public class Screen<T : BaseRoute>(
         internal val route: KClass<T>,
         internal val fragmentClass: KClass<out Fragment>,
-        internal val defaultArguments: Bundle?,
-    ) : NavDestination {
-        public constructor(
-            route: KClass<T>,
-            fragmentClass: KClass<out Fragment>,
-        ) : this(route, fragmentClass, null)
-    }
+    ) : NavDestination
 
     /**
      * Represents a dialog. The [route] will be used as a unique identifier. The given
      * [fragmentClass] will be shown when it's being navigated to using an instance of [route].
      */
-    public class Dialog<T : NavRoute> @ObsoleteNavigatorApi constructor(
+    public class Dialog<T : NavRoute>(
         internal val route: KClass<T>,
         internal val fragmentClass: KClass<out DialogFragment>,
-        internal val defaultArguments: Bundle?,
-    ) : NavDestination {
-        public constructor(
-            route: KClass<T>,
-            fragmentClass: KClass<out DialogFragment>,
-        ) : this(route, fragmentClass, null)
-    }
+    ) : NavDestination
 
     /**
      * Represents an `Activity`. The [route] will be used as a unique identifier. The given

--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavHostFragment.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavHostFragment.kt
@@ -1,9 +1,6 @@
 package com.freeletics.mad.navigator.fragment
 
-import androidx.navigation.NavDestination as AndroidXNavDestination
-import android.os.Bundle
 import androidx.navigation.ActivityNavigator
-import androidx.navigation.NavArgument
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.createGraph
@@ -52,7 +49,6 @@ private fun NavDestination.Screen<*>.toDestination(
     return FragmentNavigator.Destination(navigator).also {
         it.id = route.destinationId()
         it.setClassName(fragmentClass.java.name)
-        it.addDefaultArguments(defaultArguments)
     }
 }
 
@@ -63,7 +59,6 @@ private fun NavDestination.Dialog<*>.toDestination(
     return DialogFragmentNavigator.Destination(navigator).also {
         it.id = route.destinationId()
         it.setClassName(fragmentClass.java.name)
-        it.addDefaultArguments(defaultArguments)
     }
 }
 
@@ -74,15 +69,5 @@ private fun NavDestination.Activity<*>.toDestination(
     return ActivityNavigator.Destination(navigator).also {
         it.id = route.destinationId()
         it.setIntent(intent)
-    }
-}
-
-private fun AndroidXNavDestination.addDefaultArguments(extras: Bundle?) {
-    extras?.keySet()?.forEach { key ->
-        val argument = NavArgument.Builder()
-            .setDefaultValue(extras.get(key))
-            .setIsNullable(false)
-            .build()
-        addArgument(key, argument)
     }
 }

--- a/whetstone/runtime-compose/api/runtime-compose.api
+++ b/whetstone/runtime-compose/api/runtime-compose.api
@@ -10,7 +10,6 @@ public abstract interface annotation class com/freeletics/mad/whetstone/compose/
 public final class com/freeletics/mad/whetstone/compose/DestinationType : java/lang/Enum {
 	public static final field BOTTOM_SHEET Lcom/freeletics/mad/whetstone/compose/DestinationType;
 	public static final field DIALOG Lcom/freeletics/mad/whetstone/compose/DestinationType;
-	public static final field NONE Lcom/freeletics/mad/whetstone/compose/DestinationType;
 	public static final field SCREEN Lcom/freeletics/mad/whetstone/compose/DestinationType;
 	public static fun valueOf (Ljava/lang/String;)Lcom/freeletics/mad/whetstone/compose/DestinationType;
 	public static fun values ()[Lcom/freeletics/mad/whetstone/compose/DestinationType;

--- a/whetstone/runtime-compose/build.gradle
+++ b/whetstone/runtime-compose/build.gradle
@@ -39,7 +39,6 @@ kotlin {
         languageSettings {
             optIn("kotlin.RequiresOptIn")
             optIn("com.freeletics.mad.whetstone.internal.InternalWhetstoneApi")
-            optIn("com.freeletics.mad.whetstone.internal.ObsoleteWhetstoneApi")
         }
     }
 }

--- a/whetstone/runtime-compose/src/main/java/com/freeletics/mad/whetstone/compose/NavDestination.kt
+++ b/whetstone/runtime-compose/src/main/java/com/freeletics/mad/whetstone/compose/NavDestination.kt
@@ -2,7 +2,6 @@ package com.freeletics.mad.whetstone.compose
 
 import com.freeletics.mad.navigator.NavRoot
 import com.freeletics.mad.navigator.NavRoute
-import com.freeletics.mad.whetstone.internal.ObsoleteWhetstoneApi
 import kotlin.reflect.KClass
 
 /**
@@ -26,8 +25,6 @@ public annotation class NavDestination(
  * Describing the type of [NavDestination].
  */
 public enum class DestinationType {
-    @ObsoleteWhetstoneApi
-    NONE,
     SCREEN,
     DIALOG,
     BOTTOM_SHEET,

--- a/whetstone/runtime-fragment/api/runtime-fragment.api
+++ b/whetstone/runtime-fragment/api/runtime-fragment.api
@@ -11,7 +11,6 @@ public abstract interface annotation class com/freeletics/mad/whetstone/fragment
 
 public final class com/freeletics/mad/whetstone/fragment/DestinationType : java/lang/Enum {
 	public static final field DIALOG Lcom/freeletics/mad/whetstone/fragment/DestinationType;
-	public static final field NONE Lcom/freeletics/mad/whetstone/fragment/DestinationType;
 	public static final field SCREEN Lcom/freeletics/mad/whetstone/fragment/DestinationType;
 	public static fun valueOf (Ljava/lang/String;)Lcom/freeletics/mad/whetstone/fragment/DestinationType;
 	public static fun values ()[Lcom/freeletics/mad/whetstone/fragment/DestinationType;

--- a/whetstone/runtime-fragment/build.gradle
+++ b/whetstone/runtime-fragment/build.gradle
@@ -34,7 +34,6 @@ kotlin {
         languageSettings {
             optIn("kotlin.RequiresOptIn")
             optIn("com.freeletics.mad.whetstone.internal.InternalWhetstoneApi")
-            optIn("com.freeletics.mad.whetstone.internal.ObsoleteWhetstoneApi")
         }
     }
 }

--- a/whetstone/runtime-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/NavDestination.kt
+++ b/whetstone/runtime-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/NavDestination.kt
@@ -2,7 +2,6 @@ package com.freeletics.mad.whetstone.fragment
 
 import com.freeletics.mad.navigator.NavRoot
 import com.freeletics.mad.navigator.NavRoute
-import com.freeletics.mad.whetstone.internal.ObsoleteWhetstoneApi
 import kotlin.reflect.KClass
 
 /**
@@ -27,8 +26,6 @@ public annotation class NavDestination(
  * Describing the type of [NavDestination].
  */
 public enum class DestinationType {
-    @ObsoleteWhetstoneApi
-    NONE,
     SCREEN,
     DIALOG,
 }

--- a/whetstone/runtime/api/runtime.api
+++ b/whetstone/runtime/api/runtime.api
@@ -25,9 +25,6 @@ public final class com/freeletics/mad/whetstone/internal/CollectAsStateKt {
 public abstract interface annotation class com/freeletics/mad/whetstone/internal/InternalWhetstoneApi : java/lang/annotation/Annotation {
 }
 
-public abstract interface annotation class com/freeletics/mad/whetstone/internal/ObsoleteWhetstoneApi : java/lang/annotation/Annotation {
-}
-
 public final class com/freeletics/mad/whetstone/internal/ViewModelProviderKt {
 }
 

--- a/whetstone/runtime/src/main/java/com/freeletics/mad/whetstone/internal/ObsoleteWhetstoneApi.kt
+++ b/whetstone/runtime/src/main/java/com/freeletics/mad/whetstone/internal/ObsoleteWhetstoneApi.kt
@@ -1,8 +1,0 @@
-package com.freeletics.mad.whetstone.internal
-
-/**
- * Code marked with [ObsoleteWhetstoneApi] has no guarantees about API stability and will be removed
- * in a future release.
- */
-@RequiresOptIn
-public annotation class ObsoleteWhetstoneApi


### PR DESCRIPTION
Removes the APIs to pass default arguments to destinations now that we don't use them anymore internally. Also removes the option to not generate a destination because there are no custom destinations anymore.