### PR TITLE
read channels in a cold flow to avoid dropping events

### DIFF
--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.receiveAsFlow
 
 /**
@@ -42,7 +43,11 @@ public open class NavEventNavigator {
      * A [Flow] to collect [NavEvents][NavEvent] produced by this navigator.
      */
     @VisibleForTesting(otherwise = PACKAGE_PRIVATE)
-    public val navEvents: Flow<NavEvent> = _navEvents.receiveAsFlow()
+    public val navEvents: Flow<NavEvent> = flow {
+        for (result in _navEvents) {
+            emit(result)
+        }
+    }
 
     private val _activityResultRequests = mutableListOf<ActivityResultRequest<*, *>>()
     private val _permissionsResultRequests = mutableListOf<PermissionsResultRequest>()

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/ResultOwner.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/ResultOwner.kt
@@ -13,8 +13,11 @@ import com.freeletics.mad.navigator.PermissionsResultRequest.PermissionResult.DE
 import com.freeletics.mad.navigator.PermissionsResultRequest.PermissionResult.GRANTED
 import com.freeletics.mad.navigator.internal.InternalNavigatorApi
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.receiveAsFlow
 
 /**
@@ -28,7 +31,11 @@ public sealed class ResultOwner<O> {
      * Emits any result passed to [onResult]. Results will only be delivered
      * to one collector at a time.
      */
-    public val results: Flow<O> = _results.receiveAsFlow()
+    public val results: Flow<O> = flow {
+        for (result in _results) {
+            emit(result)
+        }
+    }
 
     /**
      * Deliver a new [result] to [results]. This method should be called by a


### PR DESCRIPTION
`receiveAsFlow()`  creates a hot flow which means that results and events that are added to channel while no one is collection the flow are lost. This is mostly an issue for results which are often delivered before the results are collected. The iterator from channel handles cancellation while we wait for the next item to be added while it's empty