### PR TITLE
move @NavEntryComponent to other annotations, use route to get id

### DIFF
--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/Data.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/Data.kt
@@ -39,11 +39,13 @@ internal sealed interface Navigation {
     val destinationClass: ClassName
     val destinationScope: ClassName
     val destinationMethod: MemberName?
+    val navEntryData: NavEntryData?
 
     data class Compose(
         override val route: ClassName,
         private val destinationType: String,
         override val destinationScope: ClassName,
+        override val navEntryData: NavEntryData?,
     ) : Navigation {
         override val destinationClass: ClassName = composeDestination
 
@@ -60,6 +62,7 @@ internal sealed interface Navigation {
         override val route: ClassName,
         private val destinationType: String,
         override val destinationScope: ClassName,
+        override val navEntryData: NavEntryData?,
     ) : Navigation {
         override val destinationClass: ClassName = fragmentDestination
 
@@ -128,13 +131,17 @@ internal data class RendererFragmentData(
 ) : FragmentCommonData
 
 internal data class NavEntryData(
-    override val baseName: String,
     override val packageName: String,
 
     val scope: ClassName,
 
     val parentScope: ClassName,
+    val destinationScope: ClassName,
+
+    val route: ClassName,
 
     val coroutinesEnabled: Boolean,
     val rxJavaEnabled: Boolean,
-): BaseData
+): BaseData {
+    override val baseName: String = scope.simpleName
+}

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/FileGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/FileGenerator.kt
@@ -1,5 +1,6 @@
 package com.freeletics.mad.whetstone.codegen
 
+import com.freeletics.mad.whetstone.CommonData
 import com.freeletics.mad.whetstone.ComposeFragmentData
 import com.freeletics.mad.whetstone.ComposeScreenData
 import com.freeletics.mad.whetstone.NavEntryData
@@ -23,18 +24,14 @@ internal class FileGenerator{
         val viewModelGenerator = ViewModelGenerator(data)
         val composeScreenGenerator = ComposeScreenGenerator(data)
         val composeGenerator = ComposeGenerator(data)
-        val navDestinationGenerator = NavDestinationModuleGenerator(data)
 
         return FileSpec.builder(data.packageName, "Whetstone${data.baseName}")
             .addType(retainedComponentGenerator.generate())
             .addType(viewModelGenerator.generate())
             .addFunction(composeScreenGenerator.generate())
             .addFunction(composeGenerator.generate())
-            .also {
-                if (data.navigation?.destinationMethod != null) {
-                    it.addType(navDestinationGenerator.generate())
-                }
-            }
+            .addNavDestinationType(data)
+            .addNavEntryTypes(data.navigation?.navEntryData)
             .build()
     }
 
@@ -43,18 +40,14 @@ internal class FileGenerator{
         val viewModelGenerator = ViewModelGenerator(data)
         val composeFragmentGenerator = ComposeFragmentGenerator(data)
         val composeGenerator = ComposeGenerator(data)
-        val navDestinationGenerator = NavDestinationModuleGenerator(data)
 
         return FileSpec.builder(data.packageName, "Whetstone${data.baseName}")
             .addType(retainedComponentGenerator.generate())
             .addType(viewModelGenerator.generate())
             .addType(composeFragmentGenerator.generate())
             .addFunction(composeGenerator.generate())
-            .also {
-                if (data.navigation?.destinationMethod != null) {
-                    it.addType(navDestinationGenerator.generate())
-                }
-            }
+            .addNavDestinationType(data)
+            .addNavEntryTypes(data.navigation?.navEntryData)
             .build()
     }
 
@@ -62,29 +55,39 @@ internal class FileGenerator{
         val retainedComponentGenerator = RetainedComponentGenerator(data)
         val viewModelGenerator = ViewModelGenerator(data)
         val rendererFragmentGenerator = RendererFragmentGenerator(data)
-        val navDestinationGenerator = NavDestinationModuleGenerator(data)
 
         return FileSpec.builder(data.packageName, "Whetstone${data.baseName}")
             .addType(retainedComponentGenerator.generate())
             .addType(viewModelGenerator.generate())
             .addType(rendererFragmentGenerator.generate())
-            .also {
-                if (data.navigation?.destinationMethod != null) {
-                    it.addType(navDestinationGenerator.generate())
-                }
-            }
+            .addNavDestinationType(data)
+            .addNavEntryTypes(data.navigation?.navEntryData)
             .build()
     }
 
-    fun generate(data: NavEntryData): FileSpec {
-        val subcomponentGenerator = NavEntrySubcomponentGenerator(data)
-        val viewModelGenerator = NavEntryViewModelGenerator(data)
-        val componentGetterGenerator = NavEntryComponentGetterGenerator(data)
+    private fun FileSpec.Builder.addNavDestinationType(data: CommonData) = apply {
+        if (data.navigation?.destinationMethod != null) {
+            val navDestinationGenerator = NavDestinationModuleGenerator(data)
+            addType(navDestinationGenerator.generate())
+        }
+    }
 
+    private fun FileSpec.Builder.addNavEntryTypes(data: NavEntryData?) = apply {
+        if (data != null) {
+            val subcomponentGenerator = NavEntrySubcomponentGenerator(data)
+            val viewModelGenerator = NavEntryViewModelGenerator(data)
+            val componentGetterGenerator = NavEntryComponentGetterGenerator(data)
+
+            addType(subcomponentGenerator.generate())
+            addType(viewModelGenerator.generate())
+            addType(componentGetterGenerator.generate())
+        }
+    }
+
+    // for testing
+    internal fun generate(data: NavEntryData): FileSpec {
         return FileSpec.builder(data.packageName, "WhetstoneNavEntry${data.baseName}")
-            .addType(subcomponentGenerator.generate())
-            .addType(viewModelGenerator.generate())
-            .addType(componentGetterGenerator.generate())
+            .addNavEntryTypes(data)
             .build()
     }
 }

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/naventry/NavEntryComponentGetterGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/naventry/NavEntryComponentGetterGenerator.kt
@@ -7,6 +7,7 @@ import com.freeletics.mad.whetstone.codegen.util.context
 import com.freeletics.mad.whetstone.codegen.util.destinationId
 import com.freeletics.mad.whetstone.codegen.util.inject
 import com.freeletics.mad.whetstone.codegen.util.internalNavigatorApi
+import com.freeletics.mad.whetstone.codegen.util.internalWhetstoneApi
 import com.freeletics.mad.whetstone.codegen.util.navBackStackEntry
 import com.freeletics.mad.whetstone.codegen.util.navEntryComponentGetter
 import com.freeletics.mad.whetstone.codegen.util.navEntryComponentGetterKey
@@ -66,8 +67,7 @@ internal class NavEntryComponentGetterGenerator(
     private fun retrieveFunction(): FunSpec {
         return FunSpec.builder("retrieve")
             .addModifiers(OVERRIDE)
-            .addAnnotation(optInAnnotation())
-            .addAnnotation(optInAnnotation(internalNavigatorApi))
+            .addAnnotation(optInAnnotation(internalWhetstoneApi, internalNavigatorApi))
             .addParameter("findEntry", LambdaTypeName.get(parameters = arrayOf(INT), returnType = navBackStackEntry))
             .addParameter("context", context)
             .returns(ANY)

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/naventry/NavEntryComponentGetterGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/naventry/NavEntryComponentGetterGenerator.kt
@@ -4,7 +4,9 @@ import com.freeletics.mad.whetstone.NavEntryData
 import com.freeletics.mad.whetstone.codegen.Generator
 import com.freeletics.mad.whetstone.codegen.util.bundle
 import com.freeletics.mad.whetstone.codegen.util.context
+import com.freeletics.mad.whetstone.codegen.util.destinationId
 import com.freeletics.mad.whetstone.codegen.util.inject
+import com.freeletics.mad.whetstone.codegen.util.internalNavigatorApi
 import com.freeletics.mad.whetstone.codegen.util.navBackStackEntry
 import com.freeletics.mad.whetstone.codegen.util.navEntryComponentGetter
 import com.freeletics.mad.whetstone.codegen.util.navEntryComponentGetterKey
@@ -38,7 +40,6 @@ internal class NavEntryComponentGetterGenerator(
             .addAnnotation(contributesMultibindingAnnotation())
             .addSuperinterface(navEntryComponentGetter)
             .primaryConstructor(ctor())
-            .addProperty(idProperty())
             .addFunction(retrieveFunction())
             .build()
     }
@@ -51,27 +52,14 @@ internal class NavEntryComponentGetterGenerator(
 
     private fun contributesMultibindingAnnotation(): AnnotationSpec {
         return AnnotationSpec.builder(ContributesMultibinding::class)
-            .addMember("%T::class", data.parentScope)
+            .addMember("%T::class", data.destinationScope)
             .addMember("%T::class", navEntryComponentGetter)
             .build()
     }
 
     private fun ctor(): FunSpec {
-        val scopeIdAnnoation = AnnotationSpec.builder(navEntryIdScope)
-            .addMember("%T::class", data.scope)
-            .build()
-        val parameter = ParameterSpec.builder("id", INT)
-            .addAnnotation(scopeIdAnnoation)
-            .build()
         return FunSpec.constructorBuilder()
             .addAnnotation(inject)
-            .addParameter(parameter)
-            .build()
-    }
-
-    private fun idProperty(): PropertySpec {
-        return PropertySpec.builder("id", INT, PRIVATE)
-            .initializer("id")
             .build()
     }
 
@@ -79,10 +67,11 @@ internal class NavEntryComponentGetterGenerator(
         return FunSpec.builder("retrieve")
             .addModifiers(OVERRIDE)
             .addAnnotation(optInAnnotation())
+            .addAnnotation(optInAnnotation(internalNavigatorApi))
             .addParameter("findEntry", LambdaTypeName.get(parameters = arrayOf(INT), returnType = navBackStackEntry))
             .addParameter("context", context)
             .returns(ANY)
-            .addStatement("val entry = findEntry(id)")
+            .addStatement("val entry = findEntry(%T::class.%M())", data.route, destinationId)
             .beginControlFlow("val viewModelProvider = %M<%T>(entry, context, %T::class) { parentComponent, handle -> ",
                 navEntryViewModelProvider, navEntryParentComponentClassName, data.parentScope)
             // arguments: external method

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
@@ -46,6 +46,8 @@ internal val fragmentDestination = ClassName("com.freeletics.mad.navigator.fragm
 internal val fragmentScreenDestination = MemberName("com.freeletics.mad.navigator.fragment", "ScreenDestination")
 internal val fragmentDialogDestination = MemberName("com.freeletics.mad.navigator.fragment", "DialogDestination")
 internal val requireRoute = MemberName("com.freeletics.mad.navigator.fragment", "requireRoute")
+internal val destinationId = MemberName("com.freeletics.mad.navigator.internal", "destinationId")
+internal val internalNavigatorApi = ClassName("com.freeletics.mad.navigator.internal", "InternalNavigatorApi")
 
 // Renderer
 internal val rendererConnect = MemberName("com.gabrielittner.renderer.connect", "connect")

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/KotlinPoet.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/KotlinPoet.kt
@@ -84,8 +84,12 @@ internal fun internalApiAnnotation(): AnnotationSpec {
 }
 
 internal fun optInAnnotation(): AnnotationSpec {
+    return optInAnnotation(internalWhetstoneApi)
+}
+
+internal fun optInAnnotation(className: ClassName): AnnotationSpec {
     return AnnotationSpec.builder(optIn)
-        .addMember("%T::class", internalWhetstoneApi)
+        .addMember("%T::class", className)
         .build()
 }
 

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/KotlinPoet.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/KotlinPoet.kt
@@ -87,9 +87,16 @@ internal fun optInAnnotation(): AnnotationSpec {
     return optInAnnotation(internalWhetstoneApi)
 }
 
-internal fun optInAnnotation(className: ClassName): AnnotationSpec {
+internal fun optInAnnotation(vararg classNames: ClassName): AnnotationSpec {
+    val member = CodeBlock.builder()
+    classNames.forEachIndexed { index, className ->
+        if (index > 0) {
+            member.add(", ")
+        }
+        member.add("%T::class", className)
+    }
     return AnnotationSpec.builder(optIn)
-        .addMember("%T::class", className)
+        .addMember(member.build())
         .build()
 }
 

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
@@ -9,9 +9,10 @@ import org.junit.Test
 internal class FileGeneratorTestCompose {
 
     private val navigation = Navigation.Compose(
-        ClassName("com.test", "TestRoute"),
-        "NONE",
-        ClassName("com.test.destination", "TestDestinationScope"),
+        route = ClassName("com.test", "TestRoute"),
+        destinationType = "NONE",
+        destinationScope = ClassName("com.test.destination", "TestDestinationScope"),
+        navEntryData = null,
     )
 
     private val full = ComposeScreenData(

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
@@ -11,9 +11,10 @@ import org.junit.Test
 internal class FileGeneratorTestComposeFragment {
 
     private val navigation = Navigation.Fragment(
-        ClassName("com.test", "TestRoute"),
-        "NONE",
-        ClassName("com.test.destination", "TestDestinationScope"),
+        route = ClassName("com.test", "TestRoute"),
+        destinationType = "NONE",
+        destinationScope = ClassName("com.test.destination", "TestDestinationScope"),
+        navEntryData = null,
     )
 
     private val full = ComposeFragmentData(

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestRendererFragment.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestRendererFragment.kt
@@ -9,9 +9,10 @@ import org.junit.Test
 internal class FileGeneratorTestRendererFragment {
 
     private val navigation = Navigation.Fragment(
-        ClassName("com.test", "TestRoute"),
-        "NONE",
-        ClassName("com.test.destination", "TestDestinationScope"),
+        route = ClassName("com.test", "TestRoute"),
+        destinationType = "NONE",
+        destinationScope = ClassName("com.test.destination", "TestDestinationScope"),
+        navEntryData = null,
     )
 
     private val full = RendererFragmentData(

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/NavEntryFileGeneratorTest.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/NavEntryFileGeneratorTest.kt
@@ -98,8 +98,7 @@ internal class NavEntryFileGeneratorTest {
               NavEntryComponentGetter::class
             )
             public class TestFlowScopeComponentGetter @Inject constructor() : NavEntryComponentGetter {
-              @OptIn(InternalWhetstoneApi::class)
-              @OptIn(InternalNavigatorApi::class)
+              @OptIn(InternalWhetstoneApi::class, InternalNavigatorApi::class)
               public override fun retrieve(findEntry: (Int) -> NavBackStackEntry, context: Context): Any {
                 val entry = findEntry(TestRoute::class.destinationId())
                 val viewModelProvider = viewModelProvider<NavEntryTestFlowScopeComponent.ParentComponent>(entry,
@@ -191,8 +190,7 @@ internal class NavEntryFileGeneratorTest {
               NavEntryComponentGetter::class
             )
             public class TestFlowScopeComponentGetter @Inject constructor() : NavEntryComponentGetter {
-              @OptIn(InternalWhetstoneApi::class)
-              @OptIn(InternalNavigatorApi::class)
+              @OptIn(InternalWhetstoneApi::class, InternalNavigatorApi::class)
               public override fun retrieve(findEntry: (Int) -> NavBackStackEntry, context: Context): Any {
                 val entry = findEntry(TestRoute::class.destinationId())
                 val viewModelProvider = viewModelProvider<NavEntryTestFlowScopeComponent.ParentComponent>(entry,
@@ -286,8 +284,7 @@ internal class NavEntryFileGeneratorTest {
               NavEntryComponentGetter::class
             )
             public class TestFlowScopeComponentGetter @Inject constructor() : NavEntryComponentGetter {
-              @OptIn(InternalWhetstoneApi::class)
-              @OptIn(InternalNavigatorApi::class)
+              @OptIn(InternalWhetstoneApi::class, InternalNavigatorApi::class)
               public override fun retrieve(findEntry: (Int) -> NavBackStackEntry, context: Context): Any {
                 val entry = findEntry(TestRoute::class.destinationId())
                 val viewModelProvider = viewModelProvider<NavEntryTestFlowScopeComponent.ParentComponent>(entry,

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/NavEntryFileGeneratorTest.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/NavEntryFileGeneratorTest.kt
@@ -8,10 +8,11 @@ import org.junit.Test
 internal class NavEntryFileGeneratorTest {
 
     private val full = NavEntryData(
-        baseName = "TestFlow",
         packageName = "com.test",
         scope = ClassName("com.test", "TestFlowScope"),
         parentScope = ClassName("com.test.parent", "TestParentScope"),
+        destinationScope = ClassName("com.test", "TestDestinationScope"),
+        route = ClassName("com.test", "TestRoute"),
         coroutinesEnabled = true,
         rxJavaEnabled = true,
     )
@@ -26,7 +27,8 @@ internal class NavEntryFileGeneratorTest {
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
             import androidx.navigation.NavBackStackEntry
-            import com.freeletics.mad.whetstone.NavEntryId
+            import com.freeletics.mad.navigator.`internal`.InternalNavigatorApi
+            import com.freeletics.mad.navigator.`internal`.destinationId
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetter
@@ -53,7 +55,7 @@ internal class NavEntryFileGeneratorTest {
               scope = TestFlowScope::class,
               parentScope = TestParentScope::class
             )
-            public interface NavEntryTestFlowComponent {
+            public interface NavEntryTestFlowScopeComponent {
               @ContributesSubcomponent.Factory
               public interface Factory {
                 public fun create(
@@ -61,7 +63,7 @@ internal class NavEntryFileGeneratorTest {
                   @BindsInstance arguments: Bundle,
                   @BindsInstance compositeDisposable: CompositeDisposable,
                   @BindsInstance coroutineScope: CoroutineScope
-                ): NavEntryTestFlowComponent
+                ): NavEntryTestFlowScopeComponent
               }
 
               @ContributesTo(TestParentScope::class)
@@ -71,8 +73,8 @@ internal class NavEntryFileGeneratorTest {
             }
 
             @InternalWhetstoneApi
-            internal class TestFlowViewModel(
-              factory: NavEntryTestFlowComponent.Factory,
+            internal class TestFlowScopeViewModel(
+              factory: NavEntryTestFlowScopeComponent.Factory,
               savedStateHandle: SavedStateHandle,
               arguments: Bundle
             ) : ViewModel() {
@@ -80,7 +82,7 @@ internal class NavEntryFileGeneratorTest {
 
               private val scope: CoroutineScope = MainScope()
 
-              public val component: NavEntryTestFlowComponent = factory.create(savedStateHandle, arguments,
+              public val component: NavEntryTestFlowScopeComponent = factory.create(savedStateHandle, arguments,
                   disposable, scope)
 
               public override fun onCleared(): Unit {
@@ -92,22 +94,20 @@ internal class NavEntryFileGeneratorTest {
             @OptIn(InternalWhetstoneApi::class)
             @NavEntryComponentGetterKey(TestFlowScope::class)
             @ContributesMultibinding(
-              TestParentScope::class,
+              TestDestinationScope::class,
               NavEntryComponentGetter::class
             )
-            public class TestFlowComponentGetter @Inject constructor(
-              @NavEntryId(TestFlowScope::class)
-              private val id: Int
-            ) : NavEntryComponentGetter {
+            public class TestFlowScopeComponentGetter @Inject constructor() : NavEntryComponentGetter {
               @OptIn(InternalWhetstoneApi::class)
+              @OptIn(InternalNavigatorApi::class)
               public override fun retrieve(findEntry: (Int) -> NavBackStackEntry, context: Context): Any {
-                val entry = findEntry(id)
-                val viewModelProvider = viewModelProvider<NavEntryTestFlowComponent.ParentComponent>(entry,
+                val entry = findEntry(TestRoute::class.destinationId())
+                val viewModelProvider = viewModelProvider<NavEntryTestFlowScopeComponent.ParentComponent>(entry,
                     context, TestParentScope::class) { parentComponent, handle -> 
                   val arguments = entry.arguments ?: Bundle.EMPTY
-                  TestFlowViewModel(parentComponent.factory, handle, arguments)
+                  TestFlowScopeViewModel(parentComponent.factory, handle, arguments)
                 }
-                val viewModel = viewModelProvider[TestFlowViewModel::class.java]
+                val viewModel = viewModelProvider[TestFlowScopeViewModel::class.java]
                 return viewModel.component
               }
             }
@@ -127,7 +127,8 @@ internal class NavEntryFileGeneratorTest {
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
             import androidx.navigation.NavBackStackEntry
-            import com.freeletics.mad.whetstone.NavEntryId
+            import com.freeletics.mad.navigator.`internal`.InternalNavigatorApi
+            import com.freeletics.mad.navigator.`internal`.destinationId
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetter
@@ -151,14 +152,14 @@ internal class NavEntryFileGeneratorTest {
               scope = TestFlowScope::class,
               parentScope = TestParentScope::class
             )
-            public interface NavEntryTestFlowComponent {
+            public interface NavEntryTestFlowScopeComponent {
               @ContributesSubcomponent.Factory
               public interface Factory {
                 public fun create(
                   @BindsInstance savedStateHandle: SavedStateHandle,
                   @BindsInstance arguments: Bundle,
                   @BindsInstance compositeDisposable: CompositeDisposable
-                ): NavEntryTestFlowComponent
+                ): NavEntryTestFlowScopeComponent
               }
 
               @ContributesTo(TestParentScope::class)
@@ -168,14 +169,14 @@ internal class NavEntryFileGeneratorTest {
             }
 
             @InternalWhetstoneApi
-            internal class TestFlowViewModel(
-              factory: NavEntryTestFlowComponent.Factory,
+            internal class TestFlowScopeViewModel(
+              factory: NavEntryTestFlowScopeComponent.Factory,
               savedStateHandle: SavedStateHandle,
               arguments: Bundle
             ) : ViewModel() {
               private val disposable: CompositeDisposable = CompositeDisposable()
 
-              public val component: NavEntryTestFlowComponent = factory.create(savedStateHandle, arguments,
+              public val component: NavEntryTestFlowScopeComponent = factory.create(savedStateHandle, arguments,
                   disposable)
 
               public override fun onCleared(): Unit {
@@ -186,22 +187,20 @@ internal class NavEntryFileGeneratorTest {
             @OptIn(InternalWhetstoneApi::class)
             @NavEntryComponentGetterKey(TestFlowScope::class)
             @ContributesMultibinding(
-              TestParentScope::class,
+              TestDestinationScope::class,
               NavEntryComponentGetter::class
             )
-            public class TestFlowComponentGetter @Inject constructor(
-              @NavEntryId(TestFlowScope::class)
-              private val id: Int
-            ) : NavEntryComponentGetter {
+            public class TestFlowScopeComponentGetter @Inject constructor() : NavEntryComponentGetter {
               @OptIn(InternalWhetstoneApi::class)
+              @OptIn(InternalNavigatorApi::class)
               public override fun retrieve(findEntry: (Int) -> NavBackStackEntry, context: Context): Any {
-                val entry = findEntry(id)
-                val viewModelProvider = viewModelProvider<NavEntryTestFlowComponent.ParentComponent>(entry,
+                val entry = findEntry(TestRoute::class.destinationId())
+                val viewModelProvider = viewModelProvider<NavEntryTestFlowScopeComponent.ParentComponent>(entry,
                     context, TestParentScope::class) { parentComponent, handle -> 
                   val arguments = entry.arguments ?: Bundle.EMPTY
-                  TestFlowViewModel(parentComponent.factory, handle, arguments)
+                  TestFlowScopeViewModel(parentComponent.factory, handle, arguments)
                 }
-                val viewModel = viewModelProvider[TestFlowViewModel::class.java]
+                val viewModel = viewModelProvider[TestFlowScopeViewModel::class.java]
                 return viewModel.component
               }
             }
@@ -221,7 +220,8 @@ internal class NavEntryFileGeneratorTest {
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
             import androidx.navigation.NavBackStackEntry
-            import com.freeletics.mad.whetstone.NavEntryId
+            import com.freeletics.mad.navigator.`internal`.InternalNavigatorApi
+            import com.freeletics.mad.navigator.`internal`.destinationId
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetter
@@ -247,14 +247,14 @@ internal class NavEntryFileGeneratorTest {
               scope = TestFlowScope::class,
               parentScope = TestParentScope::class
             )
-            public interface NavEntryTestFlowComponent {
+            public interface NavEntryTestFlowScopeComponent {
               @ContributesSubcomponent.Factory
               public interface Factory {
                 public fun create(
                   @BindsInstance savedStateHandle: SavedStateHandle,
                   @BindsInstance arguments: Bundle,
                   @BindsInstance coroutineScope: CoroutineScope
-                ): NavEntryTestFlowComponent
+                ): NavEntryTestFlowScopeComponent
               }
 
               @ContributesTo(TestParentScope::class)
@@ -264,14 +264,14 @@ internal class NavEntryFileGeneratorTest {
             }
 
             @InternalWhetstoneApi
-            internal class TestFlowViewModel(
-              factory: NavEntryTestFlowComponent.Factory,
+            internal class TestFlowScopeViewModel(
+              factory: NavEntryTestFlowScopeComponent.Factory,
               savedStateHandle: SavedStateHandle,
               arguments: Bundle
             ) : ViewModel() {
               private val scope: CoroutineScope = MainScope()
 
-              public val component: NavEntryTestFlowComponent = factory.create(savedStateHandle, arguments,
+              public val component: NavEntryTestFlowScopeComponent = factory.create(savedStateHandle, arguments,
                   scope)
 
               public override fun onCleared(): Unit {
@@ -282,22 +282,20 @@ internal class NavEntryFileGeneratorTest {
             @OptIn(InternalWhetstoneApi::class)
             @NavEntryComponentGetterKey(TestFlowScope::class)
             @ContributesMultibinding(
-              TestParentScope::class,
+              TestDestinationScope::class,
               NavEntryComponentGetter::class
             )
-            public class TestFlowComponentGetter @Inject constructor(
-              @NavEntryId(TestFlowScope::class)
-              private val id: Int
-            ) : NavEntryComponentGetter {
+            public class TestFlowScopeComponentGetter @Inject constructor() : NavEntryComponentGetter {
               @OptIn(InternalWhetstoneApi::class)
+              @OptIn(InternalNavigatorApi::class)
               public override fun retrieve(findEntry: (Int) -> NavBackStackEntry, context: Context): Any {
-                val entry = findEntry(id)
-                val viewModelProvider = viewModelProvider<NavEntryTestFlowComponent.ParentComponent>(entry,
+                val entry = findEntry(TestRoute::class.destinationId())
+                val viewModelProvider = viewModelProvider<NavEntryTestFlowScopeComponent.ParentComponent>(entry,
                     context, TestParentScope::class) { parentComponent, handle -> 
                   val arguments = entry.arguments ?: Bundle.EMPTY
-                  TestFlowViewModel(parentComponent.factory, handle, arguments)
+                  TestFlowScopeViewModel(parentComponent.factory, handle, arguments)
                 }
-                val viewModel = viewModelProvider[TestFlowViewModel::class.java]
+                val viewModel = viewModelProvider[TestFlowScopeViewModel::class.java]
                 return viewModel.component
               }
             }

--- a/whetstone/runtime/api/runtime.api
+++ b/whetstone/runtime/api/runtime.api
@@ -11,10 +11,6 @@ public final class com/freeletics/mad/whetstone/NavEntryComponents {
 	public final fun get (Ljava/lang/String;Landroid/content/Context;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
-public abstract interface annotation class com/freeletics/mad/whetstone/NavEntryId : java/lang/annotation/Annotation {
-	public abstract fun value ()Ljava/lang/Class;
-}
-
 public abstract interface annotation class com/freeletics/mad/whetstone/ScopeTo : java/lang/annotation/Annotation {
 	public abstract fun marker ()Ljava/lang/Class;
 }

--- a/whetstone/runtime/src/main/java/com/freeletics/mad/whetstone/NavEntryComponent.kt
+++ b/whetstone/runtime/src/main/java/com/freeletics/mad/whetstone/NavEntryComponent.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import androidx.navigation.NavBackStackEntry
 import com.freeletics.mad.whetstone.internal.NavEntryComponentGetter
 import javax.inject.Inject
-import javax.inject.Qualifier
 import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.annotation.AnnotationTarget.CLASS
 import kotlin.annotation.AnnotationTarget.FUNCTION
 import kotlin.reflect.KClass
 
@@ -43,7 +43,7 @@ import kotlin.reflect.KClass
  * It's recommended to put this annotation on the method that provides the matching [NavEntryId]
  * value.
  */
-@Target(FUNCTION)
+@Target(CLASS, FUNCTION)
 @Retention(RUNTIME)
 public annotation class NavEntryComponent(
     val scope: KClass<*>,
@@ -52,17 +52,6 @@ public annotation class NavEntryComponent(
     val coroutinesEnabled: Boolean = false,
     val rxJavaEnabled: Boolean = false,
 )
-
-/**
- * A qualifier that should be used to provide a resource id that represents an androidx.navigation
- * destination. This navigation id will be the one that a [NavEntryComponent], that uses the same
- * scope as the given [value], is tied to.
- *
- * It is recommended to put [NavEntryComponent] onto the same method that uses this qualifier
- * annotation.
- */
-@Qualifier
-public annotation class NavEntryId(val value: KClass<*>)
 
 /**
  * Class that allows to retrieve generated [NavEntryComponent] instances.
@@ -76,9 +65,8 @@ public class NavEntryComponents @Inject constructor(
      * Tries to retrieve a generated [NavEntryComponent] for the given [name], where `name` is the
      * fully qualified name of the [NavEntryComponent.scope].
      *
-     * The id that is passed as parameter to [findEntry] is the id that was provided with
-     * [NavEntryId]. The given [findEntry] should look up a back strack entry for that id
-     * in the current `NavController`.
+     * The given [findEntry] should look up a back stack entry for that id in the current
+     * `NavController`.
      */
     public fun get(name: String, context: Context, findEntry: (Int) -> NavBackStackEntry): Any? {
         return navEntryComponentGetters[name]?.retrieve(findEntry, context)

--- a/whetstone/runtime/src/main/java/com/freeletics/mad/whetstone/NavEntryComponent.kt
+++ b/whetstone/runtime/src/main/java/com/freeletics/mad/whetstone/NavEntryComponent.kt
@@ -39,9 +39,6 @@ import kotlin.reflect.KClass
  *
  * The generated component can be accessed through a `Map<Class<*>, NavEntryComponentGetter` that
  * will automatically be available in the parent component. See [NavEntryComponentGetter].
- *
- * It's recommended to put this annotation on the method that provides the matching [NavEntryId]
- * value.
  */
 @Target(CLASS, FUNCTION)
 @Retention(RUNTIME)

--- a/whetstone/runtime/src/main/java/com/freeletics/mad/whetstone/internal/NavEntryComponentGetter.kt
+++ b/whetstone/runtime/src/main/java/com/freeletics/mad/whetstone/internal/NavEntryComponentGetter.kt
@@ -3,7 +3,6 @@ package com.freeletics.mad.whetstone.internal
 import android.content.Context
 import androidx.navigation.NavBackStackEntry
 import com.freeletics.mad.whetstone.NavEntryComponent
-import com.freeletics.mad.whetstone.NavEntryId
 import dagger.MapKey
 import kotlin.reflect.KClass
 
@@ -11,14 +10,13 @@ import kotlin.reflect.KClass
  * A generated implementation of this can be used to retrieve a generated [NavEntryComponent].
  *
  * The implementation will be bound into a `Map<Class<*>, NavEntryComponentGetter>` were the key
- * is the same scope that is used in [NavEntryId] and [NavEntryComponent]. It can be used through
+ * is the same scope that is used in [NavEntryComponent]. It can be used through
  * [com.freeletics.mad.whetstone.NavEntryComponents].
  */
 @InternalWhetstoneApi
 public interface NavEntryComponentGetter {
     /**
-     * The id that is passed as parameter to [findEntry] is the id that was provided with
-     * [NavEntryId]. The given [findEntry] should look up a back strack entry for that id
+     * The given [findEntry] should look up a back strack entry for that id
      * in the current `NavController`.
      */
     public fun retrieve(findEntry: (Int) -> NavBackStackEntry, context: Context): Any


### PR DESCRIPTION
`NavEntryComponent` didn't get any updates with all the navigation route changes and it still used destination ids. Instead of putting it on an extra function the annoation now lives next to the other on the screen to which the component should be tied to.

```
@ComposeScreen(...)
@NavDestination(...)
@NavEntryComponent(...)
```

It will take the `route` and `destinationScope` from `@NavDestination` to for the code generation. The route is used automatically during the lookup of the component in the generated `NavEntryComponentGetter` and the getters are now all contributed to the destination scope which puts the map into the same component as the set of destinations. This also makes `@NavEntryId` obsolete and it was removed.

Theoretically we could use the parent scope of `@ComposeScreen` automatically as scope for the nav entry component but I like the consistency of the parameters. `destinationScope` could also serve as parent scope here (it would disallow nesting NavEntryComponents but I'm not sure if that even works right now).

Next steps:
- put an instance of the route into the generated component instead of the arguments bundle (like we already do for regular components)
- refactor the lookup so that retrieving a `NavBackStackEntry` happens internally, this would then allow us to remove our last obsolete navigation API (the one that allows to obtain the `NavController` for `getSystemService`)

