### PR TITLE
refactor dependency lookup

### DIFF
--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/compose/ComposeScreenGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/compose/ComposeScreenGenerator.kt
@@ -1,26 +1,19 @@
 package com.freeletics.mad.whetstone.codegen.compose
 
 import com.freeletics.mad.whetstone.CommonData
-import com.freeletics.mad.whetstone.codegen.common.providedValueSetPropertyName
 import com.freeletics.mad.whetstone.codegen.common.viewModelClassName
 import com.freeletics.mad.whetstone.codegen.common.viewModelComponentName
 import com.freeletics.mad.whetstone.codegen.Generator
 import com.freeletics.mad.whetstone.codegen.common.composableName
-import com.freeletics.mad.whetstone.codegen.common.retainedComponentClassName
-import com.freeletics.mad.whetstone.codegen.util.asComposeState
 import com.freeletics.mad.whetstone.codegen.util.asParameter
 import com.freeletics.mad.whetstone.codegen.util.composable
 import com.freeletics.mad.whetstone.codegen.util.composeNavigationHandler
-import com.freeletics.mad.whetstone.codegen.util.compositionLocalProvider
-import com.freeletics.mad.whetstone.codegen.util.launch
 import com.freeletics.mad.whetstone.codegen.util.navEventNavigator
 import com.freeletics.mad.whetstone.codegen.util.optInAnnotation
 import com.freeletics.mad.whetstone.codegen.util.propertyName
