### PR TITLE
replace NavEntryComponents with automatically contributed interface

### DIFF
--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/RetainedComponentGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/RetainedComponentGenerator.kt
@@ -11,9 +11,12 @@ import com.freeletics.mad.whetstone.codegen.util.componentAnnotation
 import com.freeletics.mad.whetstone.codegen.util.componentFactory
 import com.freeletics.mad.whetstone.codegen.util.composeProviderValueModule
 import com.freeletics.mad.whetstone.codegen.util.compositeDisposable
+import com.freeletics.mad.whetstone.codegen.util.contributesToAnnotation
 import com.freeletics.mad.whetstone.codegen.util.coroutineScope
+import com.freeletics.mad.whetstone.codegen.util.destinationComponent
 import com.freeletics.mad.whetstone.codegen.util.internalApiAnnotation
 import com.freeletics.mad.whetstone.codegen.util.navEventNavigator
+import com.freeletics.mad.whetstone.codegen.util.optInAnnotation
 import com.freeletics.mad.whetstone.codegen.util.providedValue
 import com.freeletics.mad.whetstone.codegen.util.savedStateHandle
 import com.freeletics.mad.whetstone.codegen.util.scopeToAnnotation
@@ -47,6 +50,7 @@ internal class RetainedComponentGenerator(
             .addAnnotation(componentAnnotation(data.scope, data.dependencies, moduleClassName()))
             .addProperties(componentProperties())
             .addType(retainedComponentFactory())
+            .addDestinationComponent()
             .build()
     }
 
@@ -100,5 +104,17 @@ internal class RetainedComponentGenerator(
             .addAnnotation(componentFactory)
             .addFunction(createFun)
             .build()
+    }
+
+    private fun TypeSpec.Builder.addDestinationComponent() = apply {
+        val destinationScope = data.navigation?.destinationScope
+        if (destinationScope != null && destinationScope != data.parentScope) {
+            val type = TypeSpec.interfaceBuilder("NavEntry${data.baseName}DestinationComponent")
+                .addAnnotation(contributesToAnnotation(destinationScope))
+                .addAnnotation(optInAnnotation())
+                .addSuperinterface(destinationComponent)
+                .build()
+            addType(type)
+        }
     }
 }

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/compose/ComposeScreenGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/compose/ComposeScreenGenerator.kt
@@ -8,6 +8,7 @@ import com.freeletics.mad.whetstone.codegen.common.composableName
 import com.freeletics.mad.whetstone.codegen.util.asParameter
 import com.freeletics.mad.whetstone.codegen.util.composable
 import com.freeletics.mad.whetstone.codegen.util.composeNavigationHandler
+import com.freeletics.mad.whetstone.codegen.util.fragmentViewModel
 import com.freeletics.mad.whetstone.codegen.util.navEventNavigator
 import com.freeletics.mad.whetstone.codegen.util.optInAnnotation
 import com.freeletics.mad.whetstone.codegen.util.propertyName
