### PR TITLE
move DestinationComponent to the top level

### DIFF
--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/FileGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/FileGenerator.kt
@@ -6,6 +6,7 @@ import com.freeletics.mad.whetstone.ComposeScreenData
 import com.freeletics.mad.whetstone.NavEntryData
 import com.freeletics.mad.whetstone.RendererFragmentData
 import com.freeletics.mad.whetstone.codegen.common.ComposeGenerator
+import com.freeletics.mad.whetstone.codegen.common.DestinationComponentGenerator
 import com.freeletics.mad.whetstone.codegen.common.NavDestinationModuleGenerator
 import com.freeletics.mad.whetstone.codegen.common.RetainedComponentGenerator
 import com.freeletics.mad.whetstone.codegen.common.ViewModelGenerator
@@ -66,6 +67,12 @@ internal class FileGenerator{
     }
 
     private fun FileSpec.Builder.addNavDestinationType(data: CommonData) = apply {
+        val destinationScope = data.navigation?.destinationScope
+        if (destinationScope != null && destinationScope != data.parentScope) {
+            val destinationComponentGenerator = DestinationComponentGenerator(data)
+            addType(destinationComponentGenerator.generate())
+        }
+
         if (data.navigation?.destinationMethod != null) {
             val navDestinationGenerator = NavDestinationModuleGenerator(data)
             addType(navDestinationGenerator.generate())

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/DestinationComponentGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/DestinationComponentGenerator.kt
@@ -1,0 +1,22 @@
+package com.freeletics.mad.whetstone.codegen.common
+
+import com.freeletics.mad.whetstone.CommonData
+import com.freeletics.mad.whetstone.codegen.Generator
+import com.freeletics.mad.whetstone.codegen.util.contributesToAnnotation
+import com.freeletics.mad.whetstone.codegen.util.destinationComponent
+import com.freeletics.mad.whetstone.codegen.util.optInAnnotation
+import com.squareup.kotlinpoet.TypeSpec
+
+
+internal class DestinationComponentGenerator(
+    override val data: CommonData,
+) : Generator<CommonData>() {
+
+    fun generate(): TypeSpec {
+        return TypeSpec.interfaceBuilder("NavEntry${data.baseName}DestinationComponent")
+            .addAnnotation(contributesToAnnotation(data.navigation!!.destinationScope))
+            .addAnnotation(optInAnnotation())
+            .addSuperinterface(destinationComponent)
+            .build()
+    }
+}

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/RetainedComponentGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/RetainedComponentGenerator.kt
@@ -11,12 +11,9 @@ import com.freeletics.mad.whetstone.codegen.util.componentAnnotation
 import com.freeletics.mad.whetstone.codegen.util.componentFactory
 import com.freeletics.mad.whetstone.codegen.util.composeProviderValueModule
 import com.freeletics.mad.whetstone.codegen.util.compositeDisposable
-import com.freeletics.mad.whetstone.codegen.util.contributesToAnnotation
 import com.freeletics.mad.whetstone.codegen.util.coroutineScope
-import com.freeletics.mad.whetstone.codegen.util.destinationComponent
 import com.freeletics.mad.whetstone.codegen.util.internalApiAnnotation
 import com.freeletics.mad.whetstone.codegen.util.navEventNavigator
-import com.freeletics.mad.whetstone.codegen.util.optInAnnotation
 import com.freeletics.mad.whetstone.codegen.util.providedValue
 import com.freeletics.mad.whetstone.codegen.util.savedStateHandle
 import com.freeletics.mad.whetstone.codegen.util.scopeToAnnotation
@@ -50,7 +47,6 @@ internal class RetainedComponentGenerator(
             .addAnnotation(componentAnnotation(data.scope, data.dependencies, moduleClassName()))
             .addProperties(componentProperties())
             .addType(retainedComponentFactory())
-            .addDestinationComponent()
             .build()
     }
 
@@ -104,17 +100,5 @@ internal class RetainedComponentGenerator(
             .addAnnotation(componentFactory)
             .addFunction(createFun)
             .build()
-    }
-
-    private fun TypeSpec.Builder.addDestinationComponent() = apply {
-        val destinationScope = data.navigation?.destinationScope
-        if (destinationScope != null && destinationScope != data.parentScope) {
-            val type = TypeSpec.interfaceBuilder("NavEntry${data.baseName}DestinationComponent")
-                .addAnnotation(contributesToAnnotation(destinationScope))
-                .addAnnotation(optInAnnotation())
-                .addSuperinterface(destinationComponent)
-                .build()
-            addType(type)
-        }
     }
 }

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
@@ -85,10 +85,6 @@ internal class FileGeneratorTestCompose {
                   @BindsInstance coroutineScope: CoroutineScope
                 ): RetainedTestComponent
               }
