### PR TITLE
add Activity.requireRoute API

### DIFF
--- a/navigator/runtime/api/navigator-runtime.api
+++ b/navigator/runtime/api/navigator-runtime.api
@@ -44,6 +44,10 @@ public abstract interface class com/freeletics/mad/navigator/NavRoot : com/freel
 public abstract interface class com/freeletics/mad/navigator/NavRoute : com/freeletics/mad/navigator/BaseRoute {
 }
 
+public final class com/freeletics/mad/navigator/NavRouteKt {
+	public static final fun requireRoute (Landroid/app/Activity;)Lcom/freeletics/mad/navigator/ActivityRoute;
+}
+
 public final class com/freeletics/mad/navigator/NavigationResultRequest : com/freeletics/mad/navigator/ResultOwner {
 	public final fun getKey ()Lcom/freeletics/mad/navigator/NavigationResultRequest$Key;
 }

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavRoute.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavRoute.kt
@@ -1,8 +1,9 @@
 package com.freeletics.mad.navigator
 
+import android.app.Activity
 import android.content.Intent
-import android.os.Bundle
 import android.os.Parcelable
+import com.freeletics.mad.navigator.internal.toActivityRoute
 
 public sealed interface BaseRoute : Parcelable
 
@@ -37,4 +38,11 @@ public interface ActivityRoute {
     public companion object {
         private val EMPTY_INTENT = Intent()
     }
+}
+
+/**
+ * Returns the [ActivityRoute] that was used to navigate to this [Activity].
+ */
+public fun <T : ActivityRoute> Activity.requireRoute(): T {
+    return intent.extras!!.toActivityRoute()
 }


### PR DESCRIPTION
We didn't have any public API that isn't marked as internal to do this until now. Fragments already had one and for compose it's passed directly to your destination.