-import com.freeletics.mad.whetstone.codegen.util.rememberCoroutineScope
-import com.freeletics.mad.whetstone.codegen.util.rememberViewModelProvider
+import com.freeletics.mad.whetstone.codegen.util.rememberViewModel
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
-import com.squareup.kotlinpoet.KModifier.PRIVATE
 
 internal class ComposeScreenGenerator(
     override val data: CommonData,
@@ -32,11 +25,8 @@ internal class ComposeScreenGenerator(
             .addAnnotation(composable)
             .addAnnotation(optInAnnotation())
             .addParameter(parameter)
-            .beginControlFlow("val viewModelProvider = %M<%T>(%T::class) { dependencies, handle -> ",
-                rememberViewModelProvider, data.dependencies, data.parentScope)
-            .addStatement("%T(dependencies, handle, %N)", viewModelClassName, parameter)
-            .endControlFlow()
-            .addStatement("val viewModel = viewModelProvider[%T::class.java]", viewModelClassName)
+            .addStatement("val viewModel = %M(%T::class, %N, ::%T)",
+                rememberViewModel, data.parentScope, parameter, viewModelClassName)
             .addStatement("val component = viewModel.%L", viewModelComponentName)
             .addCode("\n")
             .addCode(composableNavigationSetup())

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/fragment/BaseFragmentGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/fragment/BaseFragmentGenerator.kt
@@ -10,19 +10,19 @@ import com.freeletics.mad.whetstone.codegen.util.asParameter
 import com.freeletics.mad.whetstone.codegen.util.bundle
 import com.freeletics.mad.whetstone.codegen.util.requireArguments
 import com.freeletics.mad.whetstone.codegen.util.fragmentNavigationHandler
-import com.freeletics.mad.whetstone.codegen.util.fragmentViewModelProvider
+import com.freeletics.mad.whetstone.codegen.util.fragmentViewModel
 import com.freeletics.mad.whetstone.codegen.util.lateinitPropertySpec
 import com.freeletics.mad.whetstone.codegen.util.layoutInflater
 import com.freeletics.mad.whetstone.codegen.util.navEventNavigator
 import com.freeletics.mad.whetstone.codegen.util.optInAnnotation
 import com.freeletics.mad.whetstone.codegen.util.propertyName
+import com.freeletics.mad.whetstone.codegen.util.rememberViewModel
 import com.freeletics.mad.whetstone.codegen.util.view
 import com.freeletics.mad.whetstone.codegen.util.viewGroup
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier.OVERRIDE
 import com.squareup.kotlinpoet.KModifier.PRIVATE
-import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.TypeSpec
 
 internal val Generator<out CommonData>.fragmentName
@@ -36,11 +36,11 @@ internal abstract class BaseFragmentGenerator<T : FragmentCommonData> : Generato
             .superclass(data.fragmentBaseClass)
             .addProperty(lateinitPropertySpec(retainedComponentClassName))
             .addFunction(onCreateViewFun())
-            .addFunction(injectFun())
             .build()
     }
 
     private fun onCreateViewFun(): FunSpec {
+        val argumentsParameter = data.navigation.asParameter()
         return FunSpec.builder("onCreateView")
             .addModifiers(OVERRIDE)
             .addParameter("inflater", layoutInflater)
@@ -48,7 +48,12 @@ internal abstract class BaseFragmentGenerator<T : FragmentCommonData> : Generato
             .addParameter("savedInstanceState", bundle.copy(nullable = true))
             .returns(view)
             .beginControlFlow("if (!::%L.isInitialized)", retainedComponentClassName.propertyName)
-            .addStatement("%L()", fragmentInjectName)
+            .addCode("val %N = ", argumentsParameter)
+            .addCode(data.navigation.requireArguments())
+            .addCode("\n")
+            .addStatement("val viewModel = %M(%T::class, %N, ::%T)",
+                fragmentViewModel, data.parentScope, argumentsParameter, viewModelClassName)
+            .addStatement("%L = viewModel.%L", retainedComponentClassName.propertyName, viewModelComponentName)
             .addCode(navigationCode())
             .endControlFlow()
             .addCode("\n")
@@ -57,24 +62,6 @@ internal abstract class BaseFragmentGenerator<T : FragmentCommonData> : Generato
     }
 
     protected abstract fun createViewCode(): CodeBlock
-
-    private val fragmentInjectName = "inject"
-
-    private fun injectFun(): FunSpec {
-        val argumentsParameter = data.navigation.asParameter()
-        return FunSpec.builder(fragmentInjectName)
-            .addModifiers(PRIVATE)
-            .addCode("val %N = ", argumentsParameter)
-            .addCode(data.navigation.requireArguments())
-            .addCode("\n")
-            .beginControlFlow("val viewModelProvider = %M<%T>(this, %T::class) { dependencies, handle -> ",
-                fragmentViewModelProvider, data.dependencies, data.parentScope)
-            .addStatement("%T(dependencies, handle, %N)", viewModelClassName, argumentsParameter)
-            .endControlFlow()
-            .addStatement("val viewModel = viewModelProvider[%T::class.java]", viewModelClassName)
-            .addStatement("%L = viewModel.%L", retainedComponentClassName.propertyName, viewModelComponentName)
-            .build()
-    }
 
     private fun navigationCode(): CodeBlock {
         if (data.navigation == null) {

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/naventry/NavEntryComponentGetterGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/naventry/NavEntryComponentGetterGenerator.kt
@@ -2,7 +2,6 @@ package com.freeletics.mad.whetstone.codegen.naventry
 
 import com.freeletics.mad.whetstone.NavEntryData
 import com.freeletics.mad.whetstone.codegen.Generator
-import com.freeletics.mad.whetstone.codegen.util.bundle
 import com.freeletics.mad.whetstone.codegen.util.context
 import com.freeletics.mad.whetstone.codegen.util.destinationId
 import com.freeletics.mad.whetstone.codegen.util.inject
@@ -11,8 +10,7 @@ import com.freeletics.mad.whetstone.codegen.util.internalWhetstoneApi
 import com.freeletics.mad.whetstone.codegen.util.navBackStackEntry
 import com.freeletics.mad.whetstone.codegen.util.navEntryComponentGetter
 import com.freeletics.mad.whetstone.codegen.util.navEntryComponentGetterKey
-import com.freeletics.mad.whetstone.codegen.util.navEntryIdScope
-import com.freeletics.mad.whetstone.codegen.util.navEntryViewModelProvider
+import com.freeletics.mad.whetstone.codegen.util.navEntryViewModel
 import com.freeletics.mad.whetstone.codegen.util.optInAnnotation
 import com.freeletics.mad.whetstone.codegen.util.toRoute
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -21,10 +19,7 @@ import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.INT
 import com.squareup.kotlinpoet.KModifier.OVERRIDE
-import com.squareup.kotlinpoet.KModifier.PRIVATE
 import com.squareup.kotlinpoet.LambdaTypeName
-import com.squareup.kotlinpoet.ParameterSpec
-import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 
 internal val Generator<NavEntryData>.componentGetterClassName
@@ -73,13 +68,9 @@ internal class NavEntryComponentGetterGenerator(
             .addParameter("context", context)
             .returns(ANY)
             .addStatement("val entry = findEntry(%T::class.%M())", data.route, destinationId)
-            .beginControlFlow("val viewModelProvider = %M<%T>(entry, context, %T::class) { parentComponent, handle -> ",
-                navEntryViewModelProvider, navEntryParentComponentClassName, data.parentScope)
-            // arguments: external method
             .addStatement("val route: %T = entry.arguments!!.%M()", data.route, toRoute)
-            .addStatement("%T(parentComponent.%L(), handle, route)", viewModelClassName, navEntryParentComponentGetterName)
-            .endControlFlow()
-            .addStatement("val viewModel = viewModelProvider[%T::class.java]", viewModelClassName)
+            .addStatement("val viewModel = %M(entry, context, %T::class, route, ::%T)",
+                navEntryViewModel, data.parentScope, viewModelClassName)
             .addStatement("return viewModel.%L", viewModelComponentName)
             .build()
     }

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/naventry/NavEntryViewModelGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/naventry/NavEntryViewModelGenerator.kt
@@ -43,7 +43,7 @@ internal class NavEntryViewModelGenerator(
 
     private fun viewModelCtor(argumentsParameter: ParameterSpec): FunSpec {
         return FunSpec.constructorBuilder()
-            .addParameter("factory", navEntrySubcomponentFactoryClassName)
+            .addParameter("parentComponent", navEntryParentComponentClassName)
             .addParameter("savedStateHandle", savedStateHandle)
             .addParameter(argumentsParameter)
             .build()
@@ -52,7 +52,8 @@ internal class NavEntryViewModelGenerator(
     private fun viewModelProperties(argumentsParameter: ParameterSpec): List<PropertySpec> {
         val properties = mutableListOf<PropertySpec>()
         val componentInitializer = CodeBlock.builder().add(
-            "factory.%L(savedStateHandle, %N",
+            "parentComponent.%L().%L(savedStateHandle, %N",
+            navEntryParentComponentGetterName,
             navEntrySubcomponentFactoryCreateName,
             argumentsParameter,
         )

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
@@ -27,9 +27,9 @@ internal val navEntryIdScope = ClassName("com.freeletics.mad.whetstone", "NavEnt
 // Whetstone Internal API
 internal val asComposeState = MemberName("com.freeletics.mad.whetstone.internal", "asComposeState")
 internal val internalWhetstoneApi = ClassName("com.freeletics.mad.whetstone.internal", "InternalWhetstoneApi")
-internal val navEntryViewModelProvider = MemberName("com.freeletics.mad.whetstone.internal", "viewModelProvider")
-internal val fragmentViewModelProvider = MemberName("com.freeletics.mad.whetstone.fragment.internal", "viewModelProvider")
-internal val rememberViewModelProvider = MemberName("com.freeletics.mad.whetstone.compose.internal", "rememberViewModelProvider")
+internal val navEntryViewModel = MemberName("com.freeletics.mad.whetstone.internal", "viewModel")
+internal val fragmentViewModel = MemberName("com.freeletics.mad.whetstone.fragment.internal", "viewModel")
+internal val rememberViewModel = MemberName("com.freeletics.mad.whetstone.compose.internal", "rememberViewModel")
 internal val navEntryComponentGetter = ClassName("com.freeletics.mad.whetstone.internal", "NavEntryComponentGetter")
 internal val navEntryComponentGetterKey = ClassName("com.freeletics.mad.whetstone.internal", "NavEntryComponentGetterKey")
 internal val composeProviderValueModule = ClassName("com.freeletics.mad.whetstone.internal", "ComposeProviderValueModule")

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
@@ -44,7 +44,7 @@ internal class FileGeneratorTestCompose {
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
-            import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModelProvider
+            import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
             import com.squareup.anvil.annotations.MergeComponent
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
@@ -107,11 +107,7 @@ internal class FileGeneratorTestCompose {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             public fun TestScreen(testRoute: TestRoute): Unit {
-              val viewModelProvider = rememberViewModelProvider<TestDependencies>(TestParentScope::class) {
-                  dependencies, handle -> 
-                TestViewModel(dependencies, handle, testRoute)
-              }
-              val viewModel = viewModelProvider[TestViewModel::class.java]
+              val viewModel = rememberViewModel(TestParentScope::class, testRoute, ::TestViewModel)
               val component = viewModel.component
 
               NavigationSetup(component.navEventNavigator)
@@ -160,7 +156,7 @@ internal class FileGeneratorTestCompose {
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
-            import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModelProvider
+            import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
             import com.squareup.anvil.annotations.ContributesTo
             import com.squareup.anvil.annotations.MergeComponent
             import com.test.destination.TestDestinationScope
@@ -228,11 +224,7 @@ internal class FileGeneratorTestCompose {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             public fun TestScreen(testRoute: TestRoute): Unit {
-              val viewModelProvider = rememberViewModelProvider<TestDependencies>(TestParentScope::class) {
-                  dependencies, handle -> 
-                TestViewModel(dependencies, handle, testRoute)
-              }
-              val viewModel = viewModelProvider[TestViewModel::class.java]
+              val viewModel = rememberViewModel(TestParentScope::class, testRoute, ::TestViewModel)
               val component = viewModel.component
 
               NavigationSetup(component.navEventNavigator)
@@ -288,7 +280,7 @@ internal class FileGeneratorTestCompose {
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
-            import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModelProvider
+            import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
             import com.squareup.anvil.annotations.MergeComponent
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
@@ -349,11 +341,7 @@ internal class FileGeneratorTestCompose {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             public fun TestScreen(arguments: Bundle): Unit {
-              val viewModelProvider = rememberViewModelProvider<TestDependencies>(TestParentScope::class) {
-                  dependencies, handle -> 
-                TestViewModel(dependencies, handle, arguments)
-              }
-              val viewModel = viewModelProvider[TestViewModel::class.java]
+              val viewModel = rememberViewModel(TestParentScope::class, arguments, ::TestViewModel)
               val component = viewModel.component
 
               TestScreen(component)
@@ -398,7 +386,7 @@ internal class FileGeneratorTestCompose {
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
-            import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModelProvider
+            import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
             import com.squareup.anvil.annotations.MergeComponent
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
@@ -454,11 +442,7 @@ internal class FileGeneratorTestCompose {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             public fun TestScreen(testRoute: TestRoute): Unit {
-              val viewModelProvider = rememberViewModelProvider<TestDependencies>(TestParentScope::class) {
-                  dependencies, handle -> 
-                TestViewModel(dependencies, handle, testRoute)
-              }
-              val viewModel = viewModelProvider[TestViewModel::class.java]
+              val viewModel = rememberViewModel(TestParentScope::class, testRoute, ::TestViewModel)
               val component = viewModel.component
 
               NavigationSetup(component.navEventNavigator)
@@ -505,7 +489,7 @@ internal class FileGeneratorTestCompose {
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
-            import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModelProvider
+            import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
             import com.squareup.anvil.annotations.MergeComponent
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
@@ -562,11 +546,7 @@ internal class FileGeneratorTestCompose {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             public fun TestScreen(testRoute: TestRoute): Unit {
-              val viewModelProvider = rememberViewModelProvider<TestDependencies>(TestParentScope::class) {
-                  dependencies, handle -> 
-                TestViewModel(dependencies, handle, testRoute)
-              }
-              val viewModel = viewModelProvider[TestViewModel::class.java]
+              val viewModel = rememberViewModel(TestParentScope::class, testRoute, ::TestViewModel)
               val component = viewModel.component
 
               NavigationSetup(component.navEventNavigator)

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
@@ -56,7 +56,7 @@ internal class FileGeneratorTestComposeFragment {
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
-            import com.freeletics.mad.whetstone.fragment.`internal`.viewModelProvider
+            import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
             import com.google.accompanist.insets.LocalWindowInsets
             import com.google.accompanist.insets.ViewWindowInsetObserver
             import com.squareup.anvil.annotations.MergeComponent
@@ -128,7 +128,9 @@ internal class FileGeneratorTestComposeFragment {
                 savedInstanceState: Bundle?
               ): View {
                 if (!::retainedTestComponent.isInitialized) {
-                  inject()
+                  val testRoute = requireRoute<TestRoute>()
+                  val viewModel = viewModel(TestParentScope::class, testRoute, ::TestViewModel)
+                  retainedTestComponent = viewModel.component
             
                   handleNavigation(this, retainedTestComponent.navEventNavigator)
                 }
@@ -147,16 +149,6 @@ internal class FileGeneratorTestComposeFragment {
                     }
                   }
                 }
-              }
-
-              private fun inject(): Unit {
-                val testRoute = requireRoute<TestRoute>()
-                val viewModelProvider = viewModelProvider<TestDependencies>(this, TestParentScope::class) {
-                    dependencies, handle -> 
-                  TestViewModel(dependencies, handle, testRoute)
-                }
-                val viewModel = viewModelProvider[TestViewModel::class.java]
-                retainedTestComponent = viewModel.component
               }
             }
 
@@ -209,7 +201,7 @@ internal class FileGeneratorTestComposeFragment {
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
-            import com.freeletics.mad.whetstone.fragment.`internal`.viewModelProvider
+            import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
             import com.google.accompanist.insets.LocalWindowInsets
             import com.google.accompanist.insets.ViewWindowInsetObserver
             import com.squareup.anvil.annotations.ContributesTo
@@ -286,7 +278,9 @@ internal class FileGeneratorTestComposeFragment {
                 savedInstanceState: Bundle?
               ): View {
                 if (!::retainedTestComponent.isInitialized) {
-                  inject()
+                  val testRoute = requireRoute<TestRoute>()
+                  val viewModel = viewModel(TestParentScope::class, testRoute, ::TestViewModel)
+                  retainedTestComponent = viewModel.component
             
                   handleNavigation(this, retainedTestComponent.navEventNavigator)
                 }
@@ -305,16 +299,6 @@ internal class FileGeneratorTestComposeFragment {
                     }
                   }
                 }
-              }
-
-              private fun inject(): Unit {
-                val testRoute = requireRoute<TestRoute>()
-                val viewModelProvider = viewModelProvider<TestDependencies>(this, TestParentScope::class) {
-                    dependencies, handle -> 
-                  TestViewModel(dependencies, handle, testRoute)
-                }
-                val viewModel = viewModelProvider[TestViewModel::class.java]
-                retainedTestComponent = viewModel.component
               }
             }
 
@@ -375,7 +359,7 @@ internal class FileGeneratorTestComposeFragment {
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
-            import com.freeletics.mad.whetstone.fragment.`internal`.viewModelProvider
+            import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
             import com.google.accompanist.insets.LocalWindowInsets
             import com.google.accompanist.insets.ViewWindowInsetObserver
             import com.squareup.anvil.annotations.MergeComponent
@@ -447,7 +431,9 @@ internal class FileGeneratorTestComposeFragment {
                 savedInstanceState: Bundle?
               ): View {
                 if (!::retainedTestComponent.isInitialized) {
-                  inject()
+                  val testRoute = requireRoute<TestRoute>()
+                  val viewModel = viewModel(TestParentScope::class, testRoute, ::TestViewModel)
+                  retainedTestComponent = viewModel.component
             
                   handleNavigation(this, retainedTestComponent.navEventNavigator)
                 }
@@ -466,16 +452,6 @@ internal class FileGeneratorTestComposeFragment {
                     }
                   }
                 }
-              }
-
-              private fun inject(): Unit {
-                val testRoute = requireRoute<TestRoute>()
-                val viewModelProvider = viewModelProvider<TestDependencies>(this, TestParentScope::class) {
-                    dependencies, handle -> 
-                  TestViewModel(dependencies, handle, testRoute)
-                }
-                val viewModel = viewModelProvider[TestViewModel::class.java]
-                retainedTestComponent = viewModel.component
               }
             }
 
@@ -526,7 +502,7 @@ internal class FileGeneratorTestComposeFragment {
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
-            import com.freeletics.mad.whetstone.fragment.`internal`.viewModelProvider
+            import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
             import com.squareup.anvil.annotations.MergeComponent
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
@@ -596,7 +572,9 @@ internal class FileGeneratorTestComposeFragment {
                 savedInstanceState: Bundle?
               ): View {
                 if (!::retainedTestComponent.isInitialized) {
-                  inject()
+                  val testRoute = requireRoute<TestRoute>()
+                  val viewModel = viewModel(TestParentScope::class, testRoute, ::TestViewModel)
+                  retainedTestComponent = viewModel.component
             
                   handleNavigation(this, retainedTestComponent.navEventNavigator)
                 }
@@ -608,16 +586,6 @@ internal class FileGeneratorTestComposeFragment {
                     TestScreen(retainedTestComponent)
                   }
                 }
-              }
-
-              private fun inject(): Unit {
-                val testRoute = requireRoute<TestRoute>()
-                val viewModelProvider = viewModelProvider<TestDependencies>(this, TestParentScope::class) {
-                    dependencies, handle -> 
-                  TestViewModel(dependencies, handle, testRoute)
-                }
-                val viewModel = viewModelProvider[TestViewModel::class.java]
-                retainedTestComponent = viewModel.component
               }
             }
 
@@ -665,7 +633,7 @@ internal class FileGeneratorTestComposeFragment {
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
-            import com.freeletics.mad.whetstone.fragment.`internal`.viewModelProvider
+            import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
             import com.google.accompanist.insets.LocalWindowInsets
             import com.google.accompanist.insets.ViewWindowInsetObserver
             import com.squareup.anvil.annotations.MergeComponent
@@ -735,7 +703,9 @@ internal class FileGeneratorTestComposeFragment {
                 savedInstanceState: Bundle?
               ): View {
                 if (!::retainedTestComponent.isInitialized) {
-                  inject()
+                  val arguments = requireArguments()
+                  val viewModel = viewModel(TestParentScope::class, arguments, ::TestViewModel)
+                  retainedTestComponent = viewModel.component
                 }
 
                 return ComposeView(requireContext()).apply {
@@ -752,16 +722,6 @@ internal class FileGeneratorTestComposeFragment {
                     }
                   }
                 }
-              }
-
-              private fun inject(): Unit {
-                val arguments = requireArguments()
-                val viewModelProvider = viewModelProvider<TestDependencies>(this, TestParentScope::class) {
-                    dependencies, handle -> 
-                  TestViewModel(dependencies, handle, arguments)
-                }
-                val viewModel = viewModelProvider[TestViewModel::class.java]
-                retainedTestComponent = viewModel.component
               }
             }
 

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestRendererFragment.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestRendererFragment.kt
@@ -46,7 +46,7 @@ internal class FileGeneratorTestRendererFragment {
             import com.freeletics.mad.navigator.fragment.requireRoute
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
-            import com.freeletics.mad.whetstone.fragment.`internal`.viewModelProvider
+            import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
             import com.gabrielittner.renderer.connect.connect
             import com.squareup.anvil.annotations.MergeComponent
             import com.test.parent.TestParentScope
@@ -114,7 +114,9 @@ internal class FileGeneratorTestRendererFragment {
                 savedInstanceState: Bundle?
               ): View {
                 if (!::retainedTestComponent.isInitialized) {
-                  inject()
+                  val testRoute = requireRoute<TestRoute>()
+                  val viewModel = viewModel(TestParentScope::class, testRoute, ::TestViewModel)
+                  retainedTestComponent = viewModel.component
             
                   handleNavigation(this, retainedTestComponent.navEventNavigator)
                 }
@@ -122,16 +124,6 @@ internal class FileGeneratorTestRendererFragment {
                 val renderer = retainedTestComponent.rendererFactory.inflate(inflater, container)
                 connect(renderer, retainedTestComponent.testStateMachine)
                 return renderer.rootView
-              }
-
-              private fun inject(): Unit {
-                val testRoute = requireRoute<TestRoute>()
-                val viewModelProvider = viewModelProvider<TestDependencies>(this, TestParentScope::class) {
-                    dependencies, handle -> 
-                  TestViewModel(dependencies, handle, testRoute)
-                }
-                val viewModel = viewModelProvider[TestViewModel::class.java]
-                retainedTestComponent = viewModel.component
               }
             }
             
@@ -159,7 +151,7 @@ internal class FileGeneratorTestRendererFragment {
             import com.freeletics.mad.navigator.fragment.requireRoute
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
-            import com.freeletics.mad.whetstone.fragment.`internal`.viewModelProvider
+            import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
             import com.gabrielittner.renderer.connect.connect
             import com.squareup.anvil.annotations.ContributesTo
             import com.squareup.anvil.annotations.MergeComponent
@@ -232,7 +224,9 @@ internal class FileGeneratorTestRendererFragment {
                 savedInstanceState: Bundle?
               ): View {
                 if (!::retainedTestComponent.isInitialized) {
-                  inject()
+                  val testRoute = requireRoute<TestRoute>()
+                  val viewModel = viewModel(TestParentScope::class, testRoute, ::TestViewModel)
+                  retainedTestComponent = viewModel.component
             
                   handleNavigation(this, retainedTestComponent.navEventNavigator)
                 }
@@ -240,16 +234,6 @@ internal class FileGeneratorTestRendererFragment {
                 val renderer = retainedTestComponent.rendererFactory.inflate(inflater, container)
                 connect(renderer, retainedTestComponent.testStateMachine)
                 return renderer.rootView
-              }
-
-              private fun inject(): Unit {
-                val testRoute = requireRoute<TestRoute>()
-                val viewModelProvider = viewModelProvider<TestDependencies>(this, TestParentScope::class) {
-                    dependencies, handle -> 
-                  TestViewModel(dependencies, handle, testRoute)
-                }
-                val viewModel = viewModelProvider[TestViewModel::class.java]
-                retainedTestComponent = viewModel.component
               }
             }
             
@@ -280,7 +264,7 @@ internal class FileGeneratorTestRendererFragment {
             import androidx.lifecycle.ViewModel
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
-            import com.freeletics.mad.whetstone.fragment.`internal`.viewModelProvider
+            import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
             import com.gabrielittner.renderer.connect.connect
             import com.squareup.anvil.annotations.MergeComponent
             import com.test.parent.TestParentScope
@@ -346,22 +330,14 @@ internal class FileGeneratorTestRendererFragment {
                 savedInstanceState: Bundle?
               ): View {
                 if (!::retainedTestComponent.isInitialized) {
-                  inject()
+                  val arguments = requireArguments()
+                  val viewModel = viewModel(TestParentScope::class, arguments, ::TestViewModel)
+                  retainedTestComponent = viewModel.component
                 }
             
                 val renderer = retainedTestComponent.rendererFactory.inflate(inflater, container)
                 connect(renderer, retainedTestComponent.testStateMachine)
                 return renderer.rootView
-              }
-
-              private fun inject(): Unit {
-                val arguments = requireArguments()
-                val viewModelProvider = viewModelProvider<TestDependencies>(this, TestParentScope::class) {
-                    dependencies, handle -> 
-                  TestViewModel(dependencies, handle, arguments)
-                }
-                val viewModel = viewModelProvider[TestViewModel::class.java]
-                retainedTestComponent = viewModel.component
               }
             }
             
@@ -389,7 +365,7 @@ internal class FileGeneratorTestRendererFragment {
             import com.freeletics.mad.navigator.fragment.requireRoute
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
-            import com.freeletics.mad.whetstone.fragment.`internal`.viewModelProvider
+            import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
             import com.gabrielittner.renderer.connect.connect
             import com.squareup.anvil.annotations.MergeComponent
             import com.test.parent.TestParentScope
@@ -457,7 +433,9 @@ internal class FileGeneratorTestRendererFragment {
                 savedInstanceState: Bundle?
               ): View {
                 if (!::retainedTestComponent.isInitialized) {
-                  inject()
+                  val testRoute = requireRoute<TestRoute>()
+                  val viewModel = viewModel(TestParentScope::class, testRoute, ::TestViewModel)
+                  retainedTestComponent = viewModel.component
             
                   handleNavigation(this, retainedTestComponent.navEventNavigator)
                 }
@@ -465,16 +443,6 @@ internal class FileGeneratorTestRendererFragment {
                 val renderer = retainedTestComponent.rendererFactory.inflate(inflater, container)
                 connect(renderer, retainedTestComponent.testStateMachine)
                 return renderer.rootView
-              }
-
-              private fun inject(): Unit {
-                val testRoute = requireRoute<TestRoute>()
-                val viewModelProvider = viewModelProvider<TestDependencies>(this, TestParentScope::class) {
-                    dependencies, handle -> 
-                  TestViewModel(dependencies, handle, testRoute)
-                }
-                val viewModel = viewModelProvider[TestViewModel::class.java]
-                retainedTestComponent = viewModel.component
               }
             }
             

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/NavEntryFileGeneratorTest.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/NavEntryFileGeneratorTest.kt
@@ -33,7 +33,7 @@ internal class NavEntryFileGeneratorTest {
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetter
             import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetterKey
-            import com.freeletics.mad.whetstone.`internal`.viewModelProvider
+            import com.freeletics.mad.whetstone.`internal`.viewModel
             import com.squareup.anvil.annotations.ContributesMultibinding
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
@@ -74,7 +74,7 @@ internal class NavEntryFileGeneratorTest {
 
             @InternalWhetstoneApi
             internal class TestFlowScopeViewModel(
-              factory: NavEntryTestFlowScopeComponent.Factory,
+              parentComponent: NavEntryTestFlowScopeComponent.ParentComponent,
               savedStateHandle: SavedStateHandle,
               testRoute: TestRoute
             ) : ViewModel() {
@@ -82,7 +82,8 @@ internal class NavEntryFileGeneratorTest {
 
               private val scope: CoroutineScope = MainScope()
 
-              public val component: NavEntryTestFlowScopeComponent = factory.create(savedStateHandle, testRoute,
+              public val component: NavEntryTestFlowScopeComponent =
+                  parentComponent.navEntryTestFlowScopeComponentFactory().create(savedStateHandle, testRoute,
                   disposable, scope)
 
               public override fun onCleared(): Unit {
@@ -101,12 +102,9 @@ internal class NavEntryFileGeneratorTest {
               @OptIn(InternalWhetstoneApi::class, InternalNavigatorApi::class)
               public override fun retrieve(findEntry: (Int) -> NavBackStackEntry, context: Context): Any {
                 val entry = findEntry(TestRoute::class.destinationId())
-                val viewModelProvider = viewModelProvider<NavEntryTestFlowScopeComponent.ParentComponent>(entry,
-                    context, TestParentScope::class) { parentComponent, handle -> 
-                  val route: TestRoute = entry.arguments!!.toRoute()
-                  TestFlowScopeViewModel(parentComponent.navEntryTestFlowScopeComponentFactory(), handle, route)
-                }
-                val viewModel = viewModelProvider[TestFlowScopeViewModel::class.java]
+                val route: TestRoute = entry.arguments!!.toRoute()
+                val viewModel = viewModel(entry, context, TestParentScope::class, route,
+                    ::TestFlowScopeViewModel)
                 return viewModel.component
               }
             }
@@ -132,7 +130,7 @@ internal class NavEntryFileGeneratorTest {
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetter
             import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetterKey
-            import com.freeletics.mad.whetstone.`internal`.viewModelProvider
+            import com.freeletics.mad.whetstone.`internal`.viewModel
             import com.squareup.anvil.annotations.ContributesMultibinding
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
@@ -169,13 +167,14 @@ internal class NavEntryFileGeneratorTest {
 
             @InternalWhetstoneApi
             internal class TestFlowScopeViewModel(
-              factory: NavEntryTestFlowScopeComponent.Factory,
+              parentComponent: NavEntryTestFlowScopeComponent.ParentComponent,
               savedStateHandle: SavedStateHandle,
               testRoute: TestRoute
             ) : ViewModel() {
               private val disposable: CompositeDisposable = CompositeDisposable()
 
-              public val component: NavEntryTestFlowScopeComponent = factory.create(savedStateHandle, testRoute,
+              public val component: NavEntryTestFlowScopeComponent =
+                  parentComponent.navEntryTestFlowScopeComponentFactory().create(savedStateHandle, testRoute,
                   disposable)
 
               public override fun onCleared(): Unit {
@@ -193,12 +192,9 @@ internal class NavEntryFileGeneratorTest {
               @OptIn(InternalWhetstoneApi::class, InternalNavigatorApi::class)
               public override fun retrieve(findEntry: (Int) -> NavBackStackEntry, context: Context): Any {
                 val entry = findEntry(TestRoute::class.destinationId())
-                val viewModelProvider = viewModelProvider<NavEntryTestFlowScopeComponent.ParentComponent>(entry,
-                    context, TestParentScope::class) { parentComponent, handle -> 
-                  val route: TestRoute = entry.arguments!!.toRoute()
-                  TestFlowScopeViewModel(parentComponent.navEntryTestFlowScopeComponentFactory(), handle, route)
-                }
-                val viewModel = viewModelProvider[TestFlowScopeViewModel::class.java]
+                val route: TestRoute = entry.arguments!!.toRoute()
+                val viewModel = viewModel(entry, context, TestParentScope::class, route,
+                    ::TestFlowScopeViewModel)
                 return viewModel.component
               }
             }
@@ -224,7 +220,7 @@ internal class NavEntryFileGeneratorTest {
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetter
             import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetterKey
-            import com.freeletics.mad.whetstone.`internal`.viewModelProvider
+            import com.freeletics.mad.whetstone.`internal`.viewModel
             import com.squareup.anvil.annotations.ContributesMultibinding
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
@@ -263,13 +259,14 @@ internal class NavEntryFileGeneratorTest {
 
             @InternalWhetstoneApi
             internal class TestFlowScopeViewModel(
-              factory: NavEntryTestFlowScopeComponent.Factory,
+              parentComponent: NavEntryTestFlowScopeComponent.ParentComponent,
               savedStateHandle: SavedStateHandle,
               testRoute: TestRoute
             ) : ViewModel() {
               private val scope: CoroutineScope = MainScope()
 
-              public val component: NavEntryTestFlowScopeComponent = factory.create(savedStateHandle, testRoute,
+              public val component: NavEntryTestFlowScopeComponent =
+                  parentComponent.navEntryTestFlowScopeComponentFactory().create(savedStateHandle, testRoute,
                   scope)
 
               public override fun onCleared(): Unit {
@@ -287,12 +284,9 @@ internal class NavEntryFileGeneratorTest {
               @OptIn(InternalWhetstoneApi::class, InternalNavigatorApi::class)
               public override fun retrieve(findEntry: (Int) -> NavBackStackEntry, context: Context): Any {
                 val entry = findEntry(TestRoute::class.destinationId())
-                val viewModelProvider = viewModelProvider<NavEntryTestFlowScopeComponent.ParentComponent>(entry,
-                    context, TestParentScope::class) { parentComponent, handle -> 
-                  val route: TestRoute = entry.arguments!!.toRoute()
-                  TestFlowScopeViewModel(parentComponent.navEntryTestFlowScopeComponentFactory(), handle, route)
-                }
-                val viewModel = viewModelProvider[TestFlowScopeViewModel::class.java]
+                val route: TestRoute = entry.arguments!!.toRoute()
+                val viewModel = viewModel(entry, context, TestParentScope::class, route,
+                    ::TestFlowScopeViewModel)
                 return viewModel.component
               }
             }

--- a/whetstone/runtime-compose/api/runtime-compose.api
+++ b/whetstone/runtime-compose/api/runtime-compose.api
@@ -26,6 +26,3 @@ public abstract interface annotation class com/freeletics/mad/whetstone/compose/
 	public abstract fun root ()Ljava/lang/Class;
 }
 
-public final class com/freeletics/mad/whetstone/compose/internal/ViewModelProviderKt {
-}
-

--- a/whetstone/runtime-fragment/api/runtime-fragment.api
+++ b/whetstone/runtime-fragment/api/runtime-fragment.api
@@ -38,6 +38,3 @@ public abstract interface annotation class com/freeletics/mad/whetstone/fragment
 	public abstract fun root ()Ljava/lang/Class;
 }
 
-public final class com/freeletics/mad/whetstone/fragment/internal/FragmentViewModelProviderKt {
-}
-

--- a/whetstone/runtime/api/runtime.api
+++ b/whetstone/runtime/api/runtime.api
@@ -18,9 +18,9 @@ public abstract interface annotation class com/freeletics/mad/whetstone/ScopeTo 
 public final class com/freeletics/mad/whetstone/internal/CollectAsStateKt {
 }
 
-public abstract interface annotation class com/freeletics/mad/whetstone/internal/InternalWhetstoneApi : java/lang/annotation/Annotation {
+public final class com/freeletics/mad/whetstone/internal/FindKt {
 }
 
-public final class com/freeletics/mad/whetstone/internal/ViewModelProviderKt {
+public abstract interface annotation class com/freeletics/mad/whetstone/internal/InternalWhetstoneApi : java/lang/annotation/Annotation {
 }
 

--- a/whetstone/runtime/src/main/java/com/freeletics/mad/whetstone/internal/Find.kt
+++ b/whetstone/runtime/src/main/java/com/freeletics/mad/whetstone/internal/Find.kt
@@ -1,0 +1,19 @@
+package com.freeletics.mad.whetstone.internal
+
+import android.content.Context
+import kotlin.reflect.KClass
+
+@InternalWhetstoneApi
+public fun <T> Context.findDependencies(scope: KClass<*>): T {
+    return find(scope)!!
+}
+
+private fun <T : Any> Context.find(service: KClass<*>): T? {
+    val serviceName = service.qualifiedName!!
+    return find(serviceName) ?: applicationContext.find(serviceName)
+}
+
+@Suppress("UNCHECKED_CAST")
+private fun <T> Context.find(serviceName: String): T? {
+    return getSystemService(serviceName) as T?
+}

--- a/whetstone/runtime/src/main/java/com/freeletics/mad/whetstone/internal/NavEntryViewModelProvider.kt
+++ b/whetstone/runtime/src/main/java/com/freeletics/mad/whetstone/internal/NavEntryViewModelProvider.kt
@@ -18,12 +18,17 @@ import kotlin.reflect.KClass
  * To be used in generated code.
  */
 @InternalWhetstoneApi
-public fun <C> viewModelProvider(
+public inline fun <reified T : ViewModel, D, E> viewModel(
     entry: NavBackStackEntry,
     context: Context,
     scope: KClass<*>,
-    factory: (C, SavedStateHandle) -> ViewModel
-): ViewModelProvider {
-    val viewModelFactory = WhetstoneViewModelFactory(entry, context, scope, factory)
-    return ViewModelProvider(entry, viewModelFactory)
+    extra: E,
+    crossinline factory: (D, SavedStateHandle, E) -> T
+): T {
+    val viewModelFactory = WhetstoneViewModelFactory(entry) {
+        val dependencies = context.findDependencies<D>(scope)
+        factory(dependencies, it, extra)
+    }
+    val viewModelProvider = ViewModelProvider(entry, viewModelFactory)
+    return viewModelProvider[T::class.java]
 }

--- a/whetstone/runtime/src/main/java/com/freeletics/mad/whetstone/internal/WhetstoneViewModelFactory.kt
+++ b/whetstone/runtime/src/main/java/com/freeletics/mad/whetstone/internal/WhetstoneViewModelFactory.kt
@@ -1,18 +1,14 @@
 package com.freeletics.mad.whetstone.internal
 
-import android.content.Context
 import androidx.lifecycle.AbstractSavedStateViewModelFactory
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.savedstate.SavedStateRegistryOwner
-import kotlin.reflect.KClass
 
 @InternalWhetstoneApi
-public class WhetstoneViewModelFactory<D>(
+public class WhetstoneViewModelFactory(
     savedStateRegistryOwner: SavedStateRegistryOwner,
-    private val context: Context,
-    private val scope: KClass<*>,
-    private val factory: (D, SavedStateHandle) -> ViewModel
+    private val factory: (SavedStateHandle) -> ViewModel
 ) : AbstractSavedStateViewModelFactory(savedStateRegistryOwner, null) {
 
     @Suppress("UNCHECKED_CAST")
@@ -21,17 +17,6 @@ public class WhetstoneViewModelFactory<D>(
         modelClass: Class<T>,
         handle: SavedStateHandle
     ): T {
-        val dependencies: D = findDependencies()
-        return factory(dependencies, handle) as T
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun <T> findDependencies(): T {
-        val serviceName = scope.qualifiedName!!
-        val dependencies: T? = context.getSystemService(serviceName) as T?
-        if (dependencies != null) {
-            return dependencies
-        }
-        return context.applicationContext.getSystemService(serviceName) as T
+        return factory(handle) as T
     }
 }


### PR DESCRIPTION
- change `ViewModelProvider` methods to methods that return a `ViewModel`
- don't pass parameters to `WhetstoneViewModelFactory` that are then just passed back to us
- dependency lookup now happens in the `viewModel` methods instead of the in the factory

These changes are in preparation of making the nav entry lookup internal without requiring a `NavController` on the outside (and therefor removing the last obsolete navigation api). We will have overloads of the viewModel methods for that.