### PR TITLE
make NavigationResultRequest.Key ctor visible for testing

### DIFF
--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/ResultOwner.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/ResultOwner.kt
@@ -116,7 +116,7 @@ public class NavigationResultRequest<O : Parcelable> internal constructor(
     /**
      * Use to identify where the result should be delivered to.
      */
-    public data class Key<@Suppress("unused") O : Parcelable> internal constructor(
+    public data class Key<@Suppress("unused") O : Parcelable> @VisibleForTesting constructor(
         @property:InternalNavigatorApi
         public val destinationId: Int,
         @property:InternalNavigatorApi


### PR DESCRIPTION
Without this testing the navigation to a destination that takes a key as parameter becomes cumbersome. You'd have to create a navigator, call `registerForNavigationResult` and then get the key from the returned request object.