-
-              @ContributesTo(TestDestinationScope::class)
-              @OptIn(InternalWhetstoneApi::class)
-              public interface NavEntryTestDestinationComponent : DestinationComponent
             }
 
             @InternalWhetstoneApi
@@ -139,6 +135,10 @@ internal class FileGeneratorTestCompose {
                 }
               }
             }
+            
+            @ContributesTo(TestDestinationScope::class)
+            @OptIn(InternalWhetstoneApi::class)
+            public interface NavEntryTestDestinationComponent : DestinationComponent
             
         """.trimIndent()
     }
@@ -208,10 +208,6 @@ internal class FileGeneratorTestCompose {
                   @BindsInstance coroutineScope: CoroutineScope
                 ): RetainedTestComponent
               }
-
-              @ContributesTo(TestDestinationScope::class)
-              @OptIn(InternalWhetstoneApi::class)
-              public interface NavEntryTestDestinationComponent : DestinationComponent
             }
 
             @InternalWhetstoneApi
@@ -262,6 +258,10 @@ internal class FileGeneratorTestCompose {
                 }
               }
             }
+            
+            @ContributesTo(TestDestinationScope::class)
+            @OptIn(InternalWhetstoneApi::class)
+            public interface NavEntryTestDestinationComponent : DestinationComponent
             
             @Module
             @ContributesTo(TestDestinationScope::class)
@@ -437,10 +437,6 @@ internal class FileGeneratorTestCompose {
                   @BindsInstance compositeDisposable: CompositeDisposable
                 ): RetainedTestComponent
               }
-
-              @ContributesTo(TestDestinationScope::class)
-              @OptIn(InternalWhetstoneApi::class)
-              public interface NavEntryTestDestinationComponent : DestinationComponent
             }
 
             @InternalWhetstoneApi
@@ -488,6 +484,10 @@ internal class FileGeneratorTestCompose {
                 }
               }
             }
+            
+            @ContributesTo(TestDestinationScope::class)
+            @OptIn(InternalWhetstoneApi::class)
+            public interface NavEntryTestDestinationComponent : DestinationComponent
             
         """.trimIndent()
     }
@@ -550,10 +550,6 @@ internal class FileGeneratorTestCompose {
                   @BindsInstance coroutineScope: CoroutineScope
                 ): RetainedTestComponent
               }
-
-              @ContributesTo(TestDestinationScope::class)
-              @OptIn(InternalWhetstoneApi::class)
-              public interface NavEntryTestDestinationComponent : DestinationComponent
             }
 
             @InternalWhetstoneApi
@@ -600,6 +596,10 @@ internal class FileGeneratorTestCompose {
                 }
               }
             }
+            
+            @ContributesTo(TestDestinationScope::class)
+            @OptIn(InternalWhetstoneApi::class)
+            public interface NavEntryTestDestinationComponent : DestinationComponent
             
         """.trimIndent()
     }

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
@@ -99,10 +99,6 @@ internal class FileGeneratorTestComposeFragment {
                   @BindsInstance coroutineScope: CoroutineScope
                 ): RetainedTestComponent
               }
-
-              @ContributesTo(TestDestinationScope::class)
-              @OptIn(InternalWhetstoneApi::class)
-              public interface NavEntryTestDestinationComponent : DestinationComponent
             }
 
             @InternalWhetstoneApi
@@ -176,6 +172,10 @@ internal class FileGeneratorTestComposeFragment {
                 }
               }
             }
+            
+            @ContributesTo(TestDestinationScope::class)
+            @OptIn(InternalWhetstoneApi::class)
+            public interface NavEntryTestDestinationComponent : DestinationComponent
             
         """.trimIndent()
     }
@@ -255,10 +255,6 @@ internal class FileGeneratorTestComposeFragment {
                   @BindsInstance coroutineScope: CoroutineScope
                 ): RetainedTestComponent
               }
-
-              @ContributesTo(TestDestinationScope::class)
-              @OptIn(InternalWhetstoneApi::class)
-              public interface NavEntryTestDestinationComponent : DestinationComponent
             }
 
             @InternalWhetstoneApi
@@ -332,6 +328,10 @@ internal class FileGeneratorTestComposeFragment {
                 }
               }
             }
