### PR TITLE
improve naming for NavEntry variables in generated code

### DIFF
--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/naventry/NavEntryComponentGetterGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/naventry/NavEntryComponentGetterGenerator.kt
@@ -83,10 +83,11 @@ internal class NavEntryComponentGetterGenerator(
             .addParameter("context", context)
             .returns(ANY)
             .addStatement("val entry = findEntry(id)")
-            .beginControlFlow("val viewModelProvider = %M<%T>(entry, context, %T::class) { component, handle -> ", navEntryViewModelProvider, navEntrySubcomponentFactoryProviderClassName, data.parentScope)
+            .beginControlFlow("val viewModelProvider = %M<%T>(entry, context, %T::class) { parentComponent, handle -> ",
+                navEntryViewModelProvider, navEntryParentComponentClassName, data.parentScope)
             // arguments: external method
             .addStatement("val arguments = entry.arguments ?: %T.EMPTY", bundle)
-            .addStatement("%T(component, handle, arguments)", viewModelClassName)
+            .addStatement("%T(parentComponent.%L, handle, arguments)", viewModelClassName, navEntryParentComponentGetterName)
             .endControlFlow()
             .addStatement("val viewModel = viewModelProvider[%T::class.java]", viewModelClassName)
             .addStatement("return viewModel.%L", viewModelComponentName)

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/naventry/NavEntrySubcomponentGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/naventry/NavEntrySubcomponentGenerator.kt
@@ -8,7 +8,6 @@ import com.freeletics.mad.whetstone.codegen.util.compositeDisposable
 import com.freeletics.mad.whetstone.codegen.util.contributesToAnnotation
 import com.freeletics.mad.whetstone.codegen.util.coroutineScope
 import com.freeletics.mad.whetstone.codegen.util.internalApiAnnotation
-import com.freeletics.mad.whetstone.codegen.util.internalWhetstoneApi
 import com.freeletics.mad.whetstone.codegen.util.savedStateHandle
 import com.freeletics.mad.whetstone.codegen.util.scopeToAnnotation
 import com.freeletics.mad.whetstone.codegen.util.subcomponentAnnotation
@@ -25,9 +24,10 @@ internal val Generator<NavEntryData>.navEntrySubcomponentFactoryClassName
 
 internal const val navEntrySubcomponentFactoryCreateName = "create"
 
-internal val Generator<NavEntryData>.navEntrySubcomponentFactoryProviderClassName get() = navEntrySubcomponentClassName.nestedClass("ParentComponent")
+internal val Generator<NavEntryData>.navEntryParentComponentClassName
+    get() = navEntrySubcomponentClassName.nestedClass("ParentComponent")
 
-internal val Generator<NavEntryData>.navEntrySubcomponentFactoryProviderGetterName get() = "get${navEntrySubcomponentClassName.simpleName}"
+internal val navEntryParentComponentGetterName get() = "factory"
 
 internal class NavEntrySubcomponentGenerator(
     override val data: NavEntryData,
@@ -65,11 +65,11 @@ internal class NavEntrySubcomponentGenerator(
     }
 
     private fun navEntrySubcomponentFactoryParentComponent(): TypeSpec {
-        val getterFun = FunSpec.builder(navEntrySubcomponentFactoryProviderGetterName)
+        val getterFun = FunSpec.builder(navEntryParentComponentGetterName)
             .addModifiers(ABSTRACT)
             .returns(navEntrySubcomponentFactoryClassName)
             .build()
-        return TypeSpec.interfaceBuilder(navEntrySubcomponentFactoryProviderClassName)
+        return TypeSpec.interfaceBuilder(navEntryParentComponentClassName)
             .addAnnotation(contributesToAnnotation(data.parentScope))
             .addFunction(getterFun)
             .build()

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/naventry/NavEntryViewModelGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/naventry/NavEntryViewModelGenerator.kt
@@ -41,7 +41,7 @@ internal class NavEntryViewModelGenerator(
 
     private fun viewModelCtor(): FunSpec {
         return FunSpec.constructorBuilder()
-            .addParameter("factory", navEntrySubcomponentFactoryProviderClassName)
+            .addParameter("factory", navEntrySubcomponentFactoryClassName)
             .addParameter("savedStateHandle", savedStateHandle)
             .addParameter("arguments", bundle)
             .build()
@@ -50,8 +50,7 @@ internal class NavEntryViewModelGenerator(
     private fun viewModelProperties(): List<PropertySpec> {
         val properties = mutableListOf<PropertySpec>()
         val componentInitializer = CodeBlock.builder().add(
-            "factory.%L().%L(savedStateHandle, arguments",
-            navEntrySubcomponentFactoryProviderGetterName,
+            "factory.%L(savedStateHandle, arguments",
             navEntrySubcomponentFactoryCreateName,
         )
         if (data.rxJavaEnabled) {

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/NavEntryFileGeneratorTest.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/NavEntryFileGeneratorTest.kt
@@ -66,13 +66,13 @@ internal class NavEntryFileGeneratorTest {
 
               @ContributesTo(TestParentScope::class)
               public interface ParentComponent {
-                public fun getNavEntryTestFlowComponent(): Factory
+                public fun factory(): Factory
               }
             }
 
             @InternalWhetstoneApi
             internal class TestFlowViewModel(
-              factory: NavEntryTestFlowComponent.ParentComponent,
+              factory: NavEntryTestFlowComponent.Factory,
               savedStateHandle: SavedStateHandle,
               arguments: Bundle
             ) : ViewModel() {
@@ -80,8 +80,8 @@ internal class NavEntryFileGeneratorTest {
 
               private val scope: CoroutineScope = MainScope()
 
-              public val component: NavEntryTestFlowComponent =
-                  factory.getNavEntryTestFlowComponent().create(savedStateHandle, arguments, disposable, scope)
+              public val component: NavEntryTestFlowComponent = factory.create(savedStateHandle, arguments,
+                  disposable, scope)
 
               public override fun onCleared(): Unit {
                 disposable.clear()
@@ -103,9 +103,9 @@ internal class NavEntryFileGeneratorTest {
               public override fun retrieve(findEntry: (Int) -> NavBackStackEntry, context: Context): Any {
                 val entry = findEntry(id)
                 val viewModelProvider = viewModelProvider<NavEntryTestFlowComponent.ParentComponent>(entry,
-                    context, TestParentScope::class) { component, handle -> 
+                    context, TestParentScope::class) { parentComponent, handle -> 
                   val arguments = entry.arguments ?: Bundle.EMPTY
-                  TestFlowViewModel(component, handle, arguments)
+                  TestFlowViewModel(parentComponent.factory, handle, arguments)
                 }
                 val viewModel = viewModelProvider[TestFlowViewModel::class.java]
                 return viewModel.component
@@ -163,20 +163,20 @@ internal class NavEntryFileGeneratorTest {
 
               @ContributesTo(TestParentScope::class)
               public interface ParentComponent {
-                public fun getNavEntryTestFlowComponent(): Factory
+                public fun factory(): Factory
               }
             }
 
             @InternalWhetstoneApi
             internal class TestFlowViewModel(
-              factory: NavEntryTestFlowComponent.ParentComponent,
+              factory: NavEntryTestFlowComponent.Factory,
               savedStateHandle: SavedStateHandle,
               arguments: Bundle
             ) : ViewModel() {
               private val disposable: CompositeDisposable = CompositeDisposable()
 
-              public val component: NavEntryTestFlowComponent =
-                  factory.getNavEntryTestFlowComponent().create(savedStateHandle, arguments, disposable)
+              public val component: NavEntryTestFlowComponent = factory.create(savedStateHandle, arguments,
+                  disposable)
 
               public override fun onCleared(): Unit {
                 disposable.clear()
@@ -197,9 +197,9 @@ internal class NavEntryFileGeneratorTest {
               public override fun retrieve(findEntry: (Int) -> NavBackStackEntry, context: Context): Any {
                 val entry = findEntry(id)
                 val viewModelProvider = viewModelProvider<NavEntryTestFlowComponent.ParentComponent>(entry,
-                    context, TestParentScope::class) { component, handle -> 
+                    context, TestParentScope::class) { parentComponent, handle -> 
                   val arguments = entry.arguments ?: Bundle.EMPTY
-                  TestFlowViewModel(component, handle, arguments)
+                  TestFlowViewModel(parentComponent.factory, handle, arguments)
                 }
                 val viewModel = viewModelProvider[TestFlowViewModel::class.java]
                 return viewModel.component
@@ -259,20 +259,20 @@ internal class NavEntryFileGeneratorTest {
 
               @ContributesTo(TestParentScope::class)
               public interface ParentComponent {
-                public fun getNavEntryTestFlowComponent(): Factory
+                public fun factory(): Factory
               }
             }
 
             @InternalWhetstoneApi
             internal class TestFlowViewModel(
-              factory: NavEntryTestFlowComponent.ParentComponent,
+              factory: NavEntryTestFlowComponent.Factory,
               savedStateHandle: SavedStateHandle,
               arguments: Bundle
             ) : ViewModel() {
               private val scope: CoroutineScope = MainScope()
 
-              public val component: NavEntryTestFlowComponent =
-                  factory.getNavEntryTestFlowComponent().create(savedStateHandle, arguments, scope)
+              public val component: NavEntryTestFlowComponent = factory.create(savedStateHandle, arguments,
+                  scope)
 
               public override fun onCleared(): Unit {
                 scope.cancel()
@@ -293,9 +293,9 @@ internal class NavEntryFileGeneratorTest {
               public override fun retrieve(findEntry: (Int) -> NavBackStackEntry, context: Context): Any {
                 val entry = findEntry(id)
                 val viewModelProvider = viewModelProvider<NavEntryTestFlowComponent.ParentComponent>(entry,
-                    context, TestParentScope::class) { component, handle -> 
+                    context, TestParentScope::class) { parentComponent, handle -> 
                   val arguments = entry.arguments ?: Bundle.EMPTY
-                  TestFlowViewModel(component, handle, arguments)
+                  TestFlowViewModel(parentComponent.factory, handle, arguments)
                 }
                 val viewModel = viewModelProvider[TestFlowViewModel::class.java]
                 return viewModel.component


### PR DESCRIPTION
- changes the name of the method inside `ParentComponent` to `factory` because that is what it returns
- the view model holds the factory instead of the parent component
- improved naming in the code that obtains the view model