@@ -25,8 +26,15 @@ internal class ComposeScreenGenerator(
             .addAnnotation(composable)
             .addAnnotation(optInAnnotation())
             .addParameter(parameter)
-            .addStatement("val viewModel = %M(%T::class, %N, ::%T)",
-                rememberViewModel, data.parentScope, parameter, viewModelClassName)
+            .also {
+                if (data.navigation != null) {
+                    it.addStatement("val viewModel = %M(%T::class, %T::class, %N, ::%T)",
+                        rememberViewModel, data.parentScope, data.navigation!!.destinationScope, parameter, viewModelClassName)
+                } else {
+                    it.addStatement("val viewModel = %M(%T::class, %N, ::%T)",
+                        rememberViewModel, data.parentScope, parameter, viewModelClassName)
+                }
+            }
             .addStatement("val component = viewModel.%L", viewModelComponentName)
             .addCode("\n")
             .addCode(composableNavigationSetup())

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/fragment/BaseFragmentGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/fragment/BaseFragmentGenerator.kt
@@ -51,8 +51,15 @@ internal abstract class BaseFragmentGenerator<T : FragmentCommonData> : Generato
             .addCode("val %N = ", argumentsParameter)
             .addCode(data.navigation.requireArguments())
             .addCode("\n")
-            .addStatement("val viewModel = %M(%T::class, %N, ::%T)",
-                fragmentViewModel, data.parentScope, argumentsParameter, viewModelClassName)
+            .also {
+                if (data.navigation != null) {
+                    it.addStatement("val viewModel = %M(%T::class, %T::class, %N, ::%T)",
+                        fragmentViewModel, data.parentScope, data.navigation!!.destinationScope, argumentsParameter, viewModelClassName)
+                } else {
+                    it.addStatement("val viewModel = %M(%T::class, %N, ::%T)",
+                        fragmentViewModel, data.parentScope, argumentsParameter, viewModelClassName)
+                }
+            }
             .addStatement("%L = viewModel.%L", retainedComponentClassName.propertyName, viewModelComponentName)
             .addCode(navigationCode())
             .endControlFlow()

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/naventry/NavEntryComponentGetterGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/naventry/NavEntryComponentGetterGenerator.kt
@@ -69,8 +69,8 @@ internal class NavEntryComponentGetterGenerator(
             .returns(ANY)
             .addStatement("val entry = findEntry(%T::class.%M())", data.route, destinationId)
             .addStatement("val route: %T = entry.arguments!!.%M()", data.route, toRoute)
-            .addStatement("val viewModel = %M(entry, context, %T::class, route, ::%T)",
-                navEntryViewModel, data.parentScope, viewModelClassName)
+            .addStatement("val viewModel = %M(entry, context, %T::class, %T::class, route, ::%T)",
+                navEntryViewModel, data.parentScope, data.destinationScope, viewModelClassName)
             .addStatement("return viewModel.%L", viewModelComponentName)
             .build()
     }

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
@@ -33,6 +33,7 @@ internal val rememberViewModel = MemberName("com.freeletics.mad.whetstone.compos
 internal val navEntryComponentGetter = ClassName("com.freeletics.mad.whetstone.internal", "NavEntryComponentGetter")
 internal val navEntryComponentGetterKey = ClassName("com.freeletics.mad.whetstone.internal", "NavEntryComponentGetterKey")
 internal val composeProviderValueModule = ClassName("com.freeletics.mad.whetstone.internal", "ComposeProviderValueModule")
+internal val destinationComponent = ClassName("com.freeletics.mad.whetstone.internal", "DestinationComponent")
 
 // Navigator
 internal val navEventNavigator = ClassName("com.freeletics.mad.navigator", "NavEventNavigator")

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
@@ -42,10 +42,13 @@ internal class FileGeneratorTestCompose {
             import com.freeletics.mad.navigator.compose.NavigationSetup
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
+            import com.freeletics.mad.whetstone.`internal`.DestinationComponent
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
+            import com.squareup.anvil.annotations.ContributesTo
             import com.squareup.anvil.annotations.MergeComponent
+            import com.test.destination.TestDestinationScope
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
             import dagger.Component
@@ -82,6 +85,10 @@ internal class FileGeneratorTestCompose {
                   @BindsInstance coroutineScope: CoroutineScope
                 ): RetainedTestComponent
               }
+
+              @ContributesTo(TestDestinationScope::class)
+              @OptIn(InternalWhetstoneApi::class)
+              public interface NavEntryTestDestinationComponent : DestinationComponent
             }
 
             @InternalWhetstoneApi
@@ -107,7 +114,8 @@ internal class FileGeneratorTestCompose {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             public fun TestScreen(testRoute: TestRoute): Unit {
-              val viewModel = rememberViewModel(TestParentScope::class, testRoute, ::TestViewModel)
+              val viewModel = rememberViewModel(TestParentScope::class, TestDestinationScope::class, testRoute,
+                  ::TestViewModel)
               val component = viewModel.component
 
               NavigationSetup(component.navEventNavigator)
@@ -154,6 +162,7 @@ internal class FileGeneratorTestCompose {
             import com.freeletics.mad.navigator.compose.ScreenDestination
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
+            import com.freeletics.mad.whetstone.`internal`.DestinationComponent
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
@@ -199,6 +208,10 @@ internal class FileGeneratorTestCompose {
                   @BindsInstance coroutineScope: CoroutineScope
                 ): RetainedTestComponent
               }
+
+              @ContributesTo(TestDestinationScope::class)
+              @OptIn(InternalWhetstoneApi::class)
+              public interface NavEntryTestDestinationComponent : DestinationComponent
             }
 
             @InternalWhetstoneApi
@@ -224,7 +237,8 @@ internal class FileGeneratorTestCompose {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             public fun TestScreen(testRoute: TestRoute): Unit {
-              val viewModel = rememberViewModel(TestParentScope::class, testRoute, ::TestViewModel)
+              val viewModel = rememberViewModel(TestParentScope::class, TestDestinationScope::class, testRoute,
+                  ::TestViewModel)
               val component = viewModel.component
 
               NavigationSetup(component.navEventNavigator)
@@ -384,10 +398,13 @@ internal class FileGeneratorTestCompose {
             import com.freeletics.mad.navigator.compose.NavigationSetup
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
+            import com.freeletics.mad.whetstone.`internal`.DestinationComponent
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
+            import com.squareup.anvil.annotations.ContributesTo
             import com.squareup.anvil.annotations.MergeComponent
+            import com.test.destination.TestDestinationScope
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
             import dagger.Component
@@ -420,6 +437,10 @@ internal class FileGeneratorTestCompose {
                   @BindsInstance compositeDisposable: CompositeDisposable
                 ): RetainedTestComponent
               }
+
+              @ContributesTo(TestDestinationScope::class)
+              @OptIn(InternalWhetstoneApi::class)
+              public interface NavEntryTestDestinationComponent : DestinationComponent
             }
 
             @InternalWhetstoneApi
@@ -442,7 +463,8 @@ internal class FileGeneratorTestCompose {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             public fun TestScreen(testRoute: TestRoute): Unit {
-              val viewModel = rememberViewModel(TestParentScope::class, testRoute, ::TestViewModel)
+              val viewModel = rememberViewModel(TestParentScope::class, TestDestinationScope::class, testRoute,
+                  ::TestViewModel)
               val component = viewModel.component
 
               NavigationSetup(component.navEventNavigator)
@@ -487,10 +509,13 @@ internal class FileGeneratorTestCompose {
             import com.freeletics.mad.navigator.compose.NavigationSetup
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
+            import com.freeletics.mad.whetstone.`internal`.DestinationComponent
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
+            import com.squareup.anvil.annotations.ContributesTo
             import com.squareup.anvil.annotations.MergeComponent
+            import com.test.destination.TestDestinationScope
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
             import dagger.Component
@@ -525,6 +550,10 @@ internal class FileGeneratorTestCompose {
                   @BindsInstance coroutineScope: CoroutineScope
                 ): RetainedTestComponent
               }
+
+              @ContributesTo(TestDestinationScope::class)
+              @OptIn(InternalWhetstoneApi::class)
+              public interface NavEntryTestDestinationComponent : DestinationComponent
             }
 
             @InternalWhetstoneApi
@@ -546,7 +575,8 @@ internal class FileGeneratorTestCompose {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             public fun TestScreen(testRoute: TestRoute): Unit {
-              val viewModel = rememberViewModel(TestParentScope::class, testRoute, ::TestViewModel)
+              val viewModel = rememberViewModel(TestParentScope::class, TestDestinationScope::class, testRoute,
+                  ::TestViewModel)
               val component = viewModel.component
 
               NavigationSetup(component.navEventNavigator)

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
@@ -54,12 +54,15 @@ internal class FileGeneratorTestComposeFragment {
             import com.freeletics.mad.navigator.fragment.requireRoute
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
+            import com.freeletics.mad.whetstone.`internal`.DestinationComponent
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
             import com.google.accompanist.insets.LocalWindowInsets
             import com.google.accompanist.insets.ViewWindowInsetObserver
+            import com.squareup.anvil.annotations.ContributesTo
             import com.squareup.anvil.annotations.MergeComponent
+            import com.test.destination.TestDestinationScope
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
             import dagger.Component
@@ -96,6 +99,10 @@ internal class FileGeneratorTestComposeFragment {
                   @BindsInstance coroutineScope: CoroutineScope
                 ): RetainedTestComponent
               }
+
+              @ContributesTo(TestDestinationScope::class)
+              @OptIn(InternalWhetstoneApi::class)
+              public interface NavEntryTestDestinationComponent : DestinationComponent
             }
 
             @InternalWhetstoneApi
@@ -129,7 +136,8 @@ internal class FileGeneratorTestComposeFragment {
               ): View {
                 if (!::retainedTestComponent.isInitialized) {
                   val testRoute = requireRoute<TestRoute>()
-                  val viewModel = viewModel(TestParentScope::class, testRoute, ::TestViewModel)
+                  val viewModel = viewModel(TestParentScope::class, TestDestinationScope::class, testRoute,
+                      ::TestViewModel)
                   retainedTestComponent = viewModel.component
             
                   handleNavigation(this, retainedTestComponent.navEventNavigator)
@@ -199,6 +207,7 @@ internal class FileGeneratorTestComposeFragment {
             import com.freeletics.mad.navigator.fragment.requireRoute
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
+            import com.freeletics.mad.whetstone.`internal`.DestinationComponent
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
@@ -246,6 +255,10 @@ internal class FileGeneratorTestComposeFragment {
                   @BindsInstance coroutineScope: CoroutineScope
                 ): RetainedTestComponent
               }
+
+              @ContributesTo(TestDestinationScope::class)
+              @OptIn(InternalWhetstoneApi::class)
+              public interface NavEntryTestDestinationComponent : DestinationComponent
             }
 
             @InternalWhetstoneApi
@@ -279,7 +292,8 @@ internal class FileGeneratorTestComposeFragment {
               ): View {
                 if (!::retainedTestComponent.isInitialized) {
                   val testRoute = requireRoute<TestRoute>()
-                  val viewModel = viewModel(TestParentScope::class, testRoute, ::TestViewModel)
+                  val viewModel = viewModel(TestParentScope::class, TestDestinationScope::class, testRoute,
+                      ::TestViewModel)
                   retainedTestComponent = viewModel.component
             
                   handleNavigation(this, retainedTestComponent.navEventNavigator)
@@ -357,12 +371,15 @@ internal class FileGeneratorTestComposeFragment {
             import com.freeletics.mad.navigator.fragment.requireRoute
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
+            import com.freeletics.mad.whetstone.`internal`.DestinationComponent
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
             import com.google.accompanist.insets.LocalWindowInsets
             import com.google.accompanist.insets.ViewWindowInsetObserver
+            import com.squareup.anvil.annotations.ContributesTo
             import com.squareup.anvil.annotations.MergeComponent
+            import com.test.destination.TestDestinationScope
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
             import dagger.Component
@@ -399,6 +416,10 @@ internal class FileGeneratorTestComposeFragment {
                   @BindsInstance coroutineScope: CoroutineScope
                 ): RetainedTestComponent
               }
+
+              @ContributesTo(TestDestinationScope::class)
+              @OptIn(InternalWhetstoneApi::class)
+              public interface NavEntryTestDestinationComponent : DestinationComponent
             }
 
             @InternalWhetstoneApi
@@ -432,7 +453,8 @@ internal class FileGeneratorTestComposeFragment {
               ): View {
                 if (!::retainedTestComponent.isInitialized) {
                   val testRoute = requireRoute<TestRoute>()
-                  val viewModel = viewModel(TestParentScope::class, testRoute, ::TestViewModel)
+                  val viewModel = viewModel(TestParentScope::class, TestDestinationScope::class, testRoute,
+                      ::TestViewModel)
                   retainedTestComponent = viewModel.component
             
                   handleNavigation(this, retainedTestComponent.navEventNavigator)
@@ -500,10 +522,13 @@ internal class FileGeneratorTestComposeFragment {
             import com.freeletics.mad.navigator.fragment.requireRoute
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
+            import com.freeletics.mad.whetstone.`internal`.DestinationComponent
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
+            import com.squareup.anvil.annotations.ContributesTo
             import com.squareup.anvil.annotations.MergeComponent
+            import com.test.destination.TestDestinationScope
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
             import dagger.Component
@@ -540,6 +565,10 @@ internal class FileGeneratorTestComposeFragment {
                   @BindsInstance coroutineScope: CoroutineScope
                 ): RetainedTestComponent
               }
+
+              @ContributesTo(TestDestinationScope::class)
+              @OptIn(InternalWhetstoneApi::class)
+              public interface NavEntryTestDestinationComponent : DestinationComponent
             }
 
             @InternalWhetstoneApi
@@ -573,7 +602,8 @@ internal class FileGeneratorTestComposeFragment {
               ): View {
                 if (!::retainedTestComponent.isInitialized) {
                   val testRoute = requireRoute<TestRoute>()
-                  val viewModel = viewModel(TestParentScope::class, testRoute, ::TestViewModel)
+                  val viewModel = viewModel(TestParentScope::class, TestDestinationScope::class, testRoute,
+                      ::TestViewModel)
                   retainedTestComponent = viewModel.component
             
                   handleNavigation(this, retainedTestComponent.navEventNavigator)

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestRendererFragment.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestRendererFragment.kt
@@ -45,10 +45,13 @@ internal class FileGeneratorTestRendererFragment {
             import com.freeletics.mad.navigator.fragment.handleNavigation
             import com.freeletics.mad.navigator.fragment.requireRoute
             import com.freeletics.mad.whetstone.ScopeTo
+            import com.freeletics.mad.whetstone.`internal`.DestinationComponent
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
             import com.gabrielittner.renderer.connect.connect
+            import com.squareup.anvil.annotations.ContributesTo
             import com.squareup.anvil.annotations.MergeComponent
+            import com.test.destination.TestDestinationScope
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
             import dagger.Component
@@ -82,6 +85,10 @@ internal class FileGeneratorTestRendererFragment {
                   @BindsInstance coroutineScope: CoroutineScope
                 ): RetainedTestComponent
               }
+
+              @ContributesTo(TestDestinationScope::class)
+              @OptIn(InternalWhetstoneApi::class)
+              public interface NavEntryTestDestinationComponent : DestinationComponent
             }
 
             @InternalWhetstoneApi
@@ -115,7 +122,8 @@ internal class FileGeneratorTestRendererFragment {
               ): View {
                 if (!::retainedTestComponent.isInitialized) {
                   val testRoute = requireRoute<TestRoute>()
-                  val viewModel = viewModel(TestParentScope::class, testRoute, ::TestViewModel)
+                  val viewModel = viewModel(TestParentScope::class, TestDestinationScope::class, testRoute,
+                      ::TestViewModel)
                   retainedTestComponent = viewModel.component
             
                   handleNavigation(this, retainedTestComponent.navEventNavigator)
@@ -150,6 +158,7 @@ internal class FileGeneratorTestRendererFragment {
             import com.freeletics.mad.navigator.fragment.handleNavigation
             import com.freeletics.mad.navigator.fragment.requireRoute
             import com.freeletics.mad.whetstone.ScopeTo
+            import com.freeletics.mad.whetstone.`internal`.DestinationComponent
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
             import com.gabrielittner.renderer.connect.connect
@@ -192,6 +201,10 @@ internal class FileGeneratorTestRendererFragment {
                   @BindsInstance coroutineScope: CoroutineScope
                 ): RetainedTestComponent
               }
+
+              @ContributesTo(TestDestinationScope::class)
+              @OptIn(InternalWhetstoneApi::class)
+              public interface NavEntryTestDestinationComponent : DestinationComponent
             }
 
             @InternalWhetstoneApi
@@ -225,7 +238,8 @@ internal class FileGeneratorTestRendererFragment {
               ): View {
                 if (!::retainedTestComponent.isInitialized) {
                   val testRoute = requireRoute<TestRoute>()
-                  val viewModel = viewModel(TestParentScope::class, testRoute, ::TestViewModel)
+                  val viewModel = viewModel(TestParentScope::class, TestDestinationScope::class, testRoute,
+                      ::TestViewModel)
                   retainedTestComponent = viewModel.component
             
                   handleNavigation(this, retainedTestComponent.navEventNavigator)
@@ -364,10 +378,13 @@ internal class FileGeneratorTestRendererFragment {
             import com.freeletics.mad.navigator.fragment.handleNavigation
             import com.freeletics.mad.navigator.fragment.requireRoute
             import com.freeletics.mad.whetstone.ScopeTo
+            import com.freeletics.mad.whetstone.`internal`.DestinationComponent
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
             import com.gabrielittner.renderer.connect.connect
+            import com.squareup.anvil.annotations.ContributesTo
             import com.squareup.anvil.annotations.MergeComponent
+            import com.test.destination.TestDestinationScope
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
             import dagger.Component
@@ -401,6 +418,10 @@ internal class FileGeneratorTestRendererFragment {
                   @BindsInstance coroutineScope: CoroutineScope
                 ): RetainedTestComponent
               }
+
+              @ContributesTo(TestDestinationScope::class)
+              @OptIn(InternalWhetstoneApi::class)
+              public interface NavEntryTestDestinationComponent : DestinationComponent
             }
 
             @InternalWhetstoneApi
@@ -434,7 +455,8 @@ internal class FileGeneratorTestRendererFragment {
               ): View {
                 if (!::retainedTestComponent.isInitialized) {
                   val testRoute = requireRoute<TestRoute>()
-                  val viewModel = viewModel(TestParentScope::class, testRoute, ::TestViewModel)
+                  val viewModel = viewModel(TestParentScope::class, TestDestinationScope::class, testRoute,
+                      ::TestViewModel)
                   retainedTestComponent = viewModel.component
             
                   handleNavigation(this, retainedTestComponent.navEventNavigator)

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/NavEntryFileGeneratorTest.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/NavEntryFileGeneratorTest.kt
@@ -103,8 +103,8 @@ internal class NavEntryFileGeneratorTest {
               public override fun retrieve(findEntry: (Int) -> NavBackStackEntry, context: Context): Any {
                 val entry = findEntry(TestRoute::class.destinationId())
                 val route: TestRoute = entry.arguments!!.toRoute()
-                val viewModel = viewModel(entry, context, TestParentScope::class, route,
-                    ::TestFlowScopeViewModel)
+                val viewModel = viewModel(entry, context, TestParentScope::class, TestDestinationScope::class,
+                    route, ::TestFlowScopeViewModel)
                 return viewModel.component
               }
             }
@@ -193,8 +193,8 @@ internal class NavEntryFileGeneratorTest {
               public override fun retrieve(findEntry: (Int) -> NavBackStackEntry, context: Context): Any {
                 val entry = findEntry(TestRoute::class.destinationId())
                 val route: TestRoute = entry.arguments!!.toRoute()
-                val viewModel = viewModel(entry, context, TestParentScope::class, route,
-                    ::TestFlowScopeViewModel)
+                val viewModel = viewModel(entry, context, TestParentScope::class, TestDestinationScope::class,
+                    route, ::TestFlowScopeViewModel)
                 return viewModel.component
               }
             }
@@ -285,8 +285,8 @@ internal class NavEntryFileGeneratorTest {
               public override fun retrieve(findEntry: (Int) -> NavBackStackEntry, context: Context): Any {
                 val entry = findEntry(TestRoute::class.destinationId())
                 val route: TestRoute = entry.arguments!!.toRoute()
-                val viewModel = viewModel(entry, context, TestParentScope::class, route,
-                    ::TestFlowScopeViewModel)
+                val viewModel = viewModel(entry, context, TestParentScope::class, TestDestinationScope::class,
+                    route, ::TestFlowScopeViewModel)
                 return viewModel.component
               }
             }

--- a/whetstone/navigation-compose/src/main/java/com/freeletics/mad/whetstone/compose/internal/NavComposeViewModelProvider.kt
+++ b/whetstone/navigation-compose/src/main/java/com/freeletics/mad/whetstone/compose/internal/NavComposeViewModelProvider.kt
@@ -29,6 +29,7 @@ import kotlin.reflect.KClass
 @Composable
 public inline fun <reified T : ViewModel, D, R : BaseRoute> rememberViewModel(
     scope: KClass<*>,
+    destinationScope: KClass<*>,
     route: R,
     crossinline factory: @DisallowComposableCalls (D, SavedStateHandle, R) -> T
 ): T {
@@ -38,7 +39,7 @@ public inline fun <reified T : ViewModel, D, R : BaseRoute> rememberViewModel(
     val navController = LocalNavController.current
     return remember(viewModelStoreOwner, savedStateRegistryOwner, context, navController, route) {
         val viewModelFactory = WhetstoneViewModelFactory(savedStateRegistryOwner) {
-            val dependencies = context.findDependencies<D>(scope::class, navController::getBackStackEntry)
+            val dependencies = context.findDependencies<D>(scope::class, destinationScope, navController::getBackStackEntry)
             factory(dependencies, it, route)
         }
         val viewModelProvider = ViewModelProvider(viewModelStoreOwner, viewModelFactory)

--- a/whetstone/navigation-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/internal/NavFragmentViewModelProvider.kt
+++ b/whetstone/navigation-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/internal/NavFragmentViewModelProvider.kt
@@ -22,12 +22,13 @@ import kotlin.reflect.KClass
 @InternalWhetstoneApi
 public inline fun <reified T : ViewModel, D, R : BaseRoute> Fragment.viewModel(
     scope: KClass<*>,
+    destinationScope: KClass<*>,
     route: R,
     crossinline factory: @DisallowComposableCalls (D, SavedStateHandle, R) -> T
 ): T {
     val viewModelFactory = WhetstoneViewModelFactory(this) {
         val navController = findNavController()
-        val dependencies = requireContext().findDependencies<D>(scope, navController::getBackStackEntry)
+        val dependencies = requireContext().findDependencies<D>(scope, destinationScope, navController::getBackStackEntry)
         factory(dependencies, it, route)
     }
     val viewModelProvider = ViewModelProvider(this, viewModelFactory)

--- a/whetstone/navigation/api/navigation.api
+++ b/whetstone/navigation/api/navigation.api
@@ -5,11 +5,6 @@ public abstract interface annotation class com/freeletics/mad/whetstone/NavEntry
 	public abstract fun scope ()Ljava/lang/Class;
 }
 
-public final class com/freeletics/mad/whetstone/NavEntryComponents {
-	public fun <init> (Ljava/util/Map;)V
-	public final fun get (Ljava/lang/String;)Ljava/lang/Object;
-}
-
 public final class com/freeletics/mad/whetstone/internal/NavFindKt {
 }
 

--- a/whetstone/navigation/build.gradle
+++ b/whetstone/navigation/build.gradle
@@ -47,11 +47,11 @@ tasks.withType(JavaCompile).configureEach {
 
 dependencies {
     api project(":whetstone:runtime")
-    api "javax.inject:javax.inject:1"
     api "com.google.dagger:dagger:2.41"
     api "androidx.navigation:navigation-common:2.4.1"
 
     implementation project(":navigator:navigator-runtime")
+    implementation "javax.inject:javax.inject:1"
     implementation "androidx.savedstate:savedstate:1.1.0"
     implementation "androidx.lifecycle:lifecycle-viewmodel:2.4.1"
     implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:2.4.1"

--- a/whetstone/navigation/src/main/java/com/freeletics/mad/whetstone/NavEntryComponent.kt
+++ b/whetstone/navigation/src/main/java/com/freeletics/mad/whetstone/NavEntryComponent.kt
@@ -49,32 +49,3 @@ public annotation class NavEntryComponent(
     val coroutinesEnabled: Boolean = false,
     val rxJavaEnabled: Boolean = false,
 )
-
-/**
- * Class that allows to retrieve generated [NavEntryComponent] instances.
- */
-public class NavEntryComponents @Inject constructor(
-    private val getters: @JvmSuppressWildcards Map<Class<*>, NavEntryComponentGetter>
-) {
-    /**
-     * Tries to retrieve a generated [NavEntryComponent] for the given [scope], where `name` is the
-     * fully qualified name of the [NavEntryComponent.scope].
-     *
-     * The given [findEntry] should look up a back stack entry for that id in the current
-     * `NavController`.
-     */
-    @Suppress("UNCHECKED_CAST")
-    internal fun <T> get(scope: KClass<*>, context: Context, findEntry: (Int) -> NavBackStackEntry): T? {
-        return getters[scope.java]?.retrieve(findEntry, context) as T?
-    }
-
-    /**
-     * TODO
-     */
-    public fun get(name: String): Any? {
-        if (name == NavEntryComponents::class.qualifiedName) {
-            return this
-        }
-        return null
-    }
-}

--- a/whetstone/navigation/src/main/java/com/freeletics/mad/whetstone/internal/DestinationComponent.kt
+++ b/whetstone/navigation/src/main/java/com/freeletics/mad/whetstone/internal/DestinationComponent.kt
@@ -1,0 +1,7 @@
+package com.freeletics.mad.whetstone.internal
+
+//TODO generate something that extends this and is contributed to destination component
+@InternalWhetstoneApi
+public interface DestinationComponent {
+    public val navEntryComponentGetters: @JvmSuppressWildcards Map<Class<*>, NavEntryComponentGetter>
+}

--- a/whetstone/navigation/src/main/java/com/freeletics/mad/whetstone/internal/NavEntryViewModelProvider.kt
+++ b/whetstone/navigation/src/main/java/com/freeletics/mad/whetstone/internal/NavEntryViewModelProvider.kt
@@ -20,12 +20,13 @@ public inline fun <reified T : ViewModel, D, R : BaseRoute> viewModel(
     entry: NavBackStackEntry,
     context: Context,
     scope: KClass<*>,
+    destinationScope: KClass<*>,
     route: R,
     noinline findEntry: (Int) -> NavBackStackEntry,
     crossinline factory: (D, SavedStateHandle, R) -> T
 ): T {
     val viewModelFactory = WhetstoneViewModelFactory(entry) {
-        val dependencies = context.findDependencies<D>(scope, findEntry)
+        val dependencies = context.findDependencies<D>(scope, destinationScope, findEntry)
         factory(dependencies, it, route)
     }
     val viewModelProvider = ViewModelProvider(entry, viewModelFactory)

--- a/whetstone/navigation/src/main/java/com/freeletics/mad/whetstone/internal/NavFind.kt
+++ b/whetstone/navigation/src/main/java/com/freeletics/mad/whetstone/internal/NavFind.kt
@@ -2,7 +2,6 @@ package com.freeletics.mad.whetstone.internal
 
 import android.content.Context
 import androidx.navigation.NavBackStackEntry
-import com.freeletics.mad.whetstone.NavEntryComponents
 import kotlin.reflect.KClass
 
 /**
@@ -10,7 +9,16 @@ import kotlin.reflect.KClass
  * [Context.getSystemService].
  */
 @InternalWhetstoneApi
-public fun <T> Context.findDependencies(scope: KClass<*>, findEntry: (Int) -> NavBackStackEntry): T {
-    val components = find<NavEntryComponents>(NavEntryComponents::class)
-    return components?.get(scope, this, findEntry) ?: find(scope)!!
+public fun <T> Context.findDependencies(
+    scope: KClass<*>,
+    destinationScope: KClass<*>,
+    findEntry: (Int) -> NavBackStackEntry
+): T {
+    val destinationComponent = find<DestinationComponent>(destinationScope)
+    val getter = destinationComponent?.navEntryComponentGetters?.get(scope.java)
+    if (getter != null) {
+        @Suppress("UNCHECKED_CAST")
+        return getter.retrieve(findEntry, this) as T
+    }
+    return find(scope)!!
 }


### PR DESCRIPTION
The last part of the nav entry rewrite. The lookup methods now get the destinationScope passed to them and try to lookup `DestinationComponent` using it. The latter is the replacement for `NavEntryComponents` and allows access to the generated component getters. To make the integration seamless each screen where the `destinationScope` does not equal the `parentScope` will generate an interface that extends `DestinationComponent` which will be contributed to destinationScope. This way the component will automatically extend `DestinationComponent` without any manual integration.