+            
+            @ContributesTo(TestDestinationScope::class)
+            @OptIn(InternalWhetstoneApi::class)
+            public interface NavEntryTestDestinationComponent : DestinationComponent
             
             @Module
             @ContributesTo(TestDestinationScope::class)
@@ -416,10 +416,6 @@ internal class FileGeneratorTestComposeFragment {
                   @BindsInstance coroutineScope: CoroutineScope
                 ): RetainedTestComponent
               }
-
-              @ContributesTo(TestDestinationScope::class)
-              @OptIn(InternalWhetstoneApi::class)
-              public interface NavEntryTestDestinationComponent : DestinationComponent
             }
 
             @InternalWhetstoneApi
@@ -494,6 +490,10 @@ internal class FileGeneratorTestComposeFragment {
               }
             }
             
+            @ContributesTo(TestDestinationScope::class)
+            @OptIn(InternalWhetstoneApi::class)
+            public interface NavEntryTestDestinationComponent : DestinationComponent
+            
         """.trimIndent()
     }
 
@@ -565,10 +565,6 @@ internal class FileGeneratorTestComposeFragment {
                   @BindsInstance coroutineScope: CoroutineScope
                 ): RetainedTestComponent
               }
-
-              @ContributesTo(TestDestinationScope::class)
-              @OptIn(InternalWhetstoneApi::class)
-              public interface NavEntryTestDestinationComponent : DestinationComponent
             }
 
             @InternalWhetstoneApi
@@ -635,6 +631,10 @@ internal class FileGeneratorTestComposeFragment {
                 }
               }
             }
+            
+            @ContributesTo(TestDestinationScope::class)
+            @OptIn(InternalWhetstoneApi::class)
+            public interface NavEntryTestDestinationComponent : DestinationComponent
             
         """.trimIndent()
     }

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestRendererFragment.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestRendererFragment.kt
@@ -85,10 +85,6 @@ internal class FileGeneratorTestRendererFragment {
                   @BindsInstance coroutineScope: CoroutineScope
                 ): RetainedTestComponent
               }
-
-              @ContributesTo(TestDestinationScope::class)
-              @OptIn(InternalWhetstoneApi::class)
-              public interface NavEntryTestDestinationComponent : DestinationComponent
             }
 
             @InternalWhetstoneApi
@@ -134,6 +130,10 @@ internal class FileGeneratorTestRendererFragment {
                 return renderer.rootView
               }
             }
+            
+            @ContributesTo(TestDestinationScope::class)
+            @OptIn(InternalWhetstoneApi::class)
+            public interface NavEntryTestDestinationComponent : DestinationComponent
             
         """.trimIndent()
     }
@@ -201,10 +201,6 @@ internal class FileGeneratorTestRendererFragment {
                   @BindsInstance coroutineScope: CoroutineScope
                 ): RetainedTestComponent
               }
-
-              @ContributesTo(TestDestinationScope::class)
-              @OptIn(InternalWhetstoneApi::class)
-              public interface NavEntryTestDestinationComponent : DestinationComponent
             }
 
             @InternalWhetstoneApi
@@ -250,6 +246,10 @@ internal class FileGeneratorTestRendererFragment {
                 return renderer.rootView
               }
             }
+            
+            @ContributesTo(TestDestinationScope::class)
+            @OptIn(InternalWhetstoneApi::class)
+            public interface NavEntryTestDestinationComponent : DestinationComponent
             
             @Module
             @ContributesTo(TestDestinationScope::class)
@@ -418,10 +418,6 @@ internal class FileGeneratorTestRendererFragment {
                   @BindsInstance coroutineScope: CoroutineScope
                 ): RetainedTestComponent
               }
-
-              @ContributesTo(TestDestinationScope::class)
-              @OptIn(InternalWhetstoneApi::class)
-              public interface NavEntryTestDestinationComponent : DestinationComponent
             }
 
             @InternalWhetstoneApi
@@ -467,6 +463,10 @@ internal class FileGeneratorTestRendererFragment {
                 return renderer.rootView
               }
             }
+            
+            @ContributesTo(TestDestinationScope::class)
+            @OptIn(InternalWhetstoneApi::class)
+            public interface NavEntryTestDestinationComponent : DestinationComponent
             
         """.trimIndent()
     }


### PR DESCRIPTION
The generated `DestinationComponent` interface doesn't really have a relation with the generated component so it doesn't make sense to have it as a nested class.