### PR TITLE
use route instead of arguments Bundle inside nav entry component

### DIFF
--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/ViewModelGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/ViewModelGenerator.kt
@@ -8,6 +8,7 @@ import com.freeletics.mad.whetstone.codegen.util.coroutineScope
 import com.freeletics.mad.whetstone.codegen.util.coroutineScopeCancel
 import com.freeletics.mad.whetstone.codegen.util.internalApiAnnotation
 import com.freeletics.mad.whetstone.codegen.util.mainScope
+import com.freeletics.mad.whetstone.codegen.util.propertyName
 import com.freeletics.mad.whetstone.codegen.util.savedStateHandle
 import com.freeletics.mad.whetstone.codegen.util.viewModel
 import com.squareup.kotlinpoet.CodeBlock

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/naventry/NavEntryComponentGetterGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/naventry/NavEntryComponentGetterGenerator.kt
@@ -14,6 +14,7 @@ import com.freeletics.mad.whetstone.codegen.util.navEntryComponentGetterKey
 import com.freeletics.mad.whetstone.codegen.util.navEntryIdScope
 import com.freeletics.mad.whetstone.codegen.util.navEntryViewModelProvider
 import com.freeletics.mad.whetstone.codegen.util.optInAnnotation
+import com.freeletics.mad.whetstone.codegen.util.toRoute
 import com.squareup.anvil.annotations.ContributesMultibinding
 import com.squareup.kotlinpoet.ANY
 import com.squareup.kotlinpoet.AnnotationSpec
