### PR TITLE
fix looking up dependencies in compose

### DIFF
--- a/whetstone/navigation-compose/src/main/java/com/freeletics/mad/whetstone/compose/internal/NavComposeViewModelProvider.kt
+++ b/whetstone/navigation-compose/src/main/java/com/freeletics/mad/whetstone/compose/internal/NavComposeViewModelProvider.kt
@@ -39,7 +39,7 @@ public inline fun <reified T : ViewModel, D, R : BaseRoute> rememberViewModel(
     val navController = LocalNavController.current
     return remember(viewModelStoreOwner, savedStateRegistryOwner, context, navController, route) {
         val viewModelFactory = WhetstoneViewModelFactory(savedStateRegistryOwner) {
-            val dependencies = context.findDependencies<D>(scope::class, destinationScope, navController::getBackStackEntry)
+            val dependencies = context.findDependencies<D>(scope, destinationScope, navController::getBackStackEntry)
             factory(dependencies, it, route)
         }
         val viewModelProvider = ViewModelProvider(viewModelStoreOwner, viewModelFactory)

--- a/whetstone/runtime-compose/src/main/java/com/freeletics/mad/whetstone/compose/internal/ComposeViewModelProvider.kt
+++ b/whetstone/runtime-compose/src/main/java/com/freeletics/mad/whetstone/compose/internal/ComposeViewModelProvider.kt
@@ -35,7 +35,7 @@ public inline fun <reified T : ViewModel, D> rememberViewModel(
     val context = LocalContext.current
     return remember(viewModelStoreOwner, savedStateRegistryOwner, context, arguments) {
         val viewModelFactory = WhetstoneViewModelFactory(savedStateRegistryOwner) {
-            val dependencies = context.findDependencies<D>(scope::class)
+            val dependencies = context.findDependencies<D>(scope)
             factory(dependencies, it, arguments)
         }
         val viewModelProvider = ViewModelProvider(viewModelStoreOwner, viewModelFactory)


### PR DESCRIPTION
The compose methods were mistakenly calling `::class` on `scope` which is already a `KClass`. This makes the lookup fail because instead of looking up something like `javax.inject.Singleton` we look for `ClassReference`