### PR TITLE
fix broken dokka

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:7.2.1"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.6.21"
+        classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.6.10"
         classpath "com.vanniktech:gradle-maven-publish-plugin:0.20.0"
         classpath "com.autonomousapps:dependency-analysis-gradle-plugin:1.4.0"
         classpath "com.github.ben-manes:gradle-versions-plugin:0.42.0"


### PR DESCRIPTION
AGP depends on an old version of Dokka which causes this incompatibility. Downgrade dokka for now until AGP 7.3.0 fixes it.