### PR TITLE
make the retained component a contributed subcomponent

### DIFF
--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/Data.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/Data.kt
@@ -17,9 +17,7 @@ internal sealed interface BaseData {
 
 internal sealed interface CommonData : BaseData {
     val scope: ClassName
-
     val parentScope: ClassName
-    val dependencies: ClassName
 
     val stateMachine: ClassName
 
@@ -80,9 +78,7 @@ internal data class ComposeScreenData(
     override val packageName: String,
 
     override val scope: ClassName,
-
     override val parentScope: ClassName,
-    override val dependencies: ClassName,
 
     override val stateMachine: ClassName,
 
@@ -97,9 +93,7 @@ internal data class ComposeFragmentData(
     override val packageName: String,
 
     override val scope: ClassName,
-
     override val parentScope: ClassName,
-    override val dependencies: ClassName,
 
     override val stateMachine: ClassName,
     override val fragmentBaseClass: ClassName,
@@ -115,9 +109,7 @@ internal data class RendererFragmentData(
     override val packageName: String,
 
     override val scope: ClassName,
-
     override val parentScope: ClassName,
-    override val dependencies: ClassName,
 
     override val stateMachine: ClassName,
     val factory: ClassName,

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/WhetstoneCodeGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/WhetstoneCodeGenerator.kt
@@ -38,7 +38,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 @AutoService(CodeGenerator::class)
 public class WhetstoneCodeGenerator : CodeGenerator {
 
-    override fun isApplicable(context: AnvilContext): Boolean = !context.disableComponentMerging
+    override fun isApplicable(context: AnvilContext): Boolean = true
 
     override fun generateCode(
         codeGenDir: File,
@@ -72,13 +72,12 @@ public class WhetstoneCodeGenerator : CodeGenerator {
             packageName = declaration.packageName(),
             scope = renderer.requireClassArgument("scope", 0),
             parentScope = renderer.requireClassArgument("parentScope", 1),
-            dependencies = renderer.requireClassArgument("dependencies", 2),
             stateMachine = renderer.requireClassArgument("stateMachine", 3),
             factory = renderer.requireClassArgument("rendererFactory", 4),
             fragmentBaseClass = renderer.optionalClassArgument("fragmentBaseClass", 5) ?: fragment,
+            navigation = fragmentNavigation(declaration, declaration.packageName()),
             coroutinesEnabled = renderer.optionalBooleanArgument("coroutinesEnabled", 6) ?: false,
             rxJavaEnabled = renderer.optionalBooleanArgument("rxJavaEnabled", 7) ?: false,
-            navigation = fragmentNavigation(declaration, declaration.packageName()),
         )
 
         val file = FileGenerator().generate(data)
@@ -100,12 +99,11 @@ public class WhetstoneCodeGenerator : CodeGenerator {
             packageName = declaration.packageName(),
             scope = compose.requireClassArgument("scope", 0),
             parentScope = compose.requireClassArgument("parentScope", 1),
-            dependencies = compose.requireClassArgument("dependencies", 2),
             stateMachine = compose.requireClassArgument("stateMachine", 3),
             fragmentBaseClass = compose.optionalClassArgument("fragmentBaseClass", 4) ?: fragment,
+            navigation = fragmentNavigation(declaration, declaration.packageName()),
             coroutinesEnabled = compose.optionalBooleanArgument("coroutinesEnabled", 5) ?: false,
             rxJavaEnabled = compose.optionalBooleanArgument("rxJavaEnabled", 6) ?: false,
-            navigation = fragmentNavigation(declaration, declaration.packageName()),
         )
 
         val file = FileGenerator().generate(data)
@@ -166,11 +164,10 @@ public class WhetstoneCodeGenerator : CodeGenerator {
             packageName = declaration.packageName(),
             scope = compose.requireClassArgument("scope", 0),
             parentScope = compose.requireClassArgument("parentScope", 1),
-            dependencies = compose.requireClassArgument("dependencies", 2),
             stateMachine = compose.requireClassArgument("stateMachine", 3),
+            navigation = composeNavigation(declaration, declaration.packageName()),
             coroutinesEnabled = compose.optionalBooleanArgument("coroutinesEnabled", 4) ?: false,
             rxJavaEnabled = compose.optionalBooleanArgument("rxJavaEnabled", 5) ?: false,
-            navigation = composeNavigation(declaration, declaration.packageName()),
         )
 
         val file = FileGenerator().generate(data)

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/RetainedComponentGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/RetainedComponentGenerator.kt
@@ -7,18 +7,20 @@ import com.freeletics.mad.whetstone.RendererFragmentData
 import com.freeletics.mad.whetstone.codegen.Generator
 import com.freeletics.mad.whetstone.codegen.util.asParameter
 import com.freeletics.mad.whetstone.codegen.util.bindsInstanceParameter
-import com.freeletics.mad.whetstone.codegen.util.componentAnnotation
-import com.freeletics.mad.whetstone.codegen.util.componentFactory
 import com.freeletics.mad.whetstone.codegen.util.composeProviderValueModule
-import com.freeletics.mad.whetstone.codegen.util.internalApiAnnotation
+import com.freeletics.mad.whetstone.codegen.util.contributesToAnnotation
 import com.freeletics.mad.whetstone.codegen.util.navEventNavigator
+import com.freeletics.mad.whetstone.codegen.util.optInAnnotation
 import com.freeletics.mad.whetstone.codegen.util.providedValue
 import com.freeletics.mad.whetstone.codegen.util.savedStateHandle
 import com.freeletics.mad.whetstone.codegen.util.scopeToAnnotation
 import com.freeletics.mad.whetstone.codegen.util.simplePropertySpec
+import com.freeletics.mad.whetstone.codegen.util.subcomponentAnnotation
+import com.freeletics.mad.whetstone.codegen.util.subcomponentFactoryAnnotation
+import com.squareup.anvil.annotations.ExperimentalAnvilApi
+import com.squareup.anvil.compiler.internal.decapitalize
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec
-import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.KModifier.ABSTRACT
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
@@ -33,8 +35,18 @@ internal val Generator<out CommonData>.retainedComponentClassName
 
 internal const val retainedComponentFactoryCreateName = "create"
 
+internal val Generator<out CommonData>.retainedComponentFactoryClassName
+    get() = retainedComponentClassName.nestedClass("Factory")
+
 internal const val providedValueSetPropertyName = "providedValues"
 internal const val closeableSetPropertyName = "closeables"
+
+internal val Generator<out CommonData>.retainedParentComponentClassName
+    get() = retainedComponentClassName.nestedClass("ParentComponent")
+
+@OptIn(ExperimentalAnvilApi::class)
+internal val Generator<out CommonData>.retainedParentComponentGetterName
+    get() = "${retainedComponentClassName.simpleName.decapitalize()}Factory"
 
 internal class RetainedComponentGenerator(
     override val data: CommonData,
@@ -42,12 +54,12 @@ internal class RetainedComponentGenerator(
 
     fun generate(): TypeSpec {
         return TypeSpec.interfaceBuilder(retainedComponentClassName)
-            .addModifiers(KModifier.INTERNAL)
-            .addAnnotation(internalApiAnnotation())
+            .addAnnotation(optInAnnotation())
             .addAnnotation(scopeToAnnotation(data.scope))
-            .addAnnotation(componentAnnotation(data.scope, data.dependencies, moduleClassName()))
+            .addAnnotation(subcomponentAnnotation(data.scope, data.parentScope, moduleClassName()))
             .addProperties(componentProperties())
             .addType(retainedComponentFactory())
+            .addType(retainedComponentFactoryParentComponent())
             .build()
     }
 
@@ -62,9 +74,8 @@ internal class RetainedComponentGenerator(
     private fun componentProperties(): List<PropertySpec> {
         val properties = mutableListOf<PropertySpec>()
         properties += simplePropertySpec(data.stateMachine)
-        val navigator = data.navigation?.let { navEventNavigator }
-        if (navigator != null) {
-            properties += simplePropertySpec(navigator)
+        if (data.navigation != null) {
+            properties += simplePropertySpec(navEventNavigator)
         }
         properties += PropertySpec.builder(closeableSetPropertyName, SET.parameterizedBy(Closeable::class.asTypeName())).build()
         properties += when (data) {
@@ -80,19 +91,27 @@ internal class RetainedComponentGenerator(
         return PropertySpec.builder(providedValueSetPropertyName, type).build()
     }
 
-    private val retainedComponentFactoryClassName = retainedComponentClassName.peerClass("Factory")
-
     private fun retainedComponentFactory(): TypeSpec {
         val createFun = FunSpec.builder(retainedComponentFactoryCreateName)
             .addModifiers(ABSTRACT)
-            .addParameter("dependencies", data.dependencies)
             .addParameter(bindsInstanceParameter("savedStateHandle", savedStateHandle))
             .addParameter(bindsInstanceParameter(data.navigation.asParameter()))
             .returns(retainedComponentClassName)
             .build()
         return TypeSpec.interfaceBuilder(retainedComponentFactoryClassName)
-            .addAnnotation(componentFactory)
+            .addAnnotation(subcomponentFactoryAnnotation())
             .addFunction(createFun)
+            .build()
+    }
+
+    private fun retainedComponentFactoryParentComponent(): TypeSpec {
+        val getterFun = FunSpec.builder(retainedParentComponentGetterName)
+            .addModifiers(ABSTRACT)
+            .returns(retainedComponentFactoryClassName)
+            .build()
+        return TypeSpec.interfaceBuilder(retainedParentComponentClassName)
+            .addAnnotation(contributesToAnnotation(data.parentScope))
+            .addFunction(getterFun)
             .build()
     }
 }

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/ViewModelGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/ViewModelGenerator.kt
@@ -38,19 +38,19 @@ internal class ViewModelGenerator(
 
     private fun viewModelCtor(argumentsParameter: ParameterSpec): FunSpec {
         return FunSpec.constructorBuilder()
-            .addParameter("dependencies", data.dependencies)
+            .addParameter("parentComponent", retainedParentComponentClassName)
             .addParameter("savedStateHandle", savedStateHandle)
             .addParameter(argumentsParameter)
             .build()
     }
 
     private fun viewModelProperty(argumentsParameter: ParameterSpec): PropertySpec {
-        val componentInitializer = CodeBlock.of(
-            "%T.factory().%L(dependencies, savedStateHandle, %N)",
-            retainedComponentClassName.peerClass("Dagger${retainedComponentClassName.simpleName}"),
+        val componentInitializer = CodeBlock.builder().add(
+            "parentComponent.%L().%L(savedStateHandle, %N)",
+            retainedParentComponentGetterName,
             retainedComponentFactoryCreateName,
             argumentsParameter,
-        )
+        ).build()
 
         return PropertySpec.builder(viewModelComponentName, retainedComponentClassName)
             .initializer(componentInitializer)

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
@@ -68,9 +68,6 @@ internal val compositeDisposable = ClassName("io.reactivex.disposables", "Compos
 
 // Dagger
 internal val inject = ClassName("javax.inject", "Inject")
-internal val component = ClassName("dagger", "Component")
-internal val componentFactory = component.nestedClass("Factory")
-internal val binds = ClassName("dagger", "Binds")
 internal val provides = ClassName("dagger", "Provides")
 internal val multibinds = ClassName("dagger.multibindings", "Multibinds")
 internal val intoSet = ClassName("dagger.multibindings", "IntoSet")

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/KotlinPoet.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/KotlinPoet.kt
@@ -3,7 +3,6 @@ package com.freeletics.mad.whetstone.codegen.util
 import com.squareup.anvil.annotations.ContributesSubcomponent
 import com.freeletics.mad.whetstone.Navigation
 import com.squareup.anvil.annotations.ContributesTo
-import com.squareup.anvil.annotations.MergeComponent
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.AnnotationSpec.UseSiteTarget
 import com.squareup.kotlinpoet.ClassName
@@ -48,26 +47,19 @@ internal fun lateinitPropertySpec(className: ClassName): PropertySpec {
         .build()
 }
 
-internal fun componentAnnotation(
+internal fun subcomponentAnnotation(
     scope: ClassName,
-    dependencies: ClassName,
-    module: ClassName? = null
+    parentScope: ClassName,
+    module: ClassName? = null,
 ): AnnotationSpec {
-    return AnnotationSpec.builder(MergeComponent::class)
+    return AnnotationSpec.builder(ContributesSubcomponent::class)
         .addMember("scope = %T::class", scope)
-        .addMember("dependencies = [%T::class]", dependencies)
+        .addMember("parentScope = %T::class", parentScope)
         .apply {
             if (module != null) {
                 addMember("modules = [%T::class]", module)
             }
         }
-        .build()
-}
-
-internal fun subcomponentAnnotation(scope: ClassName, parentScope: ClassName): AnnotationSpec {
-    return AnnotationSpec.builder(ContributesSubcomponent::class)
-        .addMember("scope = %T::class", scope)
-        .addMember("parentScope = %T::class", parentScope)
         .build()
 }
 

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
@@ -20,7 +20,6 @@ internal class FileGeneratorTestCompose {
         packageName = "com.test",
         scope = ClassName("com.test", "TestScreen"),
         parentScope = ClassName("com.test.parent", "TestParentScope"),
-        dependencies = ClassName("com.test", "TestDependencies"),
         stateMachine = ClassName("com.test", "TestStateMachine"),
         navigation = navigation,
         coroutinesEnabled = true,
@@ -48,12 +47,11 @@ internal class FileGeneratorTestCompose {
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
+            import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
-            import com.squareup.anvil.annotations.MergeComponent
             import com.test.destination.TestDestinationScope
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
-            import dagger.Component
             import dagger.Module
             import dagger.Provides
             import dagger.multibindings.IntoSet
@@ -68,14 +66,14 @@ internal class FileGeneratorTestCompose {
             import kotlinx.coroutines.cancel
             import kotlinx.coroutines.launch
 
-            @InternalWhetstoneApi
+            @OptIn(InternalWhetstoneApi::class)
             @ScopeTo(TestScreen::class)
-            @MergeComponent(
+            @ContributesSubcomponent(
               scope = TestScreen::class,
-              dependencies = [TestDependencies::class],
+              parentScope = TestParentScope::class,
               modules = [ComposeProviderValueModule::class],
             )
-            internal interface RetainedTestComponent {
+            public interface RetainedTestComponent {
               public val testStateMachine: TestStateMachine
 
               public val navEventNavigator: NavEventNavigator
@@ -84,13 +82,15 @@ internal class FileGeneratorTestCompose {
 
               public val providedValues: Set<ProvidedValue<*>>
 
-              @Component.Factory
+              @ContributesSubcomponent.Factory
               public interface Factory {
-                public fun create(
-                  dependencies: TestDependencies,
-                  @BindsInstance savedStateHandle: SavedStateHandle,
-                  @BindsInstance testRoute: TestRoute,
-                ): RetainedTestComponent
+                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
+                    testRoute: TestRoute): RetainedTestComponent
+              }
+
+              @ContributesTo(TestParentScope::class)
+              public interface ParentComponent {
+                public fun retainedTestComponentFactory(): Factory
               }
             }
 
@@ -126,12 +126,12 @@ internal class FileGeneratorTestCompose {
 
             @InternalWhetstoneApi
             internal class TestViewModel(
-              dependencies: TestDependencies,
+              parentComponent: RetainedTestComponent.ParentComponent,
               savedStateHandle: SavedStateHandle,
               testRoute: TestRoute,
             ) : ViewModel() {
               public val component: RetainedTestComponent =
-                  DaggerRetainedTestComponent.factory().create(dependencies, savedStateHandle, testRoute)
+                  parentComponent.retainedTestComponentFactory().create(savedStateHandle, testRoute)
 
               public override fun onCleared(): Unit {
                 component.closeables.forEach {
@@ -202,12 +202,11 @@ internal class FileGeneratorTestCompose {
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
+            import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
-            import com.squareup.anvil.annotations.MergeComponent
             import com.test.destination.TestDestinationScope
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
-            import dagger.Component
             import dagger.Module
             import dagger.Provides
             import dagger.multibindings.IntoSet
@@ -222,14 +221,14 @@ internal class FileGeneratorTestCompose {
             import kotlinx.coroutines.cancel
             import kotlinx.coroutines.launch
 
-            @InternalWhetstoneApi
+            @OptIn(InternalWhetstoneApi::class)
             @ScopeTo(TestScreen::class)
-            @MergeComponent(
+            @ContributesSubcomponent(
               scope = TestScreen::class,
-              dependencies = [TestDependencies::class],
+              parentScope = TestParentScope::class,
               modules = [ComposeProviderValueModule::class],
             )
-            internal interface RetainedTestComponent {
+            public interface RetainedTestComponent {
               public val testStateMachine: TestStateMachine
 
               public val navEventNavigator: NavEventNavigator
@@ -238,13 +237,15 @@ internal class FileGeneratorTestCompose {
 
               public val providedValues: Set<ProvidedValue<*>>
 
-              @Component.Factory
+              @ContributesSubcomponent.Factory
               public interface Factory {
-                public fun create(
-                  dependencies: TestDependencies,
-                  @BindsInstance savedStateHandle: SavedStateHandle,
-                  @BindsInstance testRoute: TestRoute,
-                ): RetainedTestComponent
+                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
+                    testRoute: TestRoute): RetainedTestComponent
+              }
+
+              @ContributesTo(TestParentScope::class)
+              public interface ParentComponent {
+                public fun retainedTestComponentFactory(): Factory
               }
             }
 
@@ -280,12 +281,12 @@ internal class FileGeneratorTestCompose {
 
             @InternalWhetstoneApi
             internal class TestViewModel(
-              dependencies: TestDependencies,
+              parentComponent: RetainedTestComponent.ParentComponent,
               savedStateHandle: SavedStateHandle,
               testRoute: TestRoute,
             ) : ViewModel() {
               public val component: RetainedTestComponent =
-                  DaggerRetainedTestComponent.factory().create(dependencies, savedStateHandle, testRoute)
+                  parentComponent.retainedTestComponentFactory().create(savedStateHandle, testRoute)
 
               public override fun onCleared(): Unit {
                 component.closeables.forEach {
@@ -362,11 +363,10 @@ internal class FileGeneratorTestCompose {
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
+            import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
-            import com.squareup.anvil.annotations.MergeComponent
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
-            import dagger.Component
             import dagger.Module
             import dagger.Provides
             import dagger.multibindings.IntoSet
@@ -381,27 +381,29 @@ internal class FileGeneratorTestCompose {
             import kotlinx.coroutines.cancel
             import kotlinx.coroutines.launch
 
-            @InternalWhetstoneApi
+            @OptIn(InternalWhetstoneApi::class)
             @ScopeTo(TestScreen::class)
-            @MergeComponent(
+            @ContributesSubcomponent(
               scope = TestScreen::class,
-              dependencies = [TestDependencies::class],
+              parentScope = TestParentScope::class,
               modules = [ComposeProviderValueModule::class],
             )
-            internal interface RetainedTestComponent {
+            public interface RetainedTestComponent {
               public val testStateMachine: TestStateMachine
     
               public val closeables: Set<Closeable>
 
               public val providedValues: Set<ProvidedValue<*>>
 
-              @Component.Factory
+              @ContributesSubcomponent.Factory
               public interface Factory {
-                public fun create(
-                  dependencies: TestDependencies,
-                  @BindsInstance savedStateHandle: SavedStateHandle,
-                  @BindsInstance arguments: Bundle,
-                ): RetainedTestComponent
+                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
+                    arguments: Bundle): RetainedTestComponent
+              }
+
+              @ContributesTo(TestParentScope::class)
+              public interface ParentComponent {
+                public fun retainedTestComponentFactory(): Factory
               }
             }
 
@@ -437,12 +439,12 @@ internal class FileGeneratorTestCompose {
 
             @InternalWhetstoneApi
             internal class TestViewModel(
-              dependencies: TestDependencies,
+              parentComponent: RetainedTestComponent.ParentComponent,
               savedStateHandle: SavedStateHandle,
               arguments: Bundle,
             ) : ViewModel() {
               public val component: RetainedTestComponent =
-                  DaggerRetainedTestComponent.factory().create(dependencies, savedStateHandle, arguments)
+                  parentComponent.retainedTestComponentFactory().create(savedStateHandle, arguments)
 
               public override fun onCleared(): Unit {
                 component.closeables.forEach {
@@ -504,12 +506,11 @@ internal class FileGeneratorTestCompose {
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
+            import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
-            import com.squareup.anvil.annotations.MergeComponent
             import com.test.destination.TestDestinationScope
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
-            import dagger.Component
             import dagger.Module
             import dagger.Provides
             import dagger.multibindings.IntoSet
@@ -521,14 +522,14 @@ internal class FileGeneratorTestCompose {
             import kotlin.collections.Set
             import kotlinx.coroutines.launch
 
-            @InternalWhetstoneApi
+            @OptIn(InternalWhetstoneApi::class)
             @ScopeTo(TestScreen::class)
-            @MergeComponent(
+            @ContributesSubcomponent(
               scope = TestScreen::class,
-              dependencies = [TestDependencies::class],
+              parentScope = TestParentScope::class,
               modules = [ComposeProviderValueModule::class],
             )
-            internal interface RetainedTestComponent {
+            public interface RetainedTestComponent {
               public val testStateMachine: TestStateMachine
 
               public val navEventNavigator: NavEventNavigator
@@ -537,13 +538,15 @@ internal class FileGeneratorTestCompose {
 
               public val providedValues: Set<ProvidedValue<*>>
 
-              @Component.Factory
+              @ContributesSubcomponent.Factory
               public interface Factory {
-                public fun create(
-                  dependencies: TestDependencies,
-                  @BindsInstance savedStateHandle: SavedStateHandle,
-                  @BindsInstance testRoute: TestRoute,
-                ): RetainedTestComponent
+                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
+                    testRoute: TestRoute): RetainedTestComponent
+              }
+
+              @ContributesTo(TestParentScope::class)
+              public interface ParentComponent {
+                public fun retainedTestComponentFactory(): Factory
               }
             }
 
@@ -569,12 +572,12 @@ internal class FileGeneratorTestCompose {
 
             @InternalWhetstoneApi
             internal class TestViewModel(
-              dependencies: TestDependencies,
+              parentComponent: RetainedTestComponent.ParentComponent,
               savedStateHandle: SavedStateHandle,
               testRoute: TestRoute,
             ) : ViewModel() {
               public val component: RetainedTestComponent =
-                  DaggerRetainedTestComponent.factory().create(dependencies, savedStateHandle, testRoute)
+                  parentComponent.retainedTestComponentFactory().create(savedStateHandle, testRoute)
 
               public override fun onCleared(): Unit {
                 component.closeables.forEach {
@@ -643,12 +646,11 @@ internal class FileGeneratorTestCompose {
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
+            import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
-            import com.squareup.anvil.annotations.MergeComponent
             import com.test.destination.TestDestinationScope
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
-            import dagger.Component
             import dagger.Module
             import dagger.Provides
             import dagger.multibindings.IntoSet
@@ -662,14 +664,14 @@ internal class FileGeneratorTestCompose {
             import kotlinx.coroutines.cancel
             import kotlinx.coroutines.launch
 
-            @InternalWhetstoneApi
+            @OptIn(InternalWhetstoneApi::class)
             @ScopeTo(TestScreen::class)
-            @MergeComponent(
+            @ContributesSubcomponent(
               scope = TestScreen::class,
-              dependencies = [TestDependencies::class],
+              parentScope = TestParentScope::class,
               modules = [ComposeProviderValueModule::class],
             )
-            internal interface RetainedTestComponent {
+            public interface RetainedTestComponent {
               public val testStateMachine: TestStateMachine
 
               public val navEventNavigator: NavEventNavigator
@@ -678,13 +680,15 @@ internal class FileGeneratorTestCompose {
 
               public val providedValues: Set<ProvidedValue<*>>
 
-              @Component.Factory
+              @ContributesSubcomponent.Factory
               public interface Factory {
-                public fun create(
-                  dependencies: TestDependencies,
-                  @BindsInstance savedStateHandle: SavedStateHandle,
-                  @BindsInstance testRoute: TestRoute,
-                ): RetainedTestComponent
+                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
+                    testRoute: TestRoute): RetainedTestComponent
+              }
+
+              @ContributesTo(TestParentScope::class)
+              public interface ParentComponent {
+                public fun retainedTestComponentFactory(): Factory
               }
             }
 
@@ -709,12 +713,12 @@ internal class FileGeneratorTestCompose {
 
             @InternalWhetstoneApi
             internal class TestViewModel(
-              dependencies: TestDependencies,
+              parentComponent: RetainedTestComponent.ParentComponent,
               savedStateHandle: SavedStateHandle,
               testRoute: TestRoute,
             ) : ViewModel() {
               public val component: RetainedTestComponent =
-                  DaggerRetainedTestComponent.factory().create(dependencies, savedStateHandle, testRoute)
+                  parentComponent.retainedTestComponentFactory().create(savedStateHandle, testRoute)
 
               public override fun onCleared(): Unit {
                 component.closeables.forEach {
@@ -783,12 +787,11 @@ internal class FileGeneratorTestCompose {
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
+            import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
-            import com.squareup.anvil.annotations.MergeComponent
             import com.test.destination.TestDestinationScope
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
-            import dagger.Component
             import dagger.Module
             import dagger.multibindings.Multibinds
             import java.io.Closeable
@@ -797,14 +800,14 @@ internal class FileGeneratorTestCompose {
             import kotlin.collections.Set
             import kotlinx.coroutines.launch
 
-            @InternalWhetstoneApi
+            @OptIn(InternalWhetstoneApi::class)
             @ScopeTo(TestScreen::class)
-            @MergeComponent(
+            @ContributesSubcomponent(
               scope = TestScreen::class,
-              dependencies = [TestDependencies::class],
+              parentScope = TestParentScope::class,
               modules = [ComposeProviderValueModule::class],
             )
-            internal interface RetainedTestComponent {
+            public interface RetainedTestComponent {
               public val testStateMachine: TestStateMachine
 
               public val navEventNavigator: NavEventNavigator
@@ -813,13 +816,15 @@ internal class FileGeneratorTestCompose {
 
               public val providedValues: Set<ProvidedValue<*>>
 
-              @Component.Factory
+              @ContributesSubcomponent.Factory
               public interface Factory {
-                public fun create(
-                  dependencies: TestDependencies,
-                  @BindsInstance savedStateHandle: SavedStateHandle,
-                  @BindsInstance testRoute: TestRoute,
-                ): RetainedTestComponent
+                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
+                    testRoute: TestRoute): RetainedTestComponent
+              }
+
+              @ContributesTo(TestParentScope::class)
+              public interface ParentComponent {
+                public fun retainedTestComponentFactory(): Factory
               }
             }
 
@@ -832,12 +837,12 @@ internal class FileGeneratorTestCompose {
 
             @InternalWhetstoneApi
             internal class TestViewModel(
-              dependencies: TestDependencies,
+              parentComponent: RetainedTestComponent.ParentComponent,
               savedStateHandle: SavedStateHandle,
               testRoute: TestRoute,
             ) : ViewModel() {
               public val component: RetainedTestComponent =
-                  DaggerRetainedTestComponent.factory().create(dependencies, savedStateHandle, testRoute)
+                  parentComponent.retainedTestComponentFactory().create(savedStateHandle, testRoute)
 
               public override fun onCleared(): Unit {
                 component.closeables.forEach {

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
@@ -22,9 +22,8 @@ internal class FileGeneratorTestComposeFragment {
         packageName = "com.test",
         scope = ClassName("com.test", "TestScreen"),
         parentScope = ClassName("com.test.parent", "TestParentScope"),
-        dependencies = ClassName("com.test", "TestDependencies"),
-        fragmentBaseClass = fragment,
         stateMachine = ClassName("com.test", "TestStateMachine"),
+        fragmentBaseClass = fragment,
         navigation = navigation,
         coroutinesEnabled = true,
         rxJavaEnabled = true,
@@ -59,12 +58,11 @@ internal class FileGeneratorTestComposeFragment {
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
+            import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
-            import com.squareup.anvil.annotations.MergeComponent
             import com.test.destination.TestDestinationScope
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
-            import dagger.Component
             import dagger.Module
             import dagger.Provides
             import dagger.multibindings.IntoSet
@@ -79,14 +77,14 @@ internal class FileGeneratorTestComposeFragment {
             import kotlinx.coroutines.cancel
             import kotlinx.coroutines.launch
 
-            @InternalWhetstoneApi
+            @OptIn(InternalWhetstoneApi::class)
             @ScopeTo(TestScreen::class)
-            @MergeComponent(
+            @ContributesSubcomponent(
               scope = TestScreen::class,
-              dependencies = [TestDependencies::class],
+              parentScope = TestParentScope::class,
               modules = [ComposeProviderValueModule::class],
             )
-            internal interface RetainedTestComponent {
+            public interface RetainedTestComponent {
               public val testStateMachine: TestStateMachine
 
               public val navEventNavigator: NavEventNavigator
@@ -95,13 +93,15 @@ internal class FileGeneratorTestComposeFragment {
 
               public val providedValues: Set<ProvidedValue<*>>
 
-              @Component.Factory
+              @ContributesSubcomponent.Factory
               public interface Factory {
-                public fun create(
-                  dependencies: TestDependencies,
-                  @BindsInstance savedStateHandle: SavedStateHandle,
-                  @BindsInstance testRoute: TestRoute,
-                ): RetainedTestComponent
+                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
+                    testRoute: TestRoute): RetainedTestComponent
+              }
+
+              @ContributesTo(TestParentScope::class)
+              public interface ParentComponent {
+                public fun retainedTestComponentFactory(): Factory
               }
             }
 
@@ -137,12 +137,12 @@ internal class FileGeneratorTestComposeFragment {
 
             @InternalWhetstoneApi
             internal class TestViewModel(
-              dependencies: TestDependencies,
+              parentComponent: RetainedTestComponent.ParentComponent,
               savedStateHandle: SavedStateHandle,
               testRoute: TestRoute,
             ) : ViewModel() {
               public val component: RetainedTestComponent =
-                  DaggerRetainedTestComponent.factory().create(dependencies, savedStateHandle, testRoute)
+                  parentComponent.retainedTestComponentFactory().create(savedStateHandle, testRoute)
 
               public override fun onCleared(): Unit {
                 component.closeables.forEach {
@@ -237,12 +237,11 @@ internal class FileGeneratorTestComposeFragment {
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
+            import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
-            import com.squareup.anvil.annotations.MergeComponent
             import com.test.destination.TestDestinationScope
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
-            import dagger.Component
             import dagger.Module
             import dagger.Provides
             import dagger.multibindings.IntoSet
@@ -257,14 +256,14 @@ internal class FileGeneratorTestComposeFragment {
             import kotlinx.coroutines.cancel
             import kotlinx.coroutines.launch
 
-            @InternalWhetstoneApi
+            @OptIn(InternalWhetstoneApi::class)
             @ScopeTo(TestScreen::class)
-            @MergeComponent(
+            @ContributesSubcomponent(
               scope = TestScreen::class,
-              dependencies = [TestDependencies::class],
+              parentScope = TestParentScope::class,
               modules = [ComposeProviderValueModule::class],
             )
-            internal interface RetainedTestComponent {
+            public interface RetainedTestComponent {
               public val testStateMachine: TestStateMachine
 
               public val navEventNavigator: NavEventNavigator
@@ -273,13 +272,15 @@ internal class FileGeneratorTestComposeFragment {
 
               public val providedValues: Set<ProvidedValue<*>>
 
-              @Component.Factory
+              @ContributesSubcomponent.Factory
               public interface Factory {
-                public fun create(
-                  dependencies: TestDependencies,
-                  @BindsInstance savedStateHandle: SavedStateHandle,
-                  @BindsInstance testRoute: TestRoute,
-                ): RetainedTestComponent
+                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
+                    testRoute: TestRoute): RetainedTestComponent
+              }
+
+              @ContributesTo(TestParentScope::class)
+              public interface ParentComponent {
+                public fun retainedTestComponentFactory(): Factory
               }
             }
 
@@ -315,12 +316,12 @@ internal class FileGeneratorTestComposeFragment {
 
             @InternalWhetstoneApi
             internal class TestViewModel(
-              dependencies: TestDependencies,
+              parentComponent: RetainedTestComponent.ParentComponent,
               savedStateHandle: SavedStateHandle,
               testRoute: TestRoute,
             ) : ViewModel() {
               public val component: RetainedTestComponent =
-                  DaggerRetainedTestComponent.factory().create(dependencies, savedStateHandle, testRoute)
+                  parentComponent.retainedTestComponentFactory().create(savedStateHandle, testRoute)
 
               public override fun onCleared(): Unit {
                 component.closeables.forEach {
@@ -423,12 +424,11 @@ internal class FileGeneratorTestComposeFragment {
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
+            import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
-            import com.squareup.anvil.annotations.MergeComponent
             import com.test.destination.TestDestinationScope
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
-            import dagger.Component
             import dagger.Module
             import dagger.Provides
             import dagger.multibindings.IntoSet
@@ -443,14 +443,14 @@ internal class FileGeneratorTestComposeFragment {
             import kotlinx.coroutines.cancel
             import kotlinx.coroutines.launch
 
-            @InternalWhetstoneApi
+            @OptIn(InternalWhetstoneApi::class)
             @ScopeTo(TestScreen::class)
-            @MergeComponent(
+            @ContributesSubcomponent(
               scope = TestScreen::class,
-              dependencies = [TestDependencies::class],
+              parentScope = TestParentScope::class,
               modules = [ComposeProviderValueModule::class],
             )
-            internal interface RetainedTestComponent {
+            public interface RetainedTestComponent {
               public val testStateMachine: TestStateMachine
 
               public val navEventNavigator: NavEventNavigator
@@ -459,13 +459,15 @@ internal class FileGeneratorTestComposeFragment {
 
               public val providedValues: Set<ProvidedValue<*>>
 
-              @Component.Factory
+              @ContributesSubcomponent.Factory
               public interface Factory {
-                public fun create(
-                  dependencies: TestDependencies,
-                  @BindsInstance savedStateHandle: SavedStateHandle,
-                  @BindsInstance testRoute: TestRoute,
-                ): RetainedTestComponent
+                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
+                    testRoute: TestRoute): RetainedTestComponent
+              }
+
+              @ContributesTo(TestParentScope::class)
+              public interface ParentComponent {
+                public fun retainedTestComponentFactory(): Factory
               }
             }
 
@@ -501,12 +503,12 @@ internal class FileGeneratorTestComposeFragment {
 
             @InternalWhetstoneApi
             internal class TestViewModel(
-              dependencies: TestDependencies,
+              parentComponent: RetainedTestComponent.ParentComponent,
               savedStateHandle: SavedStateHandle,
               testRoute: TestRoute,
             ) : ViewModel() {
               public val component: RetainedTestComponent =
-                  DaggerRetainedTestComponent.factory().create(dependencies, savedStateHandle, testRoute)
+                  parentComponent.retainedTestComponentFactory().create(savedStateHandle, testRoute)
 
               public override fun onCleared(): Unit {
                 component.closeables.forEach {
@@ -595,11 +597,10 @@ internal class FileGeneratorTestComposeFragment {
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
+            import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
-            import com.squareup.anvil.annotations.MergeComponent
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
-            import dagger.Component
             import dagger.Module
             import dagger.Provides
             import dagger.multibindings.IntoSet
@@ -614,27 +615,29 @@ internal class FileGeneratorTestComposeFragment {
             import kotlinx.coroutines.cancel
             import kotlinx.coroutines.launch
 
-            @InternalWhetstoneApi
+            @OptIn(InternalWhetstoneApi::class)
             @ScopeTo(TestScreen::class)
-            @MergeComponent(
+            @ContributesSubcomponent(
               scope = TestScreen::class,
-              dependencies = [TestDependencies::class],
+              parentScope = TestParentScope::class,
               modules = [ComposeProviderValueModule::class],
             )
-            internal interface RetainedTestComponent {
+            public interface RetainedTestComponent {
               public val testStateMachine: TestStateMachine
 
               public val closeables: Set<Closeable>
 
               public val providedValues: Set<ProvidedValue<*>>
 
-              @Component.Factory
+              @ContributesSubcomponent.Factory
               public interface Factory {
-                public fun create(
-                  dependencies: TestDependencies,
-                  @BindsInstance savedStateHandle: SavedStateHandle,
-                  @BindsInstance arguments: Bundle,
-                ): RetainedTestComponent
+                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
+                    arguments: Bundle): RetainedTestComponent
+              }
+
+              @ContributesTo(TestParentScope::class)
+              public interface ParentComponent {
+                public fun retainedTestComponentFactory(): Factory
               }
             }
 
@@ -670,12 +673,12 @@ internal class FileGeneratorTestComposeFragment {
 
             @InternalWhetstoneApi
             internal class TestViewModel(
-              dependencies: TestDependencies,
+              parentComponent: RetainedTestComponent.ParentComponent,
               savedStateHandle: SavedStateHandle,
               arguments: Bundle,
             ) : ViewModel() {
               public val component: RetainedTestComponent =
-                  DaggerRetainedTestComponent.factory().create(dependencies, savedStateHandle, arguments)
+                  parentComponent.retainedTestComponentFactory().create(savedStateHandle, arguments)
 
               public override fun onCleared(): Unit {
                 component.closeables.forEach {

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestRendererFragment.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestRendererFragment.kt
@@ -20,10 +20,9 @@ internal class FileGeneratorTestRendererFragment {
         packageName = "com.test",
         scope = ClassName("com.test", "TestScreen"),
         parentScope = ClassName("com.test.parent", "TestParentScope"),
-        dependencies = ClassName("com.test", "TestDependencies"),
-        fragmentBaseClass = ClassName("androidx.fragment.app", "Fragment"),
-        factory = ClassName("com.test", "RendererFactory"),
         stateMachine = ClassName("com.test", "TestStateMachine"),
+        factory = ClassName("com.test", "RendererFactory"),
+        fragmentBaseClass = ClassName("androidx.fragment.app", "Fragment"),
         navigation = navigation,
         coroutinesEnabled = true,
         rxJavaEnabled = true,
@@ -51,12 +50,11 @@ internal class FileGeneratorTestRendererFragment {
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
             import com.gabrielittner.renderer.connect.connect
+            import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
-            import com.squareup.anvil.annotations.MergeComponent
             import com.test.destination.TestDestinationScope
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
-            import dagger.Component
             import dagger.Module
             import dagger.Provides
             import dagger.multibindings.IntoSet
@@ -70,13 +68,13 @@ internal class FileGeneratorTestRendererFragment {
             import kotlinx.coroutines.MainScope
             import kotlinx.coroutines.cancel
 
-            @InternalWhetstoneApi
+            @OptIn(InternalWhetstoneApi::class)
             @ScopeTo(TestScreen::class)
-            @MergeComponent(
+            @ContributesSubcomponent(
               scope = TestScreen::class,
-              dependencies = [TestDependencies::class],
+              parentScope = TestParentScope::class,
             )
-            internal interface RetainedTestComponent {
+            public interface RetainedTestComponent {
               public val testStateMachine: TestStateMachine
 
               public val navEventNavigator: NavEventNavigator
@@ -85,13 +83,15 @@ internal class FileGeneratorTestRendererFragment {
 
               public val rendererFactory: RendererFactory
 
-              @Component.Factory
+              @ContributesSubcomponent.Factory
               public interface Factory {
-                public fun create(
-                  dependencies: TestDependencies,
-                  @BindsInstance savedStateHandle: SavedStateHandle,
-                  @BindsInstance testRoute: TestRoute,
-                ): RetainedTestComponent
+                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
+                    testRoute: TestRoute): RetainedTestComponent
+              }
+
+              @ContributesTo(TestParentScope::class)
+              public interface ParentComponent {
+                public fun retainedTestComponentFactory(): Factory
               }
             }
 
@@ -127,12 +127,12 @@ internal class FileGeneratorTestRendererFragment {
 
             @InternalWhetstoneApi
             internal class TestViewModel(
-              dependencies: TestDependencies,
+              parentComponent: RetainedTestComponent.ParentComponent,
               savedStateHandle: SavedStateHandle,
               testRoute: TestRoute,
             ) : ViewModel() {
               public val component: RetainedTestComponent =
-                  DaggerRetainedTestComponent.factory().create(dependencies, savedStateHandle, testRoute)
+                  parentComponent.retainedTestComponentFactory().create(savedStateHandle, testRoute)
 
               public override fun onCleared(): Unit {
                 component.closeables.forEach {
@@ -199,12 +199,11 @@ internal class FileGeneratorTestRendererFragment {
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
             import com.gabrielittner.renderer.connect.connect
+            import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
-            import com.squareup.anvil.annotations.MergeComponent
             import com.test.destination.TestDestinationScope
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
-            import dagger.Component
             import dagger.Module
             import dagger.Provides
             import dagger.multibindings.IntoSet
@@ -218,13 +217,13 @@ internal class FileGeneratorTestRendererFragment {
             import kotlinx.coroutines.MainScope
             import kotlinx.coroutines.cancel
 
-            @InternalWhetstoneApi
+            @OptIn(InternalWhetstoneApi::class)
             @ScopeTo(TestScreen::class)
-            @MergeComponent(
+            @ContributesSubcomponent(
               scope = TestScreen::class,
-              dependencies = [TestDependencies::class],
+              parentScope = TestParentScope::class,
             )
-            internal interface RetainedTestComponent {
+            public interface RetainedTestComponent {
               public val testStateMachine: TestStateMachine
 
               public val navEventNavigator: NavEventNavigator
@@ -233,13 +232,15 @@ internal class FileGeneratorTestRendererFragment {
 
               public val rendererFactory: RendererFactory
 
-              @Component.Factory
+              @ContributesSubcomponent.Factory
               public interface Factory {
-                public fun create(
-                  dependencies: TestDependencies,
-                  @BindsInstance savedStateHandle: SavedStateHandle,
-                  @BindsInstance testRoute: TestRoute,
-                ): RetainedTestComponent
+                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
+                    testRoute: TestRoute): RetainedTestComponent
+              }
+
+              @ContributesTo(TestParentScope::class)
+              public interface ParentComponent {
+                public fun retainedTestComponentFactory(): Factory
               }
             }
 
@@ -275,12 +276,12 @@ internal class FileGeneratorTestRendererFragment {
 
             @InternalWhetstoneApi
             internal class TestViewModel(
-              dependencies: TestDependencies,
+              parentComponent: RetainedTestComponent.ParentComponent,
               savedStateHandle: SavedStateHandle,
               testRoute: TestRoute,
             ) : ViewModel() {
               public val component: RetainedTestComponent =
-                  DaggerRetainedTestComponent.factory().create(dependencies, savedStateHandle, testRoute)
+                  parentComponent.retainedTestComponentFactory().create(savedStateHandle, testRoute)
 
               public override fun onCleared(): Unit {
                 component.closeables.forEach {
@@ -349,11 +350,10 @@ internal class FileGeneratorTestRendererFragment {
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
             import com.gabrielittner.renderer.connect.connect
+            import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
-            import com.squareup.anvil.annotations.MergeComponent
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
-            import dagger.Component
             import dagger.Module
             import dagger.Provides
             import dagger.multibindings.IntoSet
@@ -367,26 +367,28 @@ internal class FileGeneratorTestRendererFragment {
             import kotlinx.coroutines.MainScope
             import kotlinx.coroutines.cancel
 
-            @InternalWhetstoneApi
+            @OptIn(InternalWhetstoneApi::class)
             @ScopeTo(TestScreen::class)
-            @MergeComponent(
+            @ContributesSubcomponent(
               scope = TestScreen::class,
-              dependencies = [TestDependencies::class],
+              parentScope = TestParentScope::class,
             )
-            internal interface RetainedTestComponent {
+            public interface RetainedTestComponent {
               public val testStateMachine: TestStateMachine
             
               public val closeables: Set<Closeable>
 
               public val rendererFactory: RendererFactory
 
-              @Component.Factory
+              @ContributesSubcomponent.Factory
               public interface Factory {
-                public fun create(
-                  dependencies: TestDependencies,
-                  @BindsInstance savedStateHandle: SavedStateHandle,
-                  @BindsInstance arguments: Bundle,
-                ): RetainedTestComponent
+                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
+                    arguments: Bundle): RetainedTestComponent
+              }
+
+              @ContributesTo(TestParentScope::class)
+              public interface ParentComponent {
+                public fun retainedTestComponentFactory(): Factory
               }
             }
 
@@ -422,12 +424,12 @@ internal class FileGeneratorTestRendererFragment {
 
             @InternalWhetstoneApi
             internal class TestViewModel(
-              dependencies: TestDependencies,
+              parentComponent: RetainedTestComponent.ParentComponent,
               savedStateHandle: SavedStateHandle,
               arguments: Bundle,
             ) : ViewModel() {
               public val component: RetainedTestComponent =
-                  DaggerRetainedTestComponent.factory().create(dependencies, savedStateHandle, arguments)
+                  parentComponent.retainedTestComponentFactory().create(savedStateHandle, arguments)
 
               public override fun onCleared(): Unit {
                 component.closeables.forEach {
@@ -487,12 +489,11 @@ internal class FileGeneratorTestRendererFragment {
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
             import com.gabrielittner.renderer.connect.connect
+            import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
-            import com.squareup.anvil.annotations.MergeComponent
             import com.test.destination.TestDestinationScope
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
-            import dagger.Component
             import dagger.Module
             import dagger.Provides
             import dagger.multibindings.IntoSet
@@ -506,13 +507,13 @@ internal class FileGeneratorTestRendererFragment {
             import kotlinx.coroutines.MainScope
             import kotlinx.coroutines.cancel
 
-            @InternalWhetstoneApi
+            @OptIn(InternalWhetstoneApi::class)
             @ScopeTo(TestScreen::class)
-            @MergeComponent(
+            @ContributesSubcomponent(
               scope = TestScreen::class,
-              dependencies = [TestDependencies::class],
+              parentScope = TestParentScope::class,
             )
-            internal interface RetainedTestComponent {
+            public interface RetainedTestComponent {
               public val testStateMachine: TestStateMachine
 
               public val navEventNavigator: NavEventNavigator
@@ -521,13 +522,15 @@ internal class FileGeneratorTestRendererFragment {
 
               public val rendererFactory: RendererFactory
 
-              @Component.Factory
+              @ContributesSubcomponent.Factory
               public interface Factory {
-                public fun create(
-                  dependencies: TestDependencies,
-                  @BindsInstance savedStateHandle: SavedStateHandle,
-                  @BindsInstance testRoute: TestRoute,
-                ): RetainedTestComponent
+                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
+                    testRoute: TestRoute): RetainedTestComponent
+              }
+
+              @ContributesTo(TestParentScope::class)
+              public interface ParentComponent {
+                public fun retainedTestComponentFactory(): Factory
               }
             }
 
@@ -563,12 +566,12 @@ internal class FileGeneratorTestRendererFragment {
 
             @InternalWhetstoneApi
             internal class TestViewModel(
-              dependencies: TestDependencies,
+              parentComponent: RetainedTestComponent.ParentComponent,
               savedStateHandle: SavedStateHandle,
               testRoute: TestRoute,
             ) : ViewModel() {
               public val component: RetainedTestComponent =
-                  DaggerRetainedTestComponent.factory().create(dependencies, savedStateHandle, testRoute)
+                  parentComponent.retainedTestComponentFactory().create(savedStateHandle, testRoute)
 
               public override fun onCleared(): Unit {
                 component.closeables.forEach {


### PR DESCRIPTION
With this Whetstone will only generate subcomponents instead of full components which allows not using kapt on Gradle modules using Whetstone and also removes the need for the dependencies interface. This PR makes the changes to the code generation I will have a follow up to cleanup the annotations and the docs, as well as one follow up to unify the codegen for nav entry components with the general codegen.