### PR TITLE
introduce ActivityRoute to enable dynamically building intents

### DIFF
--- a/navigator/README.md
+++ b/navigator/README.md
@@ -245,10 +245,11 @@ class ShareRoute(
     private val title: String,
     private val message: String
 ) : ActivityRoute {
-    // the returned Bundle is added to the launched `Intent`
-    override fun intentExtras() = Bundle().apply {
-        putString(Intent.EXTRA_TITLE, title)
-        putParcelable(Intent.EXTRA_INTENT, Intent().apply {
+    // the returned Intent is filled into the Intent of the destination by calling
+    // destinationIntent.fillIn(fillInIntent())
+    override fun fillInIntent() = Intent()
+        .putExtra(Intent.EXTRA_TITLE, title)
+        .putExtra(Intent.EXTRA_INTENT, Intent().apply {
             action = Intent.ACTION_SEND
             type = "text/plain"
             putExtra(Intent.EXTRA_TEXT, message)
@@ -257,7 +258,7 @@ class ShareRoute(
 }
 
 val shareDestination: NavDestination = ActivityDestination<ShareRoute>(
-    // basic intent that is extended with the extras above
+    // basic intent that is extended with the Intent above
     intent = Intent(Intent.ACTION_CHOOSER)
 )
 
@@ -265,21 +266,20 @@ val shareDestination: NavDestination = ActivityDestination<ShareRoute>(
 class BrowserRoute(
     uri: Uri,
 ) : ActivityRoute {
-    // any of the returned extra is added to the launched `Intent`
-    override fun intentExtras: Bundle = Bundle().apply {
-        putExtra(ActivityRoute.INTENT_DATA_URI_STRING, uri.toString())
-    }
+    // the returned Intent is filled into the Intent of the destination by calling
+    // destinationIntent.fillIn(fillInIntent())
+    override fun fillInIntent() = Intent().setData(uri)
 }
 
 val browserDestination: NavDestination = ActivityDestination<BrowserRoute>(
-    // basic intent that gets the ActivityRoute.INTENT_DATA_URI_STRING String extra set as data
+    // basic intent that is extended with the Intent above
     intent = Intent(Intent.ACTION_VIEW)
 )
 ```
 
-Both shown approaches can be combined where for example some extras are statically added to the
+All shown approaches can be combined where for example some extras are statically added to the
 `Intent` when the destination is created and some others are dynamically provided through
-`intentExtras`.
+`fillInIntent`.
 
 ### Activity results
 

--- a/navigator/README.md
+++ b/navigator/README.md
@@ -232,26 +232,48 @@ It is possible to add static extras to the destination or to dynamically add ext
 by implementing `intentExtras`:
 
 ```kotlin
-class BrowserRoute(
-    uri: Uri,
-) : ActivityRoute {
-    // any of the returned extra is added to the launched `Intent`
-    override fun intentExtras: Bundle = Bundle().apply {
-        putExtra("uri", uri.toString())
-    }
-}
-
-val browserDestination: NavDestination = ActivityDestination<BrowserRoute>(
-    // basic intent
-    intent = Intent(ACTION_VIEW)
-)
-
 // minimal route
 object PlayStoreRoute : ActivityRoute
 
 val playStoreDestination: NavDestination = ActivityDestination<PlayStoreRoute>(
     // full intent is statically defined
-    intent = Intent(ACTION_VIEW, Uri.parse("market://details?id=${context.packageName}"))
+    intent = Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=${context.packageName}"))
+)
+
+// route with extra values
+class ShareRoute(
+    private val title: String,
+    private val message: String
+) : ActivityRoute {
+    // the returned Bundle is added to the launched `Intent`
+    override fun intentExtras() = Bundle().apply {
+        putString(Intent.EXTRA_TITLE, title)
+        putParcelable(Intent.EXTRA_INTENT, Intent().apply {
+            action = Intent.ACTION_SEND
+            type = "text/plain"
+            putExtra(Intent.EXTRA_TEXT, message)
+        })
+    }
+}
+
+val shareDestination: NavDestination = ActivityDestination<ShareRoute>(
+    // basic intent that is extended with the extras above
+    intent = Intent(Intent.ACTION_CHOOSER)
+)
+
+// route with a data uri extra
+class BrowserRoute(
+    uri: Uri,
+) : ActivityRoute {
+    // any of the returned extra is added to the launched `Intent`
+    override fun intentExtras: Bundle = Bundle().apply {
+        putExtra(ActivityRoute.INTENT_DATA_URI_STRING, uri.toString())
+    }
+}
+
+val browserDestination: NavDestination = ActivityDestination<BrowserRoute>(
+    // basic intent that gets the ActivityRoute.INTENT_DATA_URI_STRING String extra set as data
+    intent = Intent(Intent.ACTION_VIEW)
 )
 ```
 

--- a/navigator/README.md
+++ b/navigator/README.md
@@ -32,7 +32,7 @@ The most minimal implementation of `NavRoute` would be for a screen that doesn't
 arguments can be a simple Kotlin object:
 ```kotlin
 @Parcelize
-object HomeScreenRoute : NavRoute, Parcelable
+object HomeScreenRoute : NavRoute
 ```
 
 The more common case when a destination needs arguments passed to it would look like this
@@ -40,11 +40,10 @@ The more common case when a destination needs arguments passed to it would look 
 @Parcelize
 data class DetailScreenRoute(
     val id: String,
-) : NavRoute, Parcelable
+) : NavRoute
 ```
 
-Both of these use `Parcelable` and `Parcelize` because internally the library will pass the route
-to the screen itself so that it can access the parameters.
+Internally the library will pass the route to the screen itself so that it can access the parameters.
 
 ### NavDestination
 
@@ -58,16 +57,16 @@ If we take the `DetailScreenRoute` example from above, declaring the destination
 like this
 
 ```kotlin
-val detailScreenDestination: NavDestination = screenDestination<DetailScreenRoute> { route: DetailScreenRoute ->
+val detailScreenDestination: NavDestination = ScreenDestination<DetailScreenRoute> { route: DetailScreenRoute ->
     DetailScreen(route)
 }
 ```
 
-The `screenDestination` function will return a new `NavDestination` which is linked to the route
+The `ScreenDestination` function will return a new `NavDestination` which is linked to the route
 that was passed as the generic type parameter. The lambda function then gets an instance of that
 `NavRoute` and calls the `@Composable` function that should be shown.
 
-The other 2 functions to create destinations are `dialogDestination` and `bottomSheetDestination` - they declare destinations that use a dialog or bottom sheet as a container instead of being shown
+The other 2 functions to create destinations are `DialogDestination` and `BottomSheetDestination` - they declare destinations that use a dialog or bottom sheet as a container instead of being shown
 full screen.
 
 These destinations can then be passed to a `NavHost` by putting them into a set:
@@ -85,16 +84,16 @@ setContent {
 The approach for Fragments is very similar
 
 ```kotlin
-val detailScreenDestination: NavDestination = screenDestination<DetailScreenRoute, DetailFragment>()
+val detailScreenDestination: NavDestination = ScreenDestination<DetailScreenRoute, DetailFragment>()
 ```
 
-The `screenDestination` function will return a new `NavDestination` which is linked to the route
+The `ScreenDestination` function will return a new `NavDestination` which is linked to the route
 that was passed as the first generic type parameter. The second type parameter is the `Fragment`
 that will be shown for this destination.
 
-Like the compose destination functions there is also `dialogDestination` to have a `DialogFragment`
-destination. `bottomSheetDestination` does not exist because this would simply be a
-`dialogDestination` with a `BottomSheetDialogFragment`.
+Like the compose destination functions there is also `DialogDestination` to have a `DialogFragment`
+destination. BottomSheetDestination does not exist because this would simply be a
+`DialogDestination` with a `BottomSheetDialogFragment`.
 
 These destinations can then be passed to a `NavHostFragment` by putting them into a set:
 ```kotlin
@@ -124,7 +123,7 @@ to use dagger multibindings for these:
 object DetailScreenModule {
     @Provides
     @IntoSet
-    fun provideDetailScreenDestinations(): NavDestination = screenDestination<DetailScreenRoute> {
+    fun provideDetailScreenDestinations(): NavDestination = ScreenDestination<DetailScreenRoute> {
         DetailScreen(it)
     }
 }
@@ -204,6 +203,61 @@ the destination for `ProfileTabRoot` will be shown.
 `NavEventNavigator` has a `backPresses()` method that returns `Flow<Unit>` which will emit
 whenever Android's back button is used. While this `Flow` is collected the default back handling
 is disabled. This can be used to for example show a confirmation dialog before navigating back.
+
+### Activity destinations
+
+It is also possible navigate to an `Activity` both inside and outside of the app. In both cases
+it's required to define an `ActivityRoute` and an `ActivityDestination` like for any other screen.
+The route can then simply be passed to `navigateTo` to start the associated `Activity`. The
+`ActivityDestination` is just another `NavDestination` than can be added to the `Set` with all
+other destinations.
+
+For an `Activity` in the same app it's recommended to extend `Parcelable` with will allow the
+started `Activity` to obtain the route and use it to easily access any parameter.
+
+This is example shows the route and destination for a `SettingsActivity`:
+```kotlin
+@Parcelize
+data class SettingsActivityRoute(
+    val id: String,
+) : ActivityRoute, Parcelable
+
+val extraActivityDestination: NavDestination = ActivityDestination<SettingsRoute>(
+    intent = Intent(context, SettingsActivity::class)
+)
+```
+
+In the case of external activities `Parcelable` can't be used because it would crash the other app.
+It is possible to add static extras to the destination or to dynamically add extras to the route
+by implementing `intentExtras`:
+
+```kotlin
+class BrowserRoute(
+    uri: Uri,
+) : ActivityRoute {
+    // any of the returned extra is added to the launched `Intent`
+    override fun intentExtras: Bundle = Bundle().apply {
+        putExtra("uri", uri.toString())
+    }
+}
+
+val browserDestination: NavDestination = ActivityDestination<BrowserRoute>(
+    // basic intent
+    intent = Intent(ACTION_VIEW)
+)
+
+// minimal route
+object PlayStoreRoute : ActivityRoute
+
+val playStoreDestination: NavDestination = ActivityDestination<PlayStoreRoute>(
+    // full intent is statically defined
+    intent = Intent(ACTION_VIEW, Uri.parse("market://details?id=${context.packageName}"))
+)
+```
+
+Both shown approaches can be combined where for example some extras are statically added to the
+`Intent` when the destination is created and some others are dynamically provided through
+`intentExtras`.
 
 ### Activity results
 

--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavDestination.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavDestination.kt
@@ -2,6 +2,7 @@ package com.freeletics.mad.navigator.compose
 
 import android.content.Intent
 import androidx.compose.runtime.Composable
+import com.freeletics.mad.navigator.ActivityRoute
 import com.freeletics.mad.navigator.BaseRoute
 import com.freeletics.mad.navigator.NavRoute
 import com.freeletics.mad.navigator.compose.NavDestination.Activity
@@ -48,7 +49,7 @@ public inline fun <reified T : NavRoute> BottomSheetDestination(
  * instance of [T] for navigation.
  */
 @Suppress("FunctionName")
-public inline fun <reified T : NavRoute> ActivityDestination(
+public inline fun <reified T : ActivityRoute> ActivityDestination(
     intent: Intent,
 ): NavDestination = Activity(T::class, intent)
 
@@ -93,7 +94,7 @@ public sealed interface NavDestination {
      * an instance of [route] for navigation.
      */
     public class Activity(
-        internal val route: KClass<out NavRoute>,
+        internal val route: KClass<out ActivityRoute>,
         internal val intent: Intent,
     ) : NavDestination
 }

--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavHost.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavHost.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.ActivityNavigator
 import androidx.navigation.NavArgument
 import androidx.navigation.NavController
@@ -21,6 +22,7 @@ import com.freeletics.mad.navigator.compose.NavDestination.Activity
 import com.freeletics.mad.navigator.compose.NavDestination.BottomSheet
 import com.freeletics.mad.navigator.compose.NavDestination.Dialog
 import com.freeletics.mad.navigator.compose.NavDestination.Screen
+import com.freeletics.mad.navigator.internal.CustomActivityNavigator
 import com.freeletics.mad.navigator.internal.InternalNavigatorApi
 import com.freeletics.mad.navigator.internal.activityDestinationId
 import com.freeletics.mad.navigator.internal.destinationId
@@ -44,8 +46,10 @@ public fun NavHost(
 ) {
     val bottomSheetNavigator = rememberBottomSheetNavigator()
     val navController = rememberNavController(bottomSheetNavigator)
+    val context = LocalContext.current
 
-    val graph = remember(navController, startRoute, destinations) {
+    val graph = remember(navController, context, startRoute, destinations) {
+        navController.navigatorProvider.addNavigator(CustomActivityNavigator(context))
         @Suppress("deprecation")
         navController.createGraph(startDestination = startRoute.destinationId()) {
             destinations.forEach { destination ->
@@ -121,12 +125,11 @@ private fun <T : NavRoute> BottomSheet<T>.toDestination(
 
 private fun Activity.toDestination(
     controller: NavController,
-): ActivityNavigator.Destination {
-    val navigator = controller.navigatorProvider[ActivityNavigator::class]
-    return ActivityNavigator.Destination(navigator).also {
+): CustomActivityNavigator.Destination {
+    val navigator = controller.navigatorProvider[CustomActivityNavigator::class]
+    return CustomActivityNavigator.Destination(navigator).also {
         it.id = route.activityDestinationId()
-        it.setIntent(intent)
-        it.setDataPattern("{test}")
+        it.intent = intent
     }
 }
 

--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavHost.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavHost.kt
@@ -22,6 +22,7 @@ import com.freeletics.mad.navigator.compose.NavDestination.BottomSheet
 import com.freeletics.mad.navigator.compose.NavDestination.Dialog
 import com.freeletics.mad.navigator.compose.NavDestination.Screen
 import com.freeletics.mad.navigator.internal.InternalNavigatorApi
+import com.freeletics.mad.navigator.internal.activityDestinationId
 import com.freeletics.mad.navigator.internal.destinationId
 import com.freeletics.mad.navigator.internal.getArguments
 import com.freeletics.mad.navigator.internal.toRoute
@@ -123,8 +124,9 @@ private fun Activity.toDestination(
 ): ActivityNavigator.Destination {
     val navigator = controller.navigatorProvider[ActivityNavigator::class]
     return ActivityNavigator.Destination(navigator).also {
-        it.id = route.destinationId()
+        it.id = route.activityDestinationId()
         it.setIntent(intent)
+        it.setDataPattern("{test}")
     }
 }
 

--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavDestination.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavDestination.kt
@@ -3,6 +3,7 @@ package com.freeletics.mad.navigator.fragment
 import android.content.Intent
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
+import com.freeletics.mad.navigator.ActivityRoute
 import com.freeletics.mad.navigator.BaseRoute
 import com.freeletics.mad.navigator.NavRoute
 import com.freeletics.mad.navigator.fragment.NavDestination.Activity
@@ -34,7 +35,7 @@ public inline fun <reified T : NavRoute, reified F : DialogFragment> DialogDesti
  * instance of [T] for navigation.
  */
 @Suppress("FunctionName")
-public inline fun <reified T : NavRoute> ActivityDestination(
+public inline fun <reified T : ActivityRoute> ActivityDestination(
     intent: Intent,
 ): NavDestination = Activity(T::class, intent)
 
@@ -69,7 +70,7 @@ public sealed interface NavDestination {
      * [intent] will be used to launch the `Activity` when using an instance of [route] for
      * navigation.
      */
-    public class Activity<T : NavRoute>(
+    public class Activity<T : ActivityRoute>(
         internal val route: KClass<T>,
         internal val intent: Intent,
     ) : NavDestination

--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavHostFragment.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavHostFragment.kt
@@ -9,6 +9,7 @@ import androidx.navigation.fragment.FragmentNavigator
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.get
 import com.freeletics.mad.navigator.BaseRoute
+import com.freeletics.mad.navigator.internal.activityDestinationId
 import com.freeletics.mad.navigator.internal.getArguments
 import com.freeletics.mad.navigator.internal.destinationId
 
@@ -67,7 +68,7 @@ private fun NavDestination.Activity<*>.toDestination(
 ): ActivityNavigator.Destination {
     val navigator = controller.navigatorProvider[ActivityNavigator::class]
     return ActivityNavigator.Destination(navigator).also {
-        it.id = route.destinationId()
+        it.id = route.activityDestinationId()
         it.setIntent(intent)
     }
 }

--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavHostFragment.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavHostFragment.kt
@@ -9,6 +9,7 @@ import androidx.navigation.fragment.FragmentNavigator
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.get
 import com.freeletics.mad.navigator.BaseRoute
+import com.freeletics.mad.navigator.internal.CustomActivityNavigator
 import com.freeletics.mad.navigator.internal.activityDestinationId
 import com.freeletics.mad.navigator.internal.getArguments
 import com.freeletics.mad.navigator.internal.destinationId
@@ -21,6 +22,7 @@ public fun NavHostFragment.setGraph(
     startRoute: BaseRoute,
     destinations: Set<NavDestination>,
 ) {
+    navController.navigatorProvider.addNavigator(CustomActivityNavigator(requireContext()))
     @Suppress("deprecation")
     val graph = navController.createGraph(startDestination = startRoute.destinationId()) {
         destinations.forEach { destination ->
@@ -65,10 +67,10 @@ private fun NavDestination.Dialog<*>.toDestination(
 
 private fun NavDestination.Activity<*>.toDestination(
     controller: NavController,
-): ActivityNavigator.Destination {
-    val navigator = controller.navigatorProvider[ActivityNavigator::class]
-    return ActivityNavigator.Destination(navigator).also {
+): CustomActivityNavigator.Destination {
+    val navigator = controller.navigatorProvider[CustomActivityNavigator::class]
+    return CustomActivityNavigator.Destination(navigator).also {
         it.id = route.activityDestinationId()
-        it.setIntent(intent)
+        it.intent = intent
     }
 }

--- a/navigator/runtime/api/navigator-runtime.api
+++ b/navigator/runtime/api/navigator-runtime.api
@@ -3,11 +3,15 @@ public final class com/freeletics/mad/navigator/ActivityResultRequest : com/free
 }
 
 public abstract interface class com/freeletics/mad/navigator/ActivityRoute {
-	public abstract fun intentExtras ()Landroid/os/Bundle;
+	public static final field Companion Lcom/freeletics/mad/navigator/ActivityRoute$Companion;
+	public abstract fun fillInIntent ()Landroid/content/Intent;
+}
+
+public final class com/freeletics/mad/navigator/ActivityRoute$Companion {
 }
 
 public final class com/freeletics/mad/navigator/ActivityRoute$DefaultImpls {
-	public static fun intentExtras (Lcom/freeletics/mad/navigator/ActivityRoute;)Landroid/os/Bundle;
+	public static fun fillInIntent (Lcom/freeletics/mad/navigator/ActivityRoute;)Landroid/content/Intent;
 }
 
 public abstract interface class com/freeletics/mad/navigator/BaseRoute : android/os/Parcelable {
@@ -84,6 +88,19 @@ public final class com/freeletics/mad/navigator/PermissionsResultRequest$Permiss
 
 public abstract class com/freeletics/mad/navigator/ResultOwner {
 	public final fun getResults ()Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class com/freeletics/mad/navigator/internal/CustomActivityNavigator$Companion {
+}
+
+public class com/freeletics/mad/navigator/internal/CustomActivityNavigator$Destination : androidx/navigation/NavDestination {
+	public fun <init> (Landroidx/navigation/Navigator;)V
+	public fun <init> (Landroidx/navigation/NavigatorProvider;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIntent ()Landroid/content/Intent;
+	public fun hashCode ()I
+	public final fun setIntent (Landroid/content/Intent;)V
+	public fun supportsActions ()Z
 }
 
 public abstract interface annotation class com/freeletics/mad/navigator/internal/InternalNavigatorApi : java/lang/annotation/Annotation {

--- a/navigator/runtime/api/navigator-runtime.api
+++ b/navigator/runtime/api/navigator-runtime.api
@@ -2,7 +2,15 @@ public final class com/freeletics/mad/navigator/ActivityResultRequest : com/free
 	public final fun getContract ()Landroidx/activity/result/contract/ActivityResultContract;
 }
 
-public abstract interface class com/freeletics/mad/navigator/BaseRoute {
+public abstract interface class com/freeletics/mad/navigator/ActivityRoute {
+	public abstract fun intentExtras ()Landroid/os/Bundle;
+}
+
+public final class com/freeletics/mad/navigator/ActivityRoute$DefaultImpls {
+	public static fun intentExtras (Lcom/freeletics/mad/navigator/ActivityRoute;)Landroid/os/Bundle;
+}
+
+public abstract interface class com/freeletics/mad/navigator/BaseRoute : android/os/Parcelable {
 }
 
 public class com/freeletics/mad/navigator/NavEventNavigator {
@@ -19,6 +27,7 @@ public class com/freeletics/mad/navigator/NavEventNavigator {
 	public static synthetic fun navigateBackTo$default (Lcom/freeletics/mad/navigator/NavEventNavigator;Lkotlin/reflect/KClass;ZILjava/lang/Object;)V
 	public final fun navigateForResult (Lcom/freeletics/mad/navigator/ActivityResultRequest;)V
 	public final fun navigateForResult (Lcom/freeletics/mad/navigator/ActivityResultRequest;Ljava/lang/Object;)V
+	public final fun navigateTo (Lcom/freeletics/mad/navigator/ActivityRoute;)V
 	public final fun navigateTo (Lcom/freeletics/mad/navigator/NavRoute;)V
 	public final fun navigateToRoot (Lcom/freeletics/mad/navigator/NavRoot;Z)V
 	public static synthetic fun navigateToRoot$default (Lcom/freeletics/mad/navigator/NavEventNavigator;Lcom/freeletics/mad/navigator/NavRoot;ZILjava/lang/Object;)V

--- a/navigator/runtime/api/navigator-runtime.api
+++ b/navigator/runtime/api/navigator-runtime.api
@@ -90,19 +90,6 @@ public abstract class com/freeletics/mad/navigator/ResultOwner {
 	public final fun getResults ()Lkotlinx/coroutines/flow/Flow;
 }
 
-public final class com/freeletics/mad/navigator/internal/CustomActivityNavigator$Companion {
-}
-
-public class com/freeletics/mad/navigator/internal/CustomActivityNavigator$Destination : androidx/navigation/NavDestination {
-	public fun <init> (Landroidx/navigation/Navigator;)V
-	public fun <init> (Landroidx/navigation/NavigatorProvider;)V
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getIntent ()Landroid/content/Intent;
-	public fun hashCode ()I
-	public final fun setIntent (Landroid/content/Intent;)V
-	public fun supportsActions ()Z
-}
-
 public abstract interface annotation class com/freeletics/mad/navigator/internal/InternalNavigatorApi : java/lang/annotation/Annotation {
 }
 

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEvent.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEvent.kt
@@ -35,6 +35,14 @@ public sealed interface NavEvent {
     ) : NavEvent
 
     /**
+     * Navigates to the given [route].
+     */
+    @VisibleForTesting(otherwise = PACKAGE_PRIVATE)
+    public data class NavigateToActivityEvent(
+        internal val route: ActivityRoute,
+    ) : NavEvent
+
+    /**
      * Navigates up.
      */
     @VisibleForTesting(otherwise = PACKAGE_PRIVATE)

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
@@ -8,6 +8,7 @@ import androidx.annotation.VisibleForTesting.PACKAGE_PRIVATE
 import com.freeletics.mad.navigator.NavEvent.ActivityResultEvent
 import com.freeletics.mad.navigator.NavEvent.BackEvent
 import com.freeletics.mad.navigator.NavEvent.BackToEvent
+import com.freeletics.mad.navigator.NavEvent.NavigateToActivityEvent
 import com.freeletics.mad.navigator.NavEvent.NavigateToEvent
 import com.freeletics.mad.navigator.NavEvent.PermissionsResultEvent
 import com.freeletics.mad.navigator.NavEvent.UpEvent
@@ -21,7 +22,6 @@ import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.receiveAsFlow
 
 /**
  * A navigator that allows to fire [events][NavEvent] through it's methods. These
@@ -143,6 +143,14 @@ public open class NavEventNavigator {
         restoreRootState: Boolean = false,
     ) {
         val event = NavEvent.NavigateToRootEvent(root, restoreRootState)
+        sendNavEvent(event)
+    }
+
+    /**
+     * Triggers a new [NavEvent] to navigate to the given [route].
+     */
+    public fun navigateTo(route: ActivityRoute) {
+        val event = NavigateToActivityEvent(route)
         sendNavEvent(event)
     }
 

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavRoute.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavRoute.kt
@@ -1,5 +1,6 @@
 package com.freeletics.mad.navigator
 
+import android.content.Intent
 import android.os.Bundle
 import android.os.Parcelable
 
@@ -31,9 +32,9 @@ public interface NavRoot : BaseRoute
  * route leads to a different app.
  */
 public interface ActivityRoute {
-    public fun intentExtras(): Bundle = Bundle.EMPTY
+    public fun fillInIntent(): Intent = EMPTY_INTENT
 
     public companion object {
-        public const val INTENT_DATA_URI_STRING: String = "com.freeletics.navigator.INTENT_DATA_URI"
+        private val EMPTY_INTENT = Intent()
     }
 }

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavRoute.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavRoute.kt
@@ -1,14 +1,15 @@
 package com.freeletics.mad.navigator
 
+import android.os.Bundle
 import android.os.Parcelable
 
-public sealed interface BaseRoute
+public sealed interface BaseRoute : Parcelable
 
 /**
  * Represents the route to a destination.
  *
- * When the implementing class is [Parcelable], the instance of route will be put into the
- * navigation arguments and is then available to the target screens.
+ * The instance of this will be put into the navigation arguments as a [Parcelable] and is then
+ * available to the target screens.
  */
 public interface NavRoute : BaseRoute
 
@@ -17,7 +18,18 @@ public interface NavRoute : BaseRoute
  * a backstack. When you navigate to a [NavRoot] the current backstack is saved and removed
  * so that the [NavRoot] is right on top of the start destination.
  *
- * When the implementing class is [Parcelable], the instance of route will be put into the
- * navigation arguments and is then available to the target screens.
+ * The instance of this will be put into the navigation arguments as a [Parcelable] and is then
+ * available to the target screens.
  */
 public interface NavRoot : BaseRoute
+
+/**
+ * Represents the route to a destination.
+ *
+ * When the implementing class is [Parcelable], the instance of route will be put into the
+ * navigation arguments and is then available to the target screens. Do not do this in case this
+ * route leads to a different app.
+ */
+public interface ActivityRoute {
+    public fun intentExtras(): Bundle = Bundle.EMPTY
+}

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavRoute.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavRoute.kt
@@ -32,4 +32,8 @@ public interface NavRoot : BaseRoute
  */
 public interface ActivityRoute {
     public fun intentExtras(): Bundle = Bundle.EMPTY
+
+    public companion object {
+        public const val INTENT_DATA_URI_STRING: String = "com.freeletics.navigator.INTENT_DATA_URI"
+    }
 }

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/CustomActivityNavigator.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/CustomActivityNavigator.kt
@@ -34,7 +34,7 @@ import com.freeletics.mad.navigator.ActivityRoute
 @Navigator.Name("activity")
 @InternalNavigatorApi
 public open class CustomActivityNavigator(
-    public val context: Context
+    private val context: Context
 ) : Navigator<CustomActivityNavigator.Destination>() {
     private val hostActivity: Activity? = generateSequence(context) {
         if (it is ContextWrapper) {
@@ -85,7 +85,7 @@ public open class CustomActivityNavigator(
         }
         val intent = Intent(destination.intent)
         if (args != null) {
-            val fillInIntent = intent.getParcelableExtra<Intent>(EXTRA_FILL_IN_INTENT)
+            val fillInIntent = args.getParcelable<Intent>(EXTRA_FILL_IN_INTENT)
             if (fillInIntent != null) {
                 intent.fillIn(fillInIntent, 0)
             }
@@ -128,6 +128,7 @@ public open class CustomActivityNavigator(
      * [NavigatorProvider.getNavigator] method.
      */
     @NavDestination.ClassType(Activity::class)
+    @InternalNavigatorApi
     public open class Destination(
         activityNavigator: Navigator<out Destination>
     ) : NavDestination(activityNavigator) {
@@ -148,10 +149,6 @@ public open class CustomActivityNavigator(
             navigatorProvider: NavigatorProvider
         ) : this(navigatorProvider.getNavigator(CustomActivityNavigator::class.java))
 
-        public override fun supportsActions(): Boolean {
-            return false
-        }
-
         override fun equals(other: Any?): Boolean {
             if (other == null || other !is Destination) return false
             return super.equals(other) &&
@@ -165,7 +162,7 @@ public open class CustomActivityNavigator(
         }
     }
 
-    public companion object {
+    private companion object {
         private const val EXTRA_NAV_SOURCE = "android-support-navigation:ActivityNavigator:source"
         private const val EXTRA_NAV_CURRENT = "android-support-navigation:ActivityNavigator:current"
     }

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/CustomActivityNavigator.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/CustomActivityNavigator.kt
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.freeletics.mad.navigator.internal
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import androidx.navigation.NavController
+import androidx.navigation.NavDestination
+import androidx.navigation.NavOptions
+import androidx.navigation.Navigator
+import androidx.navigation.NavigatorProvider
+import com.freeletics.mad.navigator.ActivityRoute
+
+/**
+ * ActivityNavigator implements cross-activity navigation.
+ */
+@Navigator.Name("activity")
+@InternalNavigatorApi
+public open class CustomActivityNavigator(
+    public val context: Context
+) : Navigator<CustomActivityNavigator.Destination>() {
+    private val hostActivity: Activity? = generateSequence(context) {
+        if (it is ContextWrapper) {
+            it.baseContext
+        } else
+            null
+    }.firstOrNull {
+        it is Activity
+    } as Activity?
+
+    override fun createDestination(): Destination {
+        return Destination(this)
+    }
+
+    override fun popBackStack(): Boolean {
+        if (hostActivity != null) {
+            hostActivity.finish()
+            return true
+        }
+        return false
+    }
+
+    /**
+     * Navigate to a destination.
+     *
+     * <p>Requests navigation to a given destination associated with this navigator in
+     * the navigation graph. This method generally should not be called directly;
+     * NavController will delegate to it when appropriate.</p>
+     *
+     * @param destination destination node to navigate to
+     * @param args arguments to use for navigation
+     * @param navOptions additional options for navigation
+     * @param navigatorExtras extras unique to your Navigator.
+     * @return The NavDestination that should be added to the back stack or null if
+     * no change was made to the back stack (i.e., in cases of single top operations
+     * where the destination is already on top of the back stack).
+     *
+     * @throws IllegalArgumentException if the given destination has no Intent
+     */
+    override fun navigate(
+        destination: Destination,
+        args: Bundle?,
+        navOptions: NavOptions?,
+        navigatorExtras: Extras?
+    ): NavDestination? {
+        checkNotNull(destination.intent) {
+            ("Destination ${destination.id} does not have an Intent set.")
+        }
+        val intent = Intent(destination.intent)
+        if (args != null) {
+            intent.putExtras(args)
+            val uriString = intent.getStringExtra(ActivityRoute.INTENT_DATA_URI_STRING)
+            if (uriString != null) {
+                intent.data = Uri.parse(uriString)
+            }
+        }
+        if (hostActivity == null) {
+            // If we're not launching from an Activity context we have to launch in a new task.
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        if (navOptions != null && navOptions.shouldLaunchSingleTop()) {
+            intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
+        }
+        if (hostActivity != null) {
+            val hostIntent = hostActivity.intent
+            if (hostIntent != null) {
+                val hostCurrentId = hostIntent.getIntExtra(EXTRA_NAV_CURRENT, 0)
+                if (hostCurrentId != 0) {
+                    intent.putExtra(EXTRA_NAV_SOURCE, hostCurrentId)
+                }
+            }
+        }
+        val destId = destination.id
+        intent.putExtra(EXTRA_NAV_CURRENT, destId)
+
+        context.startActivity(intent)
+
+        // You can't pop the back stack from the caller of a new Activity,
+        // so we don't add this navigator to the controller's back stack
+        return null
+    }
+
+    /**
+     * NavDestination for activity navigation
+     *
+     * Construct a new activity destination. This destination is not valid until you set the
+     * Intent via [setIntent] or one or more of the other set method.
+     *
+     * @param activityNavigator The [ActivityNavigator] which this destination
+     * will be associated with. Generally retrieved via a
+     * [NavController]'s
+     * [NavigatorProvider.getNavigator] method.
+     */
+    @NavDestination.ClassType(Activity::class)
+    public open class Destination(
+        activityNavigator: Navigator<out Destination>
+    ) : NavDestination(activityNavigator) {
+        /**
+         * The Intent associated with this destination.
+         */
+        public var intent: Intent? = null
+
+        /**
+         * Construct a new activity destination. This destination is not valid until you set the
+         * Intent via [setIntent] or one or more of the other set method.
+         *
+         *
+         * @param navigatorProvider The [NavController] which this destination
+         * will be associated with.
+         */
+        public constructor(
+            navigatorProvider: NavigatorProvider
+        ) : this(navigatorProvider.getNavigator(CustomActivityNavigator::class.java))
+
+        public override fun supportsActions(): Boolean {
+            return false
+        }
+
+        override fun equals(other: Any?): Boolean {
+            if (other == null || other !is Destination) return false
+            return super.equals(other) &&
+                intent?.filterEquals(other.intent) ?: (other.intent == null)
+        }
+
+        override fun hashCode(): Int {
+            var result = super.hashCode()
+            result = 31 * result + (intent?.filterHashCode() ?: 0)
+            return result
+        }
+    }
+
+    public companion object {
+        private const val EXTRA_NAV_SOURCE = "android-support-navigation:ActivityNavigator:source"
+        private const val EXTRA_NAV_CURRENT = "android-support-navigation:ActivityNavigator:current"
+    }
+}

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/CustomActivityNavigator.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/CustomActivityNavigator.kt
@@ -85,10 +85,9 @@ public open class CustomActivityNavigator(
         }
         val intent = Intent(destination.intent)
         if (args != null) {
-            intent.putExtras(args)
-            val uriString = intent.getStringExtra(ActivityRoute.INTENT_DATA_URI_STRING)
-            if (uriString != null) {
-                intent.data = Uri.parse(uriString)
+            val fillInIntent = intent.getParcelableExtra<Intent>(EXTRA_FILL_IN_INTENT)
+            if (fillInIntent != null) {
+                intent.fillIn(fillInIntent, 0)
             }
         }
         if (hostActivity == null) {

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/Navigate.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/Navigate.kt
@@ -99,10 +99,11 @@ public fun BaseRoute.getArguments(): Bundle = Bundle().also {
 
 @InternalNavigatorApi
 public fun ActivityRoute.getArguments(): Bundle = Bundle().also {
-    it.putAll(intentExtras())
+    it.putParcelable(EXTRA_FILL_IN_INTENT, fillInIntent())
     if (this is Parcelable) {
         it.putParcelable(EXTRA_ROUTE, this)
     }
 }
 
 private const val EXTRA_ROUTE = "com.freeletics.mad.navigation.ROUTE"
+internal const val EXTRA_FILL_IN_INTENT = "com.freeletics.mad.navigation.FILL_IN_INTENT"

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/Navigate.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/Navigate.kt
@@ -90,6 +90,9 @@ private fun KClass<*>.internalDestinationId() = qualifiedName!!.hashCode()
 public fun <T : BaseRoute> Bundle.toRoute(): T = getParcelable(EXTRA_ROUTE)!!
 
 @InternalNavigatorApi
+public fun <T : ActivityRoute> Bundle.toActivityRoute(): T = getParcelable(EXTRA_ROUTE)!!
+
+@InternalNavigatorApi
 public fun BaseRoute.getArguments(): Bundle = Bundle().also {
     it.putParcelable(EXTRA_ROUTE, this)
 }

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/Navigate.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/Navigate.kt
@@ -6,6 +6,7 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.navigation.NavController
 import androidx.navigation.NavOptions
 import com.freeletics.mad.navigator.ActivityResultRequest
+import com.freeletics.mad.navigator.ActivityRoute
 import com.freeletics.mad.navigator.BaseRoute
 import com.freeletics.mad.navigator.NavEvent
 import com.freeletics.mad.navigator.PermissionsResultRequest
@@ -33,6 +34,9 @@ public fun navigate(
                 .setLaunchSingleTop(true)
                 .build()
             controller.navigate(event.root.destinationId(), event.root.getArguments(), options)
+        }
+        is NavEvent.NavigateToActivityEvent -> {
+            controller.navigate(event.route.destinationId(), event.route.getArguments())
         }
         is NavEvent.UpEvent -> {
             controller.navigateUp()
@@ -72,13 +76,27 @@ public fun navigate(
 public fun BaseRoute.destinationId(): Int = this::class.destinationId()
 
 @InternalNavigatorApi
-public fun KClass<out BaseRoute>.destinationId(): Int = qualifiedName!!.hashCode()
+public fun KClass<out BaseRoute>.destinationId(): Int = internalDestinationId()
+
+@InternalNavigatorApi
+public fun ActivityRoute.destinationId(): Int = this::class.activityDestinationId()
+
+@InternalNavigatorApi
+public fun KClass<out ActivityRoute>.activityDestinationId(): Int = internalDestinationId()
+
+private fun KClass<*>.internalDestinationId() = qualifiedName!!.hashCode()
 
 @InternalNavigatorApi
 public fun <T : BaseRoute> Bundle.toRoute(): T = getParcelable(EXTRA_ROUTE)!!
 
 @InternalNavigatorApi
 public fun BaseRoute.getArguments(): Bundle = Bundle().also {
+    it.putParcelable(EXTRA_ROUTE, this)
+}
+
+@InternalNavigatorApi
+public fun ActivityRoute.getArguments(): Bundle = Bundle().also {
+    it.putAll(intentExtras())
     if (this is Parcelable) {
         it.putParcelable(EXTRA_ROUTE, this)
     }

--- a/navigator/runtime/src/test/java/com/freeletics/mad/navigator/NavEventNavigatorTest.kt
+++ b/navigator/runtime/src/test/java/com/freeletics/mad/navigator/NavEventNavigatorTest.kt
@@ -5,6 +5,7 @@ import android.os.Parcelable
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.activity.result.contract.ActivityResultContracts
 import app.cash.turbine.test
+import com.freeletics.mad.navigator.NavEvent.NavigateToActivityEvent
 import com.freeletics.mad.navigator.NavEvent.NavigateToEvent
 import com.freeletics.mad.navigator.NavEvent.NavigateToRootEvent
 import com.google.common.truth.Truth.assertThat
@@ -40,6 +41,7 @@ public class NavEventNavigatorTest {
         override fun describeContents(): Int = 0
         override fun writeToParcel(dest: Parcel?, flags: Int) {}
     }
+    private data class SimpleActivity(val number: Int) : ActivityRoute
 
     private data class TestParcelable(
         val value: Int
@@ -88,6 +90,19 @@ public class NavEventNavigatorTest {
             navigator.navigateToRoot(SimpleRoot(1), true)
 
             assertThat(awaitItem()).isEqualTo(NavigateToRootEvent(SimpleRoot(1), true))
+
+            cancel()
+        }
+    }
+
+    @Test
+    public fun `navigateTo Activity event is received`(): Unit = runBlocking {
+        val navigator = TestNavigator()
+
+        navigator.navEvents.test {
+            navigator.navigateTo(SimpleActivity(1))
+
+            assertThat(awaitItem()).isEqualTo(NavigateToActivityEvent(SimpleActivity(1)))
 
             cancel()
         }

--- a/navigator/runtime/src/test/java/com/freeletics/mad/navigator/NavEventNavigatorTest.kt
+++ b/navigator/runtime/src/test/java/com/freeletics/mad/navigator/NavEventNavigatorTest.kt
@@ -28,9 +28,18 @@ public class NavEventNavigatorTest {
         }
     }
 
-    private data class SimpleRoute(val number: Int) : NavRoute
-    private data class OtherRoute(val number: Int) : NavRoute
-    private data class SimpleRoot(val number: Int) : NavRoot
+    private data class SimpleRoute(val number: Int) : NavRoute {
+        override fun describeContents(): Int = 0
+        override fun writeToParcel(dest: Parcel?, flags: Int) {}
+    }
+    private data class OtherRoute(val number: Int) : NavRoute {
+        override fun describeContents(): Int = 0
+        override fun writeToParcel(dest: Parcel?, flags: Int) {}
+    }
+    private data class SimpleRoot(val number: Int) : NavRoot {
+        override fun describeContents(): Int = 0
+        override fun writeToParcel(dest: Parcel?, flags: Int) {}
+    }
 
     private data class TestParcelable(
         val value: Int


### PR DESCRIPTION
Navigating to an internal `Activity` or an external one where you can statically define the full `Intent` in the destination already worked well. However if you need to dynamically add something to the `Intent` like a `data` `Uri` or some extra there was no direct way to do it. The workaround was to use a destination that builds the intent and then removes itself from the backstack after launching it. This worked pretty well with DialogFragments but with compose navigation you see blinking.

To solve it there is now `ActivityRoute` which is a route to activities. It has a `fillInIntent` method that can optionally be overridden to build an `Intent` based on parameters passed to the route. Internally we have a customised and stripped down copy of AndroidX's `ActivityNavigator` that will merge the destination intent and the fillInIntent using `Intnet.fillIn`. I initially didn't use a custom navigator and just allowed building a `Bundle` inside `ActivityRoute`. AndroidX would automatically add the `Bundle` to the launched `Intent` but that is limited to extras and we have mulitple use cases were we set `data` dynamicallly.

`ActivityRoute` is not a `BaseRoute` which means it's now also not possible anymore to accidentally use routes to an activity in places where it doesn't make sense like `navigateBackTo` or in whetstone annotations. The `ActivityNavDestination` enforces that `ActivityRoute` is used for activities. A nice side effect is that we can now make `BaseRoute` extend `Parcelable` by default. Before it would have caused crashes when navigating to external dependencies, not it's not an issue anymore since the hierarchies are separate. It's still possible to manually implement `Parcelable` for `ActivityRoute`s that go internal activities.

Also added a section to the README, I completely forgot to mention activities there.