### PR TITLE
fix internal api annotation on subcomponents

### DIFF
--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/naventry/NavEntrySubcomponentGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/naventry/NavEntrySubcomponentGenerator.kt
@@ -39,7 +39,6 @@ internal class NavEntrySubcomponentGenerator(
 
     fun generate(): TypeSpec {
         return TypeSpec.interfaceBuilder(navEntrySubcomponentClassName)
-            .addAnnotation(internalApiAnnotation())
             .addAnnotation(scopeToAnnotation(data.scope))
             .addAnnotation(subcomponentAnnotation(data.scope, data.parentScope))
             .addType(navEntrySubcomponentFactory())

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/NavEntryFileGeneratorTest.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/NavEntryFileGeneratorTest.kt
@@ -49,7 +49,6 @@ internal class NavEntryFileGeneratorTest {
             import kotlinx.coroutines.MainScope
             import kotlinx.coroutines.cancel
 
-            @InternalWhetstoneApi
             @ScopeTo(TestFlowScope::class)
             @ContributesSubcomponent(
               scope = TestFlowScope::class,
@@ -143,7 +142,6 @@ internal class NavEntryFileGeneratorTest {
             import kotlin.OptIn
             import kotlin.Unit
 
-            @InternalWhetstoneApi
             @ScopeTo(TestFlowScope::class)
             @ContributesSubcomponent(
               scope = TestFlowScope::class,
@@ -235,7 +233,6 @@ internal class NavEntryFileGeneratorTest {
             import kotlinx.coroutines.MainScope
             import kotlinx.coroutines.cancel
 
-            @InternalWhetstoneApi
             @ScopeTo(TestFlowScope::class)
             @ContributesSubcomponent(
               scope = TestFlowScope::class,


### PR DESCRIPTION
The generated subcomponents for `@NavEntryComponent` had an `@InternalWhetstoneApi` annotation before. This leads to a compilation error in Kotlin 1.6.20 on the generated component that extends it.