### PR TITLE
move LocalNavController provider one layer up to fix bottom sheets

### DIFF
--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavHost.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavHost.kt
@@ -64,8 +64,8 @@ public fun NavHost(
 
     LegacyFindNavControllerSupport(navController)
 
-    ModalBottomSheetLayout(bottomSheetNavigator) {
-        CompositionLocalProvider(LocalNavController provides navController) {
+    CompositionLocalProvider(LocalNavController provides navController) {
+        ModalBottomSheetLayout(bottomSheetNavigator) {
             AndroidXNavHost(navController, graph)
         }
     }


### PR DESCRIPTION
A bottom sheet destination is added to `ModalBottomSheetLayout` which right now crashes because it can't obtain the `NavController` through `LocalNavController`.