### PR TITLE
use qualifiers for everything automatically provided in nav entry component

### DIFF
--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/naventry/NavEntrySubcomponentGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/naventry/NavEntrySubcomponentGenerator.kt
@@ -5,6 +5,7 @@ import com.freeletics.mad.whetstone.codegen.Generator
 import com.freeletics.mad.whetstone.codegen.common.closeableSetPropertyName
 import com.freeletics.mad.whetstone.codegen.util.bindsInstanceParameter
 import com.freeletics.mad.whetstone.codegen.util.contributesToAnnotation
+import com.freeletics.mad.whetstone.codegen.util.navEntryAnnotation
 import com.freeletics.mad.whetstone.codegen.util.propertyName
 import com.freeletics.mad.whetstone.codegen.util.savedStateHandle
 import com.freeletics.mad.whetstone.codegen.util.scopeToAnnotation
@@ -12,6 +13,8 @@ import com.freeletics.mad.whetstone.codegen.util.subcomponentAnnotation
 import com.freeletics.mad.whetstone.codegen.util.subcomponentFactoryAnnotation
 import com.squareup.anvil.annotations.ExperimentalAnvilApi
 import com.squareup.anvil.compiler.internal.decapitalize
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.AnnotationSpec.UseSiteTarget.GET
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier.ABSTRACT
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
@@ -52,15 +55,17 @@ internal class NavEntrySubcomponentGenerator(
 
     private fun componentProperties(): List<PropertySpec> {
         val properties = mutableListOf<PropertySpec>()
-        properties += PropertySpec.builder(closeableSetPropertyName, SET.parameterizedBy(Closeable::class.asTypeName())).build()
+        properties += PropertySpec.builder(closeableSetPropertyName, SET.parameterizedBy(Closeable::class.asTypeName()))
+            .addAnnotation(navEntryAnnotation(data.scope, GET))
+            .build()
         return properties
     }
 
     private fun navEntrySubcomponentFactory(): TypeSpec {
         val createFun = FunSpec.builder(navEntrySubcomponentFactoryCreateName)
             .addModifiers(ABSTRACT)
-            .addParameter(bindsInstanceParameter("savedStateHandle", savedStateHandle))
-            .addParameter(bindsInstanceParameter(data.route.propertyName, data.route))
+            .addParameter(bindsInstanceParameter("savedStateHandle", savedStateHandle, navEntryAnnotation(data.scope)))
+            .addParameter(bindsInstanceParameter(data.route.propertyName, data.route, navEntryAnnotation(data.scope)))
             .returns(navEntrySubcomponentClassName)
             .build()
         return TypeSpec.interfaceBuilder(navEntrySubcomponentFactoryClassName)

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/naventry/NavEntrySubcomponentModuleGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/naventry/NavEntrySubcomponentModuleGenerator.kt
@@ -10,11 +10,13 @@ import com.freeletics.mad.whetstone.codegen.util.intoSet
 import com.freeletics.mad.whetstone.codegen.util.mainScope
 import com.freeletics.mad.whetstone.codegen.util.module
 import com.freeletics.mad.whetstone.codegen.util.multibinds
+import com.freeletics.mad.whetstone.codegen.util.navEntryAnnotation
 import com.freeletics.mad.whetstone.codegen.util.propertyName
 import com.freeletics.mad.whetstone.codegen.util.provides
 import com.freeletics.mad.whetstone.codegen.util.scopeToAnnotation
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier.ABSTRACT
+import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.SET
 import com.squareup.kotlinpoet.TypeSpec
@@ -38,14 +40,19 @@ internal class NavEntrySubcomponentModuleGenerator(
                     companionFunctions += FunSpec.builder("provideCompositeDisposable")
                         .addAnnotation(provides)
                         .addAnnotation(scopeToAnnotation(data.scope))
+                        .addAnnotation(navEntryAnnotation(data.scope))
                         .returns(compositeDisposable)
                         .addStatement("return %T()", compositeDisposable)
                         .build()
 
+                    val parameter = ParameterSpec.builder(compositeDisposable.propertyName, compositeDisposable)
+                        .addAnnotation(navEntryAnnotation(data.scope))
+                        .build()
                     companionFunctions += FunSpec.builder("bindCompositeDisposable")
                         .addAnnotation(provides)
                         .addAnnotation(intoSet)
-                        .addParameter(compositeDisposable.propertyName, compositeDisposable)
+                        .addAnnotation(navEntryAnnotation(data.scope))
+                        .addParameter(parameter)
                         .returns(Closeable::class.asClassName())
                         .beginControlFlow("return %T", Closeable::class.asClassName())
                         .addStatement("%L.clear()", compositeDisposable.propertyName)
@@ -56,14 +63,19 @@ internal class NavEntrySubcomponentModuleGenerator(
                     companionFunctions += FunSpec.builder("provideCoroutineScope")
                         .addAnnotation(provides)
                         .addAnnotation(scopeToAnnotation(data.scope))
+                        .addAnnotation(navEntryAnnotation(data.scope))
                         .returns(coroutineScope)
                         .addStatement("return %M()", mainScope)
                         .build()
 
+                    val parameter = ParameterSpec.builder(coroutineScope.propertyName, coroutineScope)
+                        .addAnnotation(navEntryAnnotation(data.scope))
+                        .build()
                     companionFunctions += FunSpec.builder("bindCoroutineScope")
                         .addAnnotation(provides)
                         .addAnnotation(intoSet)
-                        .addParameter(coroutineScope.propertyName, coroutineScope)
+                        .addAnnotation(navEntryAnnotation(data.scope))
+                        .addParameter(parameter)
                         .returns(Closeable::class.asClassName())
                         .beginControlFlow("return %T", Closeable::class.asClassName())
                         .addStatement("%L.%M()", coroutineScope.propertyName, coroutineScopeCancel)
@@ -86,6 +98,7 @@ internal class NavEntrySubcomponentModuleGenerator(
         return FunSpec.builder("bindCancellable")
             .addModifiers(ABSTRACT)
             .addAnnotation(multibinds)
+            .addAnnotation(navEntryAnnotation(data.scope))
             .returns(SET.parameterizedBy(Closeable::class.asClassName()))
             .build()
     }

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
@@ -20,6 +20,7 @@ internal val composeNavDestinationFqName = FqName(composeNavDestination.canonica
 internal val composeRootNavDestination = ClassName("com.freeletics.mad.whetstone.compose", "RootNavDestination")
 internal val composeRootNavDestinationFqName = FqName(composeRootNavDestination.canonicalName)
 internal val scopeTo = ClassName("com.freeletics.mad.whetstone", "ScopeTo")
+internal val navEntry = ClassName("com.freeletics.mad.whetstone", "NavEntry")
 internal val navEntryComponent = ClassName("com.freeletics.mad.whetstone", "NavEntryComponent")
 internal val navEntryComponentFqName = FqName(navEntryComponent.canonicalName)
 

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/KotlinPoet.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/KotlinPoet.kt
@@ -5,6 +5,7 @@ import com.freeletics.mad.whetstone.Navigation
 import com.squareup.anvil.annotations.ContributesTo
 import com.squareup.anvil.annotations.MergeComponent
 import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.AnnotationSpec.UseSiteTarget
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.KModifier.LATEINIT
@@ -20,6 +21,13 @@ internal val ClassName.propertyName: String get() {
 internal fun bindsInstanceParameter(name: String, className: ClassName): ParameterSpec {
     return ParameterSpec.builder(name, className)
         .addAnnotation(bindsInstance)
+        .build()
+}
+
+internal fun bindsInstanceParameter(name: String, className: ClassName, annotation: AnnotationSpec): ParameterSpec {
+    return ParameterSpec.builder(name, className)
+        .addAnnotation(bindsInstance)
+        .addAnnotation(annotation)
         .build()
 }
 
@@ -76,6 +84,13 @@ internal fun scopeToAnnotation(scope: ClassName): AnnotationSpec {
 internal fun contributesToAnnotation(scope: ClassName): AnnotationSpec {
     return AnnotationSpec.builder(ContributesTo::class)
         .addMember("%T::class", scope)
+        .build()
+}
+
+internal fun navEntryAnnotation(scope: ClassName, target: UseSiteTarget? = null): AnnotationSpec {
+    return AnnotationSpec.builder(navEntry)
+        .addMember("%T::class", scope)
+        .useSiteTarget(target)
         .build()
 }
 

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/NavEntryFileGeneratorTest.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/NavEntryFileGeneratorTest.kt
@@ -31,6 +31,7 @@ internal class NavEntryFileGeneratorTest {
             import com.freeletics.mad.navigator.`internal`.InternalNavigatorApi
             import com.freeletics.mad.navigator.`internal`.destinationId
             import com.freeletics.mad.navigator.`internal`.toRoute
+            import com.freeletics.mad.whetstone.NavEntry
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetter
@@ -63,11 +64,13 @@ internal class NavEntryFileGeneratorTest {
               parentScope = TestParentScope::class,
             )
             public interface NavEntryTestFlowScopeComponent {
+              @get:NavEntry(TestFlowScope::class)
               public val closeables: Set<Closeable>
     
               @ContributesSubcomponent.Factory
               public interface Factory {
-                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
+                public fun create(@BindsInstance @NavEntry(TestFlowScope::class)
+                    savedStateHandle: SavedStateHandle, @BindsInstance @NavEntry(TestFlowScope::class)
                     testRoute: TestRoute): NavEntryTestFlowScopeComponent
               }
 
@@ -81,27 +84,33 @@ internal class NavEntryFileGeneratorTest {
             @ContributesTo(TestFlowScope::class)
             public interface NavEntryTestFlowScopeModule {
               @Multibinds
+              @NavEntry(TestFlowScope::class)
               public fun bindCancellable(): Set<Closeable>
 
               public companion object {
                 @Provides
                 @ScopeTo(TestFlowScope::class)
+                @NavEntry(TestFlowScope::class)
                 public fun provideCompositeDisposable(): CompositeDisposable = CompositeDisposable()
 
                 @Provides
                 @IntoSet
-                public fun bindCompositeDisposable(compositeDisposable: CompositeDisposable): Closeable =
-                    Closeable {
+                @NavEntry(TestFlowScope::class)
+                public fun bindCompositeDisposable(@NavEntry(TestFlowScope::class)
+                    compositeDisposable: CompositeDisposable): Closeable = Closeable {
                   compositeDisposable.clear()
                 }
             
                 @Provides
                 @ScopeTo(TestFlowScope::class)
+                @NavEntry(TestFlowScope::class)
                 public fun provideCoroutineScope(): CoroutineScope = MainScope()
 
                 @Provides
                 @IntoSet
-                public fun bindCoroutineScope(coroutineScope: CoroutineScope): Closeable = Closeable {
+                @NavEntry(TestFlowScope::class)
+                public fun bindCoroutineScope(@NavEntry(TestFlowScope::class) coroutineScope: CoroutineScope):
+                    Closeable = Closeable {
                   coroutineScope.cancel()
                 }
               }
@@ -160,6 +169,7 @@ internal class NavEntryFileGeneratorTest {
             import com.freeletics.mad.navigator.`internal`.InternalNavigatorApi
             import com.freeletics.mad.navigator.`internal`.destinationId
             import com.freeletics.mad.navigator.`internal`.toRoute
+            import com.freeletics.mad.whetstone.NavEntry
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetter
@@ -189,11 +199,13 @@ internal class NavEntryFileGeneratorTest {
               parentScope = TestParentScope::class,
             )
             public interface NavEntryTestFlowScopeComponent {
+              @get:NavEntry(TestFlowScope::class)
               public val closeables: Set<Closeable>
 
               @ContributesSubcomponent.Factory
               public interface Factory {
-                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
+                public fun create(@BindsInstance @NavEntry(TestFlowScope::class)
+                    savedStateHandle: SavedStateHandle, @BindsInstance @NavEntry(TestFlowScope::class)
                     testRoute: TestRoute): NavEntryTestFlowScopeComponent
               }
 
@@ -207,17 +219,20 @@ internal class NavEntryFileGeneratorTest {
             @ContributesTo(TestFlowScope::class)
             public interface NavEntryTestFlowScopeModule {
               @Multibinds
+              @NavEntry(TestFlowScope::class)
               public fun bindCancellable(): Set<Closeable>
 
               public companion object {
                 @Provides
                 @ScopeTo(TestFlowScope::class)
+                @NavEntry(TestFlowScope::class)
                 public fun provideCompositeDisposable(): CompositeDisposable = CompositeDisposable()
 
                 @Provides
                 @IntoSet
-                public fun bindCompositeDisposable(compositeDisposable: CompositeDisposable): Closeable =
-                    Closeable {
+                @NavEntry(TestFlowScope::class)
+                public fun bindCompositeDisposable(@NavEntry(TestFlowScope::class)
+                    compositeDisposable: CompositeDisposable): Closeable = Closeable {
                   compositeDisposable.clear()
                 }
               }
@@ -276,6 +291,7 @@ internal class NavEntryFileGeneratorTest {
             import com.freeletics.mad.navigator.`internal`.InternalNavigatorApi
             import com.freeletics.mad.navigator.`internal`.destinationId
             import com.freeletics.mad.navigator.`internal`.toRoute
+            import com.freeletics.mad.whetstone.NavEntry
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetter
@@ -307,11 +323,13 @@ internal class NavEntryFileGeneratorTest {
               parentScope = TestParentScope::class,
             )
             public interface NavEntryTestFlowScopeComponent {
+              @get:NavEntry(TestFlowScope::class)
               public val closeables: Set<Closeable>
 
               @ContributesSubcomponent.Factory
               public interface Factory {
-                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
+                public fun create(@BindsInstance @NavEntry(TestFlowScope::class)
+                    savedStateHandle: SavedStateHandle, @BindsInstance @NavEntry(TestFlowScope::class)
                     testRoute: TestRoute): NavEntryTestFlowScopeComponent
               }
 
@@ -325,16 +343,20 @@ internal class NavEntryFileGeneratorTest {
             @ContributesTo(TestFlowScope::class)
             public interface NavEntryTestFlowScopeModule {
               @Multibinds
+              @NavEntry(TestFlowScope::class)
               public fun bindCancellable(): Set<Closeable>
 
               public companion object {
                 @Provides
                 @ScopeTo(TestFlowScope::class)
+                @NavEntry(TestFlowScope::class)
                 public fun provideCoroutineScope(): CoroutineScope = MainScope()
 
                 @Provides
                 @IntoSet
-                public fun bindCoroutineScope(coroutineScope: CoroutineScope): Closeable = Closeable {
+                @NavEntry(TestFlowScope::class)
+                public fun bindCoroutineScope(@NavEntry(TestFlowScope::class) coroutineScope: CoroutineScope):
+                    Closeable = Closeable {
                   coroutineScope.cancel()
                 }
               }

--- a/whetstone/navigation/api/navigation.api
+++ b/whetstone/navigation/api/navigation.api
@@ -1,3 +1,7 @@
+public abstract interface annotation class com/freeletics/mad/whetstone/NavEntry : java/lang/annotation/Annotation {
+	public abstract fun scope ()Ljava/lang/Class;
+}
+
 public abstract interface annotation class com/freeletics/mad/whetstone/NavEntryComponent : java/lang/annotation/Annotation {
 	public abstract fun coroutinesEnabled ()Z
 	public abstract fun parentScope ()Ljava/lang/Class;

--- a/whetstone/navigation/build.gradle
+++ b/whetstone/navigation/build.gradle
@@ -48,11 +48,11 @@ tasks.withType(JavaCompile).configureEach {
 
 dependencies {
     api project(":whetstone:runtime")
+    api "javax.inject:javax.inject:1"
     api "com.google.dagger:dagger:2.42"
     api "androidx.navigation:navigation-common:2.4.2"
 
     implementation project(":navigator:navigator-runtime")
-    implementation "javax.inject:javax.inject:1"
     implementation "androidx.savedstate:savedstate:1.1.0"
     implementation "androidx.lifecycle:lifecycle-viewmodel:2.4.1"
     implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:2.4.1"

--- a/whetstone/navigation/src/main/java/com/freeletics/mad/whetstone/NavEntry.kt
+++ b/whetstone/navigation/src/main/java/com/freeletics/mad/whetstone/NavEntry.kt
@@ -1,0 +1,20 @@
+package com.freeletics.mad.whetstone
+
+import javax.inject.Qualifier
+import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.annotation.AnnotationTarget.CLASS
+import kotlin.annotation.AnnotationTarget.FUNCTION
+import kotlin.annotation.AnnotationTarget.PROPERTY
+import kotlin.annotation.AnnotationTarget.PROPERTY_GETTER
+import kotlin.annotation.AnnotationTarget.VALUE_PARAMETER
+import kotlin.reflect.KClass
+
+/**
+ * TODO
+ */
+@Qualifier
+@Target(CLASS, FUNCTION, PROPERTY, PROPERTY_GETTER, FUNCTION, VALUE_PARAMETER)
+@Retention(RUNTIME)
+public annotation class NavEntry(
+    val scope: KClass<*>,
+)


### PR DESCRIPTION
The automatically provided `SavedStateHandle`, `NavRoute`, `CoroutineScope` and `CompositeDisposable` objects now use an `@NavEntry(Scope::class)` qualifier.

Reasoning
- when we generate subcomponents these would clash with the provided classes from the screen level component
- would already happen for nested NavEntryComponents
- generally more clarity on what you're using and where it comes from