### PR TITLE
only collect nav events while being resumed

### DIFF
--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavigationSetup.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavigationSetup.kt
@@ -12,6 +12,8 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.Lifecycle.State.RESUMED
 import androidx.lifecycle.Observer
 import androidx.lifecycle.flowWithLifecycle
 import androidx.navigation.NavController
@@ -53,7 +55,7 @@ public fun NavigationSetup(navigator: NavEventNavigator) {
 
     LaunchedEffect(lifecycleOwner, controller, navigator) {
         navigator.navEvents
-            .flowWithLifecycle(lifecycleOwner.lifecycle)
+            .flowWithLifecycle(lifecycleOwner.lifecycle, minActiveState = RESUMED)
             .collect { event ->
                 navigate(event, controller, activityLaunchers, permissionLaunchers)
             }

--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/HandleNavigation.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/HandleNavigation.kt
@@ -43,7 +43,7 @@ public fun handleNavigation(fragment: Fragment, navigator: NavEventNavigator) {
 
     val lifecycle = fragment.lifecycle
     lifecycle.coroutineScope.launch {
-        lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+        lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
             navigator.navEvents.collect { event ->
                 navigate(event, fragment.findNavController(), activityLaunchers, permissionLaunchers)
             }


### PR DESCRIPTION
Even though it's not documented anywhere, it's only safe to navigate while being resumed. This should avoid an issue we are seeing where a second navigateBack is triggered (double clicking a button) and then handling of the second crashes because the current destination isn't on the backstack anymore.