### PR TITLE
migrate Whetstone tests to truth

### DIFF
--- a/whetstone/compiler/build.gradle
+++ b/whetstone/compiler/build.gradle
@@ -29,5 +29,5 @@ dependencies {
     kapt "com.google.auto.service:auto-service:1.0.1"
 
     testImplementation "junit:junit:4.13.2"
-    testImplementation "io.kotest:kotest-assertions-shared-jvm:5.3.0"
+    testImplementation "com.google.truth:truth:1.1.3"
 }

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
@@ -3,7 +3,7 @@ package com.freeletics.mad.whetstone.codegen
 import com.freeletics.mad.whetstone.ComposeScreenData
 import com.freeletics.mad.whetstone.Navigation
 import com.squareup.kotlinpoet.ClassName
-import io.kotest.matchers.shouldBe
+import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 internal class FileGeneratorTestCompose {
@@ -29,7 +29,9 @@ internal class FileGeneratorTestCompose {
 
     @Test
     fun `generates code for ComposeScreenData`() {
-        FileGenerator().generate(full).toString() shouldBe """
+        val actual = FileGenerator().generate(full).toString()
+
+        val expected = """
             package com.test
 
             import androidx.compose.runtime.Composable
@@ -141,13 +143,16 @@ internal class FileGeneratorTestCompose {
             public interface NavEntryTestDestinationComponent : DestinationComponent
             
         """.trimIndent()
+
+        assertThat(actual).isEqualTo(expected)
     }
 
     @Test
     fun `generates code for ComposeScreenData with destination`() {
         val withDestination = full.copy(navigation = navigation.copy(destinationType = "SCREEN"))
+        val actual = FileGenerator().generate(withDestination).toString()
 
-        FileGenerator().generate(withDestination).toString() shouldBe """
+        val expected = """
             package com.test
 
             import androidx.compose.runtime.Composable
@@ -274,13 +279,16 @@ internal class FileGeneratorTestCompose {
             }
             
         """.trimIndent()
+
+        assertThat(actual).isEqualTo(expected)
     }
 
     @Test
     fun `generates code for ComposeScreenData, no navigation`() {
         val noNavigation = full.copy(navigation = null)
+        val actual = FileGenerator().generate(noNavigation).toString()
 
-        FileGenerator().generate(noNavigation).toString() shouldBe """
+        val expected = """
             package com.test
 
             import android.os.Bundle
@@ -379,13 +387,16 @@ internal class FileGeneratorTestCompose {
             }
             
         """.trimIndent()
+
+        assertThat(actual).isEqualTo(expected)
     }
 
     @Test
     fun `generates code for ComposeScreenData, without coroutines`() {
         val withoutCoroutines = full.copy(coroutinesEnabled = false)
+        val actual = FileGenerator().generate(withoutCoroutines).toString()
 
-        FileGenerator().generate(withoutCoroutines).toString() shouldBe """
+        val expected = """
             package com.test
 
             import androidx.compose.runtime.Composable
@@ -490,13 +501,16 @@ internal class FileGeneratorTestCompose {
             public interface NavEntryTestDestinationComponent : DestinationComponent
             
         """.trimIndent()
+
+        assertThat(actual).isEqualTo(expected)
     }
 
     @Test
     fun `generates code for ComposeScreenData, without rxjava`() {
         val withoutRxJava = full.copy(rxJavaEnabled = false)
+        val actual = FileGenerator().generate(withoutRxJava).toString()
 
-        FileGenerator().generate(withoutRxJava).toString() shouldBe """
+        val expected = """
             package com.test
 
             import androidx.compose.runtime.Composable
@@ -602,6 +616,8 @@ internal class FileGeneratorTestCompose {
             public interface NavEntryTestDestinationComponent : DestinationComponent
             
         """.trimIndent()
+
+        assertThat(actual).isEqualTo(expected)
     }
 
 }

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
@@ -5,7 +5,7 @@ import com.freeletics.mad.whetstone.Navigation
 import com.freeletics.mad.whetstone.codegen.util.dialogFragment
 import com.freeletics.mad.whetstone.codegen.util.fragment
 import com.squareup.kotlinpoet.ClassName
-import io.kotest.matchers.shouldBe
+import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 internal class FileGeneratorTestComposeFragment {
@@ -33,7 +33,9 @@ internal class FileGeneratorTestComposeFragment {
 
     @Test
     fun `generates code for ComposeFragmentData`() {
-        FileGenerator().generate(full).toString() shouldBe """
+        val actual = FileGenerator().generate(full).toString()
+
+        val expected = """
             package com.test
 
             import android.os.Bundle
@@ -178,13 +180,16 @@ internal class FileGeneratorTestComposeFragment {
             public interface NavEntryTestDestinationComponent : DestinationComponent
             
         """.trimIndent()
+
+        assertThat(actual).isEqualTo(expected)
     }
 
     @Test
     fun `generates code for ComposeFragmentData with destination`() {
         val withDestination = full.copy(navigation = navigation.copy(destinationType = "SCREEN"))
+        val actual = FileGenerator().generate(withDestination).toString()
 
-        FileGenerator().generate(withDestination).toString() shouldBe """
+        val expected = """
             package com.test
 
             import android.os.Bundle
@@ -342,6 +347,8 @@ internal class FileGeneratorTestComposeFragment {
             }
             
         """.trimIndent()
+
+        assertThat(actual).isEqualTo(expected)
     }
 
     @Test
@@ -349,8 +356,9 @@ internal class FileGeneratorTestComposeFragment {
         val dialogFragment = full.copy(
             fragmentBaseClass = dialogFragment
         )
+        val actual = FileGenerator().generate(dialogFragment).toString()
 
-        FileGenerator().generate(dialogFragment).toString() shouldBe """
+        val expected = """
             package com.test
 
             import android.os.Bundle
@@ -495,13 +503,16 @@ internal class FileGeneratorTestComposeFragment {
             public interface NavEntryTestDestinationComponent : DestinationComponent
             
         """.trimIndent()
+
+        assertThat(actual).isEqualTo(expected)
     }
 
     @Test
     fun `generates code for ComposeFragmentData, no inset handling`() {
         val noInsetHandling = full.copy(enableInsetHandling = false)
+        val actual = FileGenerator().generate(noInsetHandling).toString()
 
-        FileGenerator().generate(noInsetHandling).toString() shouldBe """
+        val expected = """
             package com.test
 
             import android.os.Bundle
@@ -637,13 +648,16 @@ internal class FileGeneratorTestComposeFragment {
             public interface NavEntryTestDestinationComponent : DestinationComponent
             
         """.trimIndent()
+
+        assertThat(actual).isEqualTo(expected)
     }
 
     @Test
     fun `generates code for ComposeFragmentData, no navigation`() {
         val noNavigation = full.copy(navigation = null)
+        val actual = FileGenerator().generate(noNavigation).toString()
 
-        FileGenerator().generate(noNavigation).toString() shouldBe """
+        val expected = """
             package com.test
 
             import android.os.Bundle
@@ -773,5 +787,7 @@ internal class FileGeneratorTestComposeFragment {
             }
 
         """.trimIndent()
+
+        assertThat(actual).isEqualTo(expected)
     }
 }

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestRendererFragment.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestRendererFragment.kt
@@ -3,7 +3,7 @@ package com.freeletics.mad.whetstone.codegen
 import com.freeletics.mad.whetstone.Navigation
 import com.freeletics.mad.whetstone.RendererFragmentData
 import com.squareup.kotlinpoet.ClassName
-import io.kotest.matchers.shouldBe
+import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 internal class FileGeneratorTestRendererFragment {
@@ -31,7 +31,9 @@ internal class FileGeneratorTestRendererFragment {
 
     @Test
     fun `generates code for RendererFragmentData`() {
-        FileGenerator().generate(full).toString() shouldBe """
+        val actual = FileGenerator().generate(full).toString()
+
+        val expected = """
             package com.test
 
             import android.os.Bundle
@@ -136,13 +138,16 @@ internal class FileGeneratorTestRendererFragment {
             public interface NavEntryTestDestinationComponent : DestinationComponent
             
         """.trimIndent()
+
+        assertThat(actual).isEqualTo(expected)
     }
 
     @Test
     fun `generates code for RendererFragmentData with destination`() {
         val withDestination = full.copy(navigation = navigation.copy(destinationType = "SCREEN"))
+        val actual = FileGenerator().generate(withDestination).toString()
 
-        FileGenerator().generate(withDestination).toString() shouldBe """
+        val expected = """
             package com.test
 
             import android.os.Bundle
@@ -260,13 +265,16 @@ internal class FileGeneratorTestRendererFragment {
             }
             
         """.trimIndent()
+
+        assertThat(actual).isEqualTo(expected)
     }
 
     @Test
     fun `generates code for RendererFragmentData, no navigation`() {
         val noNavigation = full.copy(navigation = null)
+        val actual = FileGenerator().generate(noNavigation).toString()
 
-        FileGenerator().generate(noNavigation).toString() shouldBe """
+        val expected = """
             package com.test
 
             import android.os.Bundle
@@ -356,6 +364,8 @@ internal class FileGeneratorTestRendererFragment {
             }
             
         """.trimIndent()
+
+        assertThat(actual).isEqualTo(expected)
     }
 
     @Test
@@ -363,8 +373,9 @@ internal class FileGeneratorTestRendererFragment {
         val dialogFragment = full.copy(
             fragmentBaseClass = ClassName("androidx.fragment.app", "DialogFragment")
         )
+        val actual = FileGenerator().generate(dialogFragment).toString()
 
-        FileGenerator().generate(dialogFragment).toString() shouldBe """
+        val expected = """
             package com.test
 
             import android.os.Bundle
@@ -469,5 +480,7 @@ internal class FileGeneratorTestRendererFragment {
             public interface NavEntryTestDestinationComponent : DestinationComponent
             
         """.trimIndent()
+
+        assertThat(actual).isEqualTo(expected)
     }
 }

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/NavEntryFileGeneratorTest.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/NavEntryFileGeneratorTest.kt
@@ -2,7 +2,7 @@ package com.freeletics.mad.whetstone.codegen
 
 import com.freeletics.mad.whetstone.NavEntryData
 import com.squareup.kotlinpoet.ClassName
-import io.kotest.matchers.shouldBe
+import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 internal class NavEntryFileGeneratorTest {
@@ -19,7 +19,9 @@ internal class NavEntryFileGeneratorTest {
 
     @Test
     fun `generates code for full NavEntryData`() {
-        FileGenerator().generate(full).toString() shouldBe """
+        val actual = FileGenerator().generate(full).toString()
+
+        val expected = """
             package com.test
 
             import android.content.Context
@@ -109,13 +111,16 @@ internal class NavEntryFileGeneratorTest {
             }
 
         """.trimIndent()
+
+        assertThat(actual).isEqualTo(expected)
     }
 
     @Test
     fun `generates code for NavEntryData without coroutines`() {
         val withoutCoroutines = full.copy(coroutinesEnabled = false)
+        val actual = FileGenerator().generate(withoutCoroutines).toString()
 
-        FileGenerator().generate(withoutCoroutines).toString() shouldBe """
+        val expected = """
             package com.test
 
             import android.content.Context
@@ -198,13 +203,16 @@ internal class NavEntryFileGeneratorTest {
             }
 
         """.trimIndent()
+
+        assertThat(actual).isEqualTo(expected)
     }
 
     @Test
     fun `generates code for NavEntryData without rxjava`() {
         val withoutRxJava = full.copy(rxJavaEnabled = false)
+        val actual = FileGenerator().generate(withoutRxJava).toString()
 
-        FileGenerator().generate(withoutRxJava).toString() shouldBe """
+        val expected = """
             package com.test
 
             import android.content.Context
@@ -289,5 +297,7 @@ internal class NavEntryFileGeneratorTest {
             }
 
         """.trimIndent()
+
+        assertThat(actual).isEqualTo(expected)
     }
 }


### PR DESCRIPTION
Kotest does multi line string diffs very weirdly where it prints both the expected and actual and then adds `[Deletion/Addition at line ...]` to both of them. It's hard to scan so I replaced it with truth which will do very standard diffs.

Truth
```
diff (-expected +actual):
    @@ -1,11 +1,13 @@
     package com.test
     
    +import androidx.compose.runtime.Composable
     import androidx.compose.runtime.CompositionLocalProvider
     import androidx.compose.runtime.ProvidedValue
     import androidx.compose.runtime.rememberCoroutineScope
     import androidx.lifecycle.SavedStateHandle
     import androidx.lifecycle.ViewModel
     import com.freeletics.mad.navigator.NavEventNavigator
    +import com.freeletics.mad.navigator.compose.NavigationSetup
     import com.freeletics.mad.whetstone.ScopeTo
     import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
     import com.freeletics.mad.whetstone.`internal`.DestinationComponent
    @@ -29,6 +31,8 @@
     @InternalWhetstoneApi
     @ScopeTo(TestScreen::class)
     @MergeComponent(
    +  scope = TestScreen::class,
    +  dependencies = [TestDependencies::class],
       modules = [ComposeProviderValueModule::class],
     )
     internal interface RetainedTestComponent {
    @@ -36,8 +40,6 @@
     
       public val navEventNavigator: NavEventNavigator
     
    -  public val foo: Foo
    -
       public val providedValues: Set<ProvidedValue<*>>
     
       @Component.Factory
    @@ -60,7 +62,7 @@
       private val scope: CoroutineScope = MainScope()
     
       public val component: RetainedTestComponent =
    -      DaggerRetainedTestComponent.factory().create(dependencies,savedStateHandle, testRoute, scope)
    +      DaggerRetainedTestComponent.factory().create(dependencies, savedStateHandle, testRoute, scope)
     
       public override fun onCleared(): Unit {
         scope.cancel()
    @@ -70,7 +72,7 @@
     @Composable
     @OptIn(InternalWhetstoneApi::class)
     public fun TestScreen(testRoute: TestRoute): Unit {
    -  val viewModel = rememberViewModel(TestParentScope::class,  TestDestinationScope::class, testRoute,
    +  val viewModel = rememberViewModel(TestParentScope::class, TestDestinationScope::class, testRoute,
           ::TestViewModel)
       val component = viewModel.component
     
    @@ -88,6 +90,7 @@
         val state = stateMachine.asComposeState()
         val currentState = state.value
         if (currentState != null) {
    +      val scope = rememberCoroutineScope()
           Test(currentState) { action ->
             scope.launch { stateMachine.dispatch(action) }
           }
	at app//com.freeletics.mad.whetstone.codegen.FileGeneratorTestCompose.generates code for ComposeScreenData, without rxjava(FileGeneratorTestCompose.kt:617)
```

Kotest
```
io.kotest.assertions.AssertionFailedError: expected:<[Deletion at line 2] 
import androidx.compose.runtime.CompositionLocalProvider
import androidx.compose.runtime.ProvidedValue

[Deletion at line 9] import com.freeletics.mad.whetstone.ScopeTo
import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
import com.freeletics.mad.whetstone.`internal`.DestinationComponent
import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
import com.freeletics.mad.whetstone.`internal`.asComposeState
import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
import com.squareup.anvil.annotations.ContributesTo
import com.squareup.anvil.annotations.MergeComponent
import com.test.destination.TestDestinationScope
import com.test.parent.TestParentScope

[Deletion at line 33] )
internal interface RetainedTestComponent {
  public val testStateMachine: TestStateMachine

  public val navEventNavigator: NavEventNavigator

  public val foo: Foo

  public val providedValues: Set<ProvidedValue<*>>

  @Component.Factory
  public interface Factory {
    public fun create(
      dependencies: TestDependencies,
      @BindsInstance savedStateHandle: SavedStateHandle,
      @BindsInstance testRoute: TestRoute,
      @BindsInstance coroutineScope: CoroutineScope,
    ): RetainedTestComponent
  }
}

@InternalWhetstoneApi
internal class TestViewModel(
  dependencies: TestDependencies,
  savedStateHandle: SavedStateHandle,
  testRoute: TestRoute,
) : ViewModel() {
  private val scope: CoroutineScope = MainScope()

  public val component: RetainedTestComponent =
      DaggerRetainedTestComponent.factory().create(dependencies,savedStateHandle, testRoute, scope)

  public override fun onCleared(): Unit {
    scope.cancel()
  }

[Addition at line 42] 
  @Component.Factory
  public interface Factory {
    public fun create(
      dependencies: TestDependencies,
      @BindsInstance savedStateHandle: SavedStateHandle,
      @BindsInstance testRoute: TestRoute,
      @BindsInstance coroutineScope: CoroutineScope,
    ): RetainedTestComponent
  }
}

@InternalWhetstoneApi
internal class TestViewModel(
  dependencies: TestDependencies,
  savedStateHandle: SavedStateHandle,
  testRoute: TestRoute,
) : ViewModel() {
  private val scope: CoroutineScope = MainScope()

  public val component: RetainedTestComponent =
      DaggerRetainedTestComponent.factory().create(dependencies,savedStateHandle, testRoute, scope)

  public override fun onCleared(): Unit {
    scope.cancel()
  }
}

@Composable
@OptIn(InternalWhetstoneApi::class)
public fun TestScreen(testRoute: TestRoute): Unit {
  val viewModel = rememberViewModel(TestParentScope::class,  TestDestinationScope::class, testRoute,
      ::TestViewModel)
  val component = viewModel.component

  NavigationSetup(component.navEventNavigator)

  TestScreen(component)
}

@Composable
@OptIn(InternalWhetstoneApi::class)

[Change at line 64] 
  public override fun onCleared(): Unit {
    scope.cancel()
  }
}

@Composable
@OptIn(InternalWhetstoneApi::class)
public fun TestScreen(testRoute: TestRoute): Unit {
  val viewModel = rememberViewModel(TestParentScope::class,  TestDestinationScope::class, testRoute,
      ::TestViewModel)
  val component = viewModel.component

  NavigationSetup(component.navEventNavigator)

  TestScreen(component)
}

@Composable
@OptIn(InternalWhetstoneApi::class)
private fun TestScreen(component: RetainedTestComponent): Unit {
  val providedValues = component.providedValues
  CompositionLocalProvider(*providedValues.toTypedArray()) {
    val stateMachine = component.testStateMachine
    val state = stateMachine.asComposeState()
    val currentState = state.value
    if (currentState != null) {
      Test(currentState) { action ->
        scope.launch { stateMachine.dispatch(action) }
      }
    }
  }
}

@ContributesTo(TestDestinationScope::class)
@OptIn(InternalWhetstoneApi::class)
public interface NavEntryTestDestinationComponent : DestinationComponent


[Change at line 74]       ::TestViewModel)
  val component = viewModel.component

  NavigationSetup(component.navEventNavigator)

  TestScreen(component)
}

@Composable
@OptIn(InternalWhetstoneApi::class)
private fun TestScreen(component: RetainedTestComponent): Unit {
  val providedValues = component.providedValues
  CompositionLocalProvider(*providedValues.toTypedArray()) {
    val stateMachine = component.testStateMachine
    val state = stateMachine.asComposeState()
    val currentState = state.value
    if (currentState != null) {
      Test(currentState) { action ->
        scope.launch { stateMachine.dispatch(action) }
      }
    }
  }
}

@ContributesTo(TestDestinationScope::class)
@OptIn(InternalWhetstoneApi::class)
public interface NavEntryTestDestinationComponent : DestinationComponent


[Deletion at line 92]         scope.launch { stateMachine.dispatch(action) }
      }
    }
  }
}

@ContributesTo(TestDestinationScope::class)
@OptIn(InternalWhetstoneApi::class)
public interface NavEntryTestDestinationComponent : DestinationComponent
> but was:<[Deletion at line 2] 
import androidx.compose.runtime.Composable

[Deletion at line 8] import androidx.lifecycle.ViewModel
import com.freeletics.mad.navigator.NavEventNavigator
import com.freeletics.mad.navigator.compose.NavigationSetup
import com.freeletics.mad.whetstone.ScopeTo
import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
import com.freeletics.mad.whetstone.`internal`.DestinationComponent
import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
import com.freeletics.mad.whetstone.`internal`.asComposeState

[Deletion at line 31] @InternalWhetstoneApi
@ScopeTo(TestScreen::class)
@MergeComponent(
  scope = TestScreen::class,
  dependencies = [TestDependencies::class],
  modules = [ComposeProviderValueModule::class],
)
internal interface RetainedTestComponent {
  public val testStateMachine: TestStateMachine

  public val navEventNavigator: NavEventNavigator

  public val providedValues: Set<ProvidedValue<*>>

  @Component.Factory
  public interface Factory {
    public fun create(
      dependencies: TestDependencies,
      @BindsInstance savedStateHandle: SavedStateHandle,
      @BindsInstance testRoute: TestRoute,
      @BindsInstance coroutineScope: CoroutineScope,
    ): RetainedTestComponent
  }
}

@InternalWhetstoneApi
internal class TestViewModel(
  dependencies: TestDependencies,
  savedStateHandle: SavedStateHandle,
  testRoute: TestRoute,
) : ViewModel() {

[Addition at line 38] internal interface RetainedTestComponent {
  public val testStateMachine: TestStateMachine

  public val navEventNavigator: NavEventNavigator

  public val providedValues: Set<ProvidedValue<*>>

  @Component.Factory
  public interface Factory {
    public fun create(
      dependencies: TestDependencies,
      @BindsInstance savedStateHandle: SavedStateHandle,
      @BindsInstance testRoute: TestRoute,
      @BindsInstance coroutineScope: CoroutineScope,
    ): RetainedTestComponent
  }
}

@InternalWhetstoneApi
internal class TestViewModel(
  dependencies: TestDependencies,
  savedStateHandle: SavedStateHandle,
  testRoute: TestRoute,
) : ViewModel() {
  private val scope: CoroutineScope = MainScope()

  public val component: RetainedTestComponent =
      DaggerRetainedTestComponent.factory().create(dependencies, savedStateHandle, testRoute, scope)

  public override fun onCleared(): Unit {
    scope.cancel()
  }
}

@Composable
@OptIn(InternalWhetstoneApi::class)
public fun TestScreen(testRoute: TestRoute): Unit {
  val viewModel = rememberViewModel(TestParentScope::class, TestDestinationScope::class, testRoute,
      ::TestViewModel)
  val component = viewModel.component

[Change at line 62]   private val scope: CoroutineScope = MainScope()

  public val component: RetainedTestComponent =
      DaggerRetainedTestComponent.factory().create(dependencies, savedStateHandle, testRoute, scope)

  public override fun onCleared(): Unit {
    scope.cancel()
  }
}

@Composable
@OptIn(InternalWhetstoneApi::class)
public fun TestScreen(testRoute: TestRoute): Unit {
  val viewModel = rememberViewModel(TestParentScope::class, TestDestinationScope::class, testRoute,
      ::TestViewModel)
  val component = viewModel.component

  NavigationSetup(component.navEventNavigator)

  TestScreen(component)
}

@Composable
@OptIn(InternalWhetstoneApi::class)
private fun TestScreen(component: RetainedTestComponent): Unit {
  val providedValues = component.providedValues
  CompositionLocalProvider(*providedValues.toTypedArray()) {
    val stateMachine = component.testStateMachine
    val state = stateMachine.asComposeState()
    val currentState = state.value
    if (currentState != null) {
      val scope = rememberCoroutineScope()
      Test(currentState) { action ->
        scope.launch { stateMachine.dispatch(action) }
      }
    }
  }
}

@ContributesTo(TestDestinationScope::class)
@OptIn(InternalWhetstoneApi::class)
public interface NavEntryTestDestinationComponent : DestinationComponent


[Change at line 72] @Composable
@OptIn(InternalWhetstoneApi::class)
public fun TestScreen(testRoute: TestRoute): Unit {
  val viewModel = rememberViewModel(TestParentScope::class, TestDestinationScope::class, testRoute,
      ::TestViewModel)
  val component = viewModel.component

  NavigationSetup(component.navEventNavigator)

  TestScreen(component)
}

@Composable
@OptIn(InternalWhetstoneApi::class)
private fun TestScreen(component: RetainedTestComponent): Unit {
  val providedValues = component.providedValues
  CompositionLocalProvider(*providedValues.toTypedArray()) {
    val stateMachine = component.testStateMachine
    val state = stateMachine.asComposeState()
    val currentState = state.value
    if (currentState != null) {
      val scope = rememberCoroutineScope()
      Test(currentState) { action ->
        scope.launch { stateMachine.dispatch(action) }
      }
    }
  }
}

@ContributesTo(TestDestinationScope::class)
@OptIn(InternalWhetstoneApi::class)
public interface NavEntryTestDestinationComponent : DestinationComponent


[Deletion at line 90]     val state = stateMachine.asComposeState()
    val currentState = state.value
    if (currentState != null) {
      val scope = rememberCoroutineScope()
      Test(currentState) { action ->
        scope.launch { stateMachine.dispatch(action) }
      }
    }
  }
}

@ContributesTo(TestDestinationScope::class)
@OptIn(InternalWhetstoneApi::class)
public interface NavEntryTestDestinationComponent : DestinationComponent
>
```