### PR TITLE
remove old ObsoleteNavigatorApi

### DIFF
--- a/navigator/runtime-compose/build.gradle
+++ b/navigator/runtime-compose/build.gradle
@@ -39,7 +39,6 @@ kotlin {
         languageSettings {
             optIn("kotlin.RequiresOptIn")
             optIn("com.freeletics.mad.navigator.internal.InternalNavigatorApi")
-            optIn("com.freeletics.mad.navigator.internal.ObsoleteNavigatorApi")
         }
     }
 }

--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavHost.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavHost.kt
@@ -1,17 +1,11 @@
 package com.freeletics.mad.navigator.compose
 
-import android.app.Activity as AndroidActivity
 import androidx.navigation.compose.NavHost as AndroidXNavHost
-import android.content.Context
-import android.content.ContextWrapper
-import android.view.View
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
-import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.ActivityNavigator
 import androidx.navigation.NavArgument
 import androidx.navigation.NavController
@@ -28,11 +22,9 @@ import com.freeletics.mad.navigator.compose.NavDestination.BottomSheet
 import com.freeletics.mad.navigator.compose.NavDestination.Dialog
 import com.freeletics.mad.navigator.compose.NavDestination.Screen
 import com.freeletics.mad.navigator.internal.InternalNavigatorApi
-import com.freeletics.mad.navigator.internal.ObsoleteNavigatorApi
 import com.freeletics.mad.navigator.internal.destinationId
 import com.freeletics.mad.navigator.internal.getArguments
 import com.freeletics.mad.navigator.internal.toRoute
-import com.freeletics.mad.navigator.runtime.compose.R
 import com.google.accompanist.navigation.material.BottomSheetNavigator
 import com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi
 import com.google.accompanist.navigation.material.ModalBottomSheetLayout
@@ -60,8 +52,6 @@ public fun NavHost(
             }
         }
     }
-
-    LegacyFindNavControllerSupport(navController)
 
     CompositionLocalProvider(LocalNavController provides navController) {
         ModalBottomSheetLayout(bottomSheetNavigator) {
@@ -142,32 +132,3 @@ private fun Activity.toDestination(
 public val LocalNavController: ProvidableCompositionLocal<NavController> = staticCompositionLocalOf {
     throw IllegalStateException("Can't use NavEventNavigationHandler outside of a navigator NavHost")
 }
-
-@ObsoleteNavigatorApi
-public fun AndroidActivity.findComposeNavController(): NavController? {
-    val view = findViewById<View>(android.R.id.content)!!
-    return view.getTag(navControllerTagId) as NavController?
-}
-
-@Composable
-private fun LegacyFindNavControllerSupport(navController: NavController) {
-    val context = LocalContext.current
-    DisposableEffect(navController, context) {
-        val view = context.findActivity().findViewById<View>(android.R.id.content)!!
-        view.setTag(navControllerTagId, navController)
-        onDispose {
-            view.setTag(navControllerTagId, null)
-        }
-    }
-}
-
-private fun Context.findActivity(): android.app.Activity {
-    var context = this
-    while (context is ContextWrapper) {
-        if (context is android.app.Activity) return context
-        context = context.baseContext
-    }
-    throw IllegalStateException("Permissions should be called in the context of an Activity")
-}
-
-private val navControllerTagId = R.id.internal_nav_controller_tag

--- a/navigator/runtime-compose/src/main/res/values/ids.xml
+++ b/navigator/runtime-compose/src/main/res/values/ids.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <item name="internal_nav_controller_tag" type="id" />
-</resources>

--- a/navigator/runtime-compose/src/main/res/values/public.xml
+++ b/navigator/runtime-compose/src/main/res/values/public.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <public type="id" name="id_that_does_not_exist" />
-</resources>

--- a/navigator/runtime-fragment/build.gradle
+++ b/navigator/runtime-fragment/build.gradle
@@ -34,7 +34,6 @@ kotlin {
         languageSettings {
             optIn("kotlin.RequiresOptIn")
             optIn("com.freeletics.mad.navigator.internal.InternalNavigatorApi")
-            optIn("com.freeletics.mad.navigator.internal.ObsoleteNavigatorApi")
         }
     }
 }

--- a/navigator/runtime/api/navigator-runtime.api
+++ b/navigator/runtime/api/navigator-runtime.api
@@ -83,6 +83,3 @@ public abstract interface annotation class com/freeletics/mad/navigator/internal
 public final class com/freeletics/mad/navigator/internal/NavigateKt {
 }
 
-public abstract interface annotation class com/freeletics/mad/navigator/internal/ObsoleteNavigatorApi : java/lang/annotation/Annotation {
-}
-

--- a/navigator/runtime/build.gradle
+++ b/navigator/runtime/build.gradle
@@ -34,7 +34,6 @@ kotlin {
         languageSettings {
             optIn("kotlin.RequiresOptIn")
             optIn("com.freeletics.mad.navigator.internal.InternalNavigatorApi")
-            optIn("com.freeletics.mad.navigator.internal.ObsoleteNavigatorApi")
         }
     }
 }

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/ObsoleteNavigatorApi.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/ObsoleteNavigatorApi.kt
@@ -1,8 +1,0 @@
-package com.freeletics.mad.navigator.internal
-
-/**
- * Code marked with [ObsoleteNavigatorApi] has no guarantees about API stability and will be removed
- * in a future release.
- */
-@RequiresOptIn
-public annotation class ObsoleteNavigatorApi


### PR DESCRIPTION
With #75 we don't need `findComposeNavController` anymore which removes our last API that is marked as obsolete 🎉 