### PR TITLE
fix DestinationComponent lookup crashing if there is none

### DIFF
--- a/whetstone/navigation-compose/src/main/java/com/freeletics/mad/whetstone/compose/internal/NavComposeViewModelProvider.kt
+++ b/whetstone/navigation-compose/src/main/java/com/freeletics/mad/whetstone/compose/internal/NavComposeViewModelProvider.kt
@@ -27,7 +27,7 @@ import kotlin.reflect.KClass
 @InternalWhetstoneApi
 @OptIn(InternalNavigatorApi::class)
 @Composable
-public inline fun <reified T : ViewModel, D, R : BaseRoute> rememberViewModel(
+public inline fun <reified T : ViewModel, D : Any, R : BaseRoute> rememberViewModel(
     scope: KClass<*>,
     destinationScope: KClass<*>,
     route: R,

--- a/whetstone/navigation-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/internal/NavFragmentViewModelProvider.kt
+++ b/whetstone/navigation-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/internal/NavFragmentViewModelProvider.kt
@@ -20,7 +20,7 @@ import kotlin.reflect.KClass
  * To be used in generated code.
  */
 @InternalWhetstoneApi
-public inline fun <reified T : ViewModel, D, R : BaseRoute> Fragment.viewModel(
+public inline fun <reified T : ViewModel, D : Any, R : BaseRoute> Fragment.viewModel(
     scope: KClass<*>,
     destinationScope: KClass<*>,
     route: R,

--- a/whetstone/navigation/src/main/java/com/freeletics/mad/whetstone/internal/NavEntryViewModelProvider.kt
+++ b/whetstone/navigation/src/main/java/com/freeletics/mad/whetstone/internal/NavEntryViewModelProvider.kt
@@ -16,7 +16,7 @@ import kotlin.reflect.KClass
  * To be used in generated code.
  */
 @InternalWhetstoneApi
-public inline fun <reified T : ViewModel, D, R : BaseRoute> viewModel(
+public inline fun <reified T : ViewModel, D : Any, R : BaseRoute> viewModel(
     entry: NavBackStackEntry,
     context: Context,
     scope: KClass<*>,

--- a/whetstone/navigation/src/main/java/com/freeletics/mad/whetstone/internal/NavFind.kt
+++ b/whetstone/navigation/src/main/java/com/freeletics/mad/whetstone/internal/NavFind.kt
@@ -9,16 +9,23 @@ import kotlin.reflect.KClass
  * [Context.getSystemService].
  */
 @InternalWhetstoneApi
-public fun <T> Context.findDependencies(
+public fun <T : Any> Context.findDependencies(
     scope: KClass<*>,
     destinationScope: KClass<*>,
     findEntry: (Int) -> NavBackStackEntry
 ): T {
-    val destinationComponent = find<DestinationComponent>(destinationScope)
-    val getter = destinationComponent?.navEntryComponentGetters?.get(scope.java)
-    if (getter != null) {
-        @Suppress("UNCHECKED_CAST")
-        return getter.retrieve(findEntry, this) as T
+    if (scope != destinationScope) {
+        val destinationComponent = find(destinationScope) as? DestinationComponent
+        val getter = destinationComponent?.navEntryComponentGetters?.get(scope.java)
+        if (getter != null) {
+            @Suppress("UNCHECKED_CAST")
+            return getter.retrieve(findEntry, this) as T
+        }
     }
-    return find(scope)!!
+    val dependency = find(scope)
+    checkNotNull(dependency) {
+        "Could not find scope ${scope.qualifiedName} through getSystemService"
+    }
+    @Suppress("UNCHECKED_CAST")
+    return dependency as T
 }

--- a/whetstone/runtime-compose/src/main/java/com/freeletics/mad/whetstone/compose/internal/ComposeViewModelProvider.kt
+++ b/whetstone/runtime-compose/src/main/java/com/freeletics/mad/whetstone/compose/internal/ComposeViewModelProvider.kt
@@ -25,7 +25,7 @@ import kotlin.reflect.KClass
  */
 @InternalWhetstoneApi
 @Composable
-public inline fun <reified T : ViewModel, D> rememberViewModel(
+public inline fun <reified T : ViewModel, D : Any> rememberViewModel(
     scope: KClass<*>,
     arguments: Bundle,
     crossinline factory: @DisallowComposableCalls (D, SavedStateHandle, Bundle) -> T

--- a/whetstone/runtime-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/internal/FragmentViewModelProvider.kt
+++ b/whetstone/runtime-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/internal/FragmentViewModelProvider.kt
@@ -20,7 +20,7 @@ import kotlin.reflect.KClass
  * To be used in generated code.
  */
 @InternalWhetstoneApi
-public inline fun <reified T : ViewModel, D> Fragment.viewModel(
+public inline fun <reified T : ViewModel, D : Any> Fragment.viewModel(
     scope: KClass<*>,
     arguments: Bundle,
     crossinline factory: @DisallowComposableCalls (D, SavedStateHandle, Bundle) -> T

--- a/whetstone/runtime/src/main/java/com/freeletics/mad/whetstone/internal/Find.kt
+++ b/whetstone/runtime/src/main/java/com/freeletics/mad/whetstone/internal/Find.kt
@@ -5,16 +5,20 @@ import kotlin.reflect.KClass
 
 @InternalWhetstoneApi
 public fun <T> Context.findDependencies(scope: KClass<*>): T {
-    return find(scope)!!
+    val dependency = find(scope)
+    checkNotNull(dependency) {
+        "Could not find scope ${scope.qualifiedName} through getSystemService"
+    }
+    @Suppress("UNCHECKED_CAST")
+    return dependency as T
 }
 
 @InternalWhetstoneApi
-public fun <T : Any> Context.find(service: KClass<*>): T? {
+public fun Context.find(service: KClass<*>): Any? {
     val serviceName = service.qualifiedName!!
     return find(serviceName) ?: applicationContext.find(serviceName)
 }
 
-@Suppress("UNCHECKED_CAST")
-private fun <T> Context.find(serviceName: String): T? {
-    return getSystemService(serviceName) as T?
+private fun Context.find(serviceName: String): Any? {
+    return getSystemService(serviceName)
 }


### PR DESCRIPTION
This crash happens if no screen in an app uses `@NavEntryComponent`. The general dependency lookup will try to lookup `DestinationComponent` in case it holds the dependencies for it and that will crash because the lookup based on `destinationScope` succeeds but the returned component does not extend `DestinationComponent`. The workaround is to manually extend `DestinationComponent` until this fix is out.

Changes
- Our internal `find` that does the `getSystemService` call will not cast anymore and just returns `Any`
- Both the regular `findDependencies` and the `findDependencies` for navigation will first do a `checkNotNull` with a proper error message on what `find` returned, this will generally make debugging issues easier because you're not just getting a random NPE
- Afterwards `findDependencies` will do the cast
- For the navigation `findDependencies` specifically the `find` call for `DestinationComponent` will now not crash anymore and we do a conditional cast with `as?`, if it's not found we will just do a regular dependency lookup. This fixes the core issue.
- As a small optimization if `scope` and `destinationScope` are equal we skip the whole destination component lookup because we know that the dependencies can't come from a custom scope with a `NavEntryComponentGetter` 