@@ -75,8 +76,8 @@ internal class NavEntryComponentGetterGenerator(
             .beginControlFlow("val viewModelProvider = %M<%T>(entry, context, %T::class) { parentComponent, handle -> ",
                 navEntryViewModelProvider, navEntryParentComponentClassName, data.parentScope)
             // arguments: external method
-            .addStatement("val arguments = entry.arguments ?: %T.EMPTY", bundle)
-            .addStatement("%T(parentComponent.%L, handle, arguments)", viewModelClassName, navEntryParentComponentGetterName)
+            .addStatement("val route: %T = entry.arguments!!.%M()", data.route, toRoute)
+            .addStatement("%T(parentComponent.%L(), handle, route)", viewModelClassName, navEntryParentComponentGetterName)
             .endControlFlow()
             .addStatement("val viewModel = viewModelProvider[%T::class.java]", viewModelClassName)
             .addStatement("return viewModel.%L", viewModelComponentName)

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/naventry/NavEntrySubcomponentGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/naventry/NavEntrySubcomponentGenerator.kt
@@ -3,15 +3,17 @@ package com.freeletics.mad.whetstone.codegen.naventry
 import com.freeletics.mad.whetstone.NavEntryData
 import com.freeletics.mad.whetstone.codegen.Generator
 import com.freeletics.mad.whetstone.codegen.util.bindsInstanceParameter
-import com.freeletics.mad.whetstone.codegen.util.bundle
 import com.freeletics.mad.whetstone.codegen.util.compositeDisposable
 import com.freeletics.mad.whetstone.codegen.util.contributesToAnnotation
 import com.freeletics.mad.whetstone.codegen.util.coroutineScope
 import com.freeletics.mad.whetstone.codegen.util.internalApiAnnotation
+import com.freeletics.mad.whetstone.codegen.util.propertyName
 import com.freeletics.mad.whetstone.codegen.util.savedStateHandle
 import com.freeletics.mad.whetstone.codegen.util.scopeToAnnotation
 import com.freeletics.mad.whetstone.codegen.util.subcomponentAnnotation
 import com.freeletics.mad.whetstone.codegen.util.subcomponentFactoryAnnotation
+import com.squareup.anvil.annotations.ExperimentalAnvilApi
+import com.squareup.anvil.compiler.internal.decapitalize
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier.ABSTRACT
 import com.squareup.kotlinpoet.TypeSpec
@@ -27,7 +29,9 @@ internal const val navEntrySubcomponentFactoryCreateName = "create"
 internal val Generator<NavEntryData>.navEntryParentComponentClassName
     get() = navEntrySubcomponentClassName.nestedClass("ParentComponent")
 
-internal val navEntryParentComponentGetterName get() = "factory"
+@OptIn(ExperimentalAnvilApi::class)
+internal val Generator<NavEntryData>.navEntryParentComponentGetterName
+    get() = "${navEntrySubcomponentClassName.simpleName.decapitalize()}Factory"
 
 internal class NavEntrySubcomponentGenerator(
     override val data: NavEntryData,
@@ -47,7 +51,7 @@ internal class NavEntrySubcomponentGenerator(
         val createFun = FunSpec.builder(navEntrySubcomponentFactoryCreateName)
             .addModifiers(ABSTRACT)
             .addParameter(bindsInstanceParameter("savedStateHandle", savedStateHandle))
-            .addParameter(bindsInstanceParameter("arguments", bundle))
+            .addParameter(bindsInstanceParameter(data.route.propertyName, data.route))
             .apply {
                 if (data.rxJavaEnabled) {
                     addParameter(bindsInstanceParameter("compositeDisposable", compositeDisposable))

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
@@ -47,6 +47,7 @@ internal val fragmentScreenDestination = MemberName("com.freeletics.mad.navigato
 internal val fragmentDialogDestination = MemberName("com.freeletics.mad.navigator.fragment", "DialogDestination")
 internal val requireRoute = MemberName("com.freeletics.mad.navigator.fragment", "requireRoute")
 internal val destinationId = MemberName("com.freeletics.mad.navigator.internal", "destinationId")
+internal val toRoute = MemberName("com.freeletics.mad.navigator.internal", "toRoute")
 internal val internalNavigatorApi = ClassName("com.freeletics.mad.navigator.internal", "InternalNavigatorApi")
 
 // Renderer

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/NavEntryFileGeneratorTest.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/NavEntryFileGeneratorTest.kt
@@ -23,12 +23,12 @@ internal class NavEntryFileGeneratorTest {
             package com.test
 
             import android.content.Context
-            import android.os.Bundle
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
             import androidx.navigation.NavBackStackEntry
             import com.freeletics.mad.navigator.`internal`.InternalNavigatorApi
             import com.freeletics.mad.navigator.`internal`.destinationId
+            import com.freeletics.mad.navigator.`internal`.toRoute
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetter
@@ -60,7 +60,7 @@ internal class NavEntryFileGeneratorTest {
               public interface Factory {
                 public fun create(
                   @BindsInstance savedStateHandle: SavedStateHandle,
-                  @BindsInstance arguments: Bundle,
+                  @BindsInstance testRoute: TestRoute,
                   @BindsInstance compositeDisposable: CompositeDisposable,
                   @BindsInstance coroutineScope: CoroutineScope
                 ): NavEntryTestFlowScopeComponent
@@ -68,7 +68,7 @@ internal class NavEntryFileGeneratorTest {
 
               @ContributesTo(TestParentScope::class)
               public interface ParentComponent {
-                public fun factory(): Factory
+                public fun navEntryTestFlowScopeComponentFactory(): Factory
               }
             }
 
@@ -76,13 +76,13 @@ internal class NavEntryFileGeneratorTest {
             internal class TestFlowScopeViewModel(
               factory: NavEntryTestFlowScopeComponent.Factory,
               savedStateHandle: SavedStateHandle,
-              arguments: Bundle
+              testRoute: TestRoute
             ) : ViewModel() {
               private val disposable: CompositeDisposable = CompositeDisposable()
 
               private val scope: CoroutineScope = MainScope()
 
-              public val component: NavEntryTestFlowScopeComponent = factory.create(savedStateHandle, arguments,
+              public val component: NavEntryTestFlowScopeComponent = factory.create(savedStateHandle, testRoute,
                   disposable, scope)
 
               public override fun onCleared(): Unit {
@@ -103,8 +103,8 @@ internal class NavEntryFileGeneratorTest {
                 val entry = findEntry(TestRoute::class.destinationId())
                 val viewModelProvider = viewModelProvider<NavEntryTestFlowScopeComponent.ParentComponent>(entry,
                     context, TestParentScope::class) { parentComponent, handle -> 
-                  val arguments = entry.arguments ?: Bundle.EMPTY
-                  TestFlowScopeViewModel(parentComponent.factory, handle, arguments)
+                  val route: TestRoute = entry.arguments!!.toRoute()
+                  TestFlowScopeViewModel(parentComponent.navEntryTestFlowScopeComponentFactory(), handle, route)
                 }
                 val viewModel = viewModelProvider[TestFlowScopeViewModel::class.java]
                 return viewModel.component
@@ -122,12 +122,12 @@ internal class NavEntryFileGeneratorTest {
             package com.test
 
             import android.content.Context
-            import android.os.Bundle
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
             import androidx.navigation.NavBackStackEntry
             import com.freeletics.mad.navigator.`internal`.InternalNavigatorApi
             import com.freeletics.mad.navigator.`internal`.destinationId
+            import com.freeletics.mad.navigator.`internal`.toRoute
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetter
@@ -156,14 +156,14 @@ internal class NavEntryFileGeneratorTest {
               public interface Factory {
                 public fun create(
                   @BindsInstance savedStateHandle: SavedStateHandle,
-                  @BindsInstance arguments: Bundle,
+                  @BindsInstance testRoute: TestRoute,
                   @BindsInstance compositeDisposable: CompositeDisposable
                 ): NavEntryTestFlowScopeComponent
               }
 
               @ContributesTo(TestParentScope::class)
               public interface ParentComponent {
-                public fun factory(): Factory
+                public fun navEntryTestFlowScopeComponentFactory(): Factory
               }
             }
 
@@ -171,11 +171,11 @@ internal class NavEntryFileGeneratorTest {
             internal class TestFlowScopeViewModel(
               factory: NavEntryTestFlowScopeComponent.Factory,
               savedStateHandle: SavedStateHandle,
-              arguments: Bundle
+              testRoute: TestRoute
             ) : ViewModel() {
               private val disposable: CompositeDisposable = CompositeDisposable()
 
-              public val component: NavEntryTestFlowScopeComponent = factory.create(savedStateHandle, arguments,
+              public val component: NavEntryTestFlowScopeComponent = factory.create(savedStateHandle, testRoute,
                   disposable)
 
               public override fun onCleared(): Unit {
@@ -195,8 +195,8 @@ internal class NavEntryFileGeneratorTest {
                 val entry = findEntry(TestRoute::class.destinationId())
                 val viewModelProvider = viewModelProvider<NavEntryTestFlowScopeComponent.ParentComponent>(entry,
                     context, TestParentScope::class) { parentComponent, handle -> 
-                  val arguments = entry.arguments ?: Bundle.EMPTY
-                  TestFlowScopeViewModel(parentComponent.factory, handle, arguments)
+                  val route: TestRoute = entry.arguments!!.toRoute()
+                  TestFlowScopeViewModel(parentComponent.navEntryTestFlowScopeComponentFactory(), handle, route)
                 }
                 val viewModel = viewModelProvider[TestFlowScopeViewModel::class.java]
                 return viewModel.component
@@ -214,12 +214,12 @@ internal class NavEntryFileGeneratorTest {
             package com.test
 
             import android.content.Context
-            import android.os.Bundle
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
             import androidx.navigation.NavBackStackEntry
             import com.freeletics.mad.navigator.`internal`.InternalNavigatorApi
             import com.freeletics.mad.navigator.`internal`.destinationId
+            import com.freeletics.mad.navigator.`internal`.toRoute
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetter
@@ -250,14 +250,14 @@ internal class NavEntryFileGeneratorTest {
               public interface Factory {
                 public fun create(
                   @BindsInstance savedStateHandle: SavedStateHandle,
-                  @BindsInstance arguments: Bundle,
+                  @BindsInstance testRoute: TestRoute,
                   @BindsInstance coroutineScope: CoroutineScope
                 ): NavEntryTestFlowScopeComponent
               }
 
               @ContributesTo(TestParentScope::class)
               public interface ParentComponent {
-                public fun factory(): Factory
+                public fun navEntryTestFlowScopeComponentFactory(): Factory
               }
             }
 
@@ -265,11 +265,11 @@ internal class NavEntryFileGeneratorTest {
             internal class TestFlowScopeViewModel(
               factory: NavEntryTestFlowScopeComponent.Factory,
               savedStateHandle: SavedStateHandle,
-              arguments: Bundle
+              testRoute: TestRoute
             ) : ViewModel() {
               private val scope: CoroutineScope = MainScope()
 
-              public val component: NavEntryTestFlowScopeComponent = factory.create(savedStateHandle, arguments,
+              public val component: NavEntryTestFlowScopeComponent = factory.create(savedStateHandle, testRoute,
                   scope)
 
               public override fun onCleared(): Unit {
@@ -289,8 +289,8 @@ internal class NavEntryFileGeneratorTest {
                 val entry = findEntry(TestRoute::class.destinationId())
                 val viewModelProvider = viewModelProvider<NavEntryTestFlowScopeComponent.ParentComponent>(entry,
                     context, TestParentScope::class) { parentComponent, handle -> 
-                  val arguments = entry.arguments ?: Bundle.EMPTY
-                  TestFlowScopeViewModel(parentComponent.factory, handle, arguments)
+                  val route: TestRoute = entry.arguments!!.toRoute()
+                  TestFlowScopeViewModel(parentComponent.navEntryTestFlowScopeComponentFactory(), handle, route)
                 }
                 val viewModel = viewModelProvider[TestFlowScopeViewModel::class.java]
                 return viewModel.component


### PR DESCRIPTION
We do the same already for retained components, instead of passing the arguments bundle to the component we now pass the route class obtained from the bundle.

Also makes a small change to the generated `factory` method inside `ParentComponent`. It needs to be unique because Anvil will merge all these interfaces in the end.