### PR TITLE
remove obsolete Whetstone parameters and update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 Change Log
 ==========
 
+
+Version 0.7.0 *(UNRELEASED)*
+----------------------------
+
+Updated to Kotlin 1.7.0 and Compose compiler 1.2.0.
+
+### Whetstone
+
+- Instead of generating full components Whetstone is now using subcomponents with Anvil's
+  `@ContributesSubcomponent` with a `ParentComponent` interface that is automatically contributed
+  to the `parentScope`. This allows to remove `kapt` from modules using Whetstone and let Anvil
+  do all of the factory generation
+- Because of that the `dependencies` parameter was removed from all annotations
+- To avoid collisions between subcomponents the `SavedStateHandle` as well as the `NavRoute` or
+  `Bundle` that are automatically available in generated `@NavEntryComponent`s now have a
+  `NavEntry(ScopeOfNavEntryComponent::class)` qualifier on them
+- The `rxJavaEnabled` and `coroutinesEnabled` parameters were removed from all annotations. For how
+  to replace them, see the 0.5.0 changelog.
+
+
 Version 0.6.0 *(2022-06-28)*
 ----------------------------
 
@@ -30,19 +50,19 @@ Version 0.5.0 *(2022-06-21)*
 object {
   @Provides
   @ScopeTo(MyScreenScope::class)
-  public fun provideCompositeDisposable() = CompositeDisposable()
+  fun provideCompositeDisposable() = CompositeDisposable()
 
   @Provides
   @IntoSet
-  public fun bindCompositeDisposable(disposable: CompositeDisposable) = Closeable { disposable.clear() }
+  fun bindCompositeDisposable(disposable: CompositeDisposable) = Closeable { disposable.clear() }
 
   @Provides
-  @ScopeTo(TestScreen::class)
-  public fun provideCoroutineScope(): CoroutineScope = MainScope()
+  @ScopeTo(MyScreenScope::class)
+  fun provideCoroutineScope() = MainScope()
 
   @Provides
   @IntoSet
-  public fun bindCoroutineScope(scpe: CoroutineScope) = Closeable { scope.cancel() }
+  fun bindCoroutineScope(scope: CoroutineScope) = Closeable { scope.cancel() }
 }
 ```
 

--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavDestination.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavDestination.kt
@@ -41,9 +41,6 @@ public inline fun <reified T : ActivityRoute> ActivityDestination(
 
 /**
  * A destination that can be navigated to. See [setGraph] for how to configure a `NavGraph` with it.
- *
- * [route] will be used as a unique identifier. The destination can be reached by navigating using
- * an instance of [route].
  */
 public sealed interface NavDestination {
     /**

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/Data.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/Data.kt
@@ -22,9 +22,6 @@ internal sealed interface CommonData : BaseData {
     val stateMachine: ClassName
 
     val navigation: Navigation?
-
-    val coroutinesEnabled: Boolean
-    val rxJavaEnabled: Boolean
 }
 
 internal sealed interface FragmentCommonData : CommonData {
@@ -83,9 +80,6 @@ internal data class ComposeScreenData(
     override val stateMachine: ClassName,
 
     override val navigation: Navigation.Compose?,
-
-    override val coroutinesEnabled: Boolean,
-    override val rxJavaEnabled: Boolean,
 ) :  CommonData
 
 internal data class ComposeFragmentData(
@@ -99,9 +93,6 @@ internal data class ComposeFragmentData(
     override val fragmentBaseClass: ClassName,
 
     override val navigation: Navigation.Fragment?,
-
-    override val coroutinesEnabled: Boolean,
-    override val rxJavaEnabled: Boolean,
 ) : FragmentCommonData
 
 internal data class RendererFragmentData(
@@ -116,9 +107,6 @@ internal data class RendererFragmentData(
     override val fragmentBaseClass: ClassName,
 
     override val navigation: Navigation.Fragment?,
-
-    override val coroutinesEnabled: Boolean,
-    override val rxJavaEnabled: Boolean,
 ) : FragmentCommonData
 
 internal data class NavEntryData(
@@ -130,9 +118,6 @@ internal data class NavEntryData(
     val destinationScope: ClassName,
 
     val route: ClassName,
-
-    val coroutinesEnabled: Boolean,
-    val rxJavaEnabled: Boolean,
 ): BaseData {
     override val baseName: String = scope.simpleName
 }

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/WhetstoneCodeGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/WhetstoneCodeGenerator.kt
@@ -11,7 +11,6 @@ import com.freeletics.mad.whetstone.codegen.util.fragment
 import com.freeletics.mad.whetstone.codegen.util.fragmentNavDestinationFqName
 import com.freeletics.mad.whetstone.codegen.util.fragmentRootNavDestinationFqName
 import com.freeletics.mad.whetstone.codegen.util.navEntryComponentFqName
-import com.freeletics.mad.whetstone.codegen.util.optionalBooleanArgument
 import com.freeletics.mad.whetstone.codegen.util.optionalClassArgument
 import com.freeletics.mad.whetstone.codegen.util.rendererFragmentFqName
 import com.freeletics.mad.whetstone.codegen.util.requireClassArgument
@@ -72,12 +71,10 @@ public class WhetstoneCodeGenerator : CodeGenerator {
             packageName = declaration.packageName(),
             scope = renderer.requireClassArgument("scope", 0),
             parentScope = renderer.requireClassArgument("parentScope", 1),
-            stateMachine = renderer.requireClassArgument("stateMachine", 3),
-            factory = renderer.requireClassArgument("rendererFactory", 4),
-            fragmentBaseClass = renderer.optionalClassArgument("fragmentBaseClass", 5) ?: fragment,
+            stateMachine = renderer.requireClassArgument("stateMachine", 2),
+            factory = renderer.requireClassArgument("rendererFactory", 3),
+            fragmentBaseClass = renderer.optionalClassArgument("fragmentBaseClass", 4) ?: fragment,
             navigation = fragmentNavigation(declaration, declaration.packageName()),
-            coroutinesEnabled = renderer.optionalBooleanArgument("coroutinesEnabled", 6) ?: false,
-            rxJavaEnabled = renderer.optionalBooleanArgument("rxJavaEnabled", 7) ?: false,
         )
 
         val file = FileGenerator().generate(data)
@@ -99,11 +96,9 @@ public class WhetstoneCodeGenerator : CodeGenerator {
             packageName = declaration.packageName(),
             scope = compose.requireClassArgument("scope", 0),
             parentScope = compose.requireClassArgument("parentScope", 1),
-            stateMachine = compose.requireClassArgument("stateMachine", 3),
-            fragmentBaseClass = compose.optionalClassArgument("fragmentBaseClass", 4) ?: fragment,
+            stateMachine = compose.requireClassArgument("stateMachine", 2),
+            fragmentBaseClass = compose.optionalClassArgument("fragmentBaseClass", 3) ?: fragment,
             navigation = fragmentNavigation(declaration, declaration.packageName()),
-            coroutinesEnabled = compose.optionalBooleanArgument("coroutinesEnabled", 5) ?: false,
-            rxJavaEnabled = compose.optionalBooleanArgument("rxJavaEnabled", 6) ?: false,
         )
 
         val file = FileGenerator().generate(data)
@@ -164,10 +159,8 @@ public class WhetstoneCodeGenerator : CodeGenerator {
             packageName = declaration.packageName(),
             scope = compose.requireClassArgument("scope", 0),
             parentScope = compose.requireClassArgument("parentScope", 1),
-            stateMachine = compose.requireClassArgument("stateMachine", 3),
+            stateMachine = compose.requireClassArgument("stateMachine", 2),
             navigation = composeNavigation(declaration, declaration.packageName()),
-            coroutinesEnabled = compose.optionalBooleanArgument("coroutinesEnabled", 4) ?: false,
-            rxJavaEnabled = compose.optionalBooleanArgument("rxJavaEnabled", 5) ?: false,
         )
 
         val file = FileGenerator().generate(data)
@@ -231,8 +224,6 @@ public class WhetstoneCodeGenerator : CodeGenerator {
             parentScope = component.requireClassArgument("parentScope", 1),
             destinationScope = destinationScope,
             route = route,
-            coroutinesEnabled = component.optionalBooleanArgument("coroutinesEnabled", 2) ?: false,
-            rxJavaEnabled = component.optionalBooleanArgument("rxJavaEnabled", 3) ?: false,
         )
     }
 

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/RetainedComponentModuleGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/RetainedComponentModuleGenerator.kt
@@ -2,17 +2,9 @@ package com.freeletics.mad.whetstone.codegen.common
 
 import com.freeletics.mad.whetstone.CommonData
 import com.freeletics.mad.whetstone.codegen.Generator
-import com.freeletics.mad.whetstone.codegen.util.compositeDisposable
 import com.freeletics.mad.whetstone.codegen.util.contributesToAnnotation
-import com.freeletics.mad.whetstone.codegen.util.coroutineScope
-import com.freeletics.mad.whetstone.codegen.util.coroutineScopeCancel
-import com.freeletics.mad.whetstone.codegen.util.intoSet
-import com.freeletics.mad.whetstone.codegen.util.mainScope
 import com.freeletics.mad.whetstone.codegen.util.module
 import com.freeletics.mad.whetstone.codegen.util.multibinds
-import com.freeletics.mad.whetstone.codegen.util.propertyName
-import com.freeletics.mad.whetstone.codegen.util.provides
-import com.freeletics.mad.whetstone.codegen.util.scopeToAnnotation
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier.ABSTRACT
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
@@ -32,53 +24,6 @@ internal class RetainedComponentModuleGenerator(
             .addAnnotation(module)
             .addAnnotation(contributesToAnnotation(data.scope))
             .addFunction(multibindsFunction())
-            .apply {
-                val companionFunctions = mutableListOf<FunSpec>()
-                if (data.rxJavaEnabled) {
-                    companionFunctions += FunSpec.builder("provideCompositeDisposable")
-                        .addAnnotation(provides)
-                        .addAnnotation(scopeToAnnotation(data.scope))
-                        .returns(compositeDisposable)
-                        .addStatement("return %T()", compositeDisposable)
-                        .build()
-
-                    companionFunctions += FunSpec.builder("bindCompositeDisposable")
-                        .addAnnotation(provides)
-                        .addAnnotation(intoSet)
-                        .addParameter(compositeDisposable.propertyName, compositeDisposable)
-                        .returns(Closeable::class.asClassName())
-                        .beginControlFlow("return %T", Closeable::class.asClassName())
-                        .addStatement("%L.clear()", compositeDisposable.propertyName)
-                        .endControlFlow()
-                        .build()
-                }
-                if (data.coroutinesEnabled) {
-                    companionFunctions += FunSpec.builder("provideCoroutineScope")
-                        .addAnnotation(provides)
-                        .addAnnotation(scopeToAnnotation(data.scope))
-                        .returns(coroutineScope)
-                        .addStatement("return %M()", mainScope)
-                        .build()
-
-                    companionFunctions += FunSpec.builder("bindCoroutineScope")
-                        .addAnnotation(provides)
-                        .addAnnotation(intoSet)
-                        .addParameter(coroutineScope.propertyName, coroutineScope)
-                        .returns(Closeable::class.asClassName())
-                        .beginControlFlow("return %T", Closeable::class.asClassName())
-                        .addStatement("%L.%M()", coroutineScope.propertyName, coroutineScopeCancel)
-                        .endControlFlow()
-                        .build()
-                }
-
-                if (companionFunctions.isNotEmpty()) {
-                    addType(
-                        TypeSpec.companionObjectBuilder()
-                            .addFunctions(companionFunctions)
-                            .build()
-                    )
-                }
-            }
             .build()
     }
 

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/compose/ComposeScreenGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/compose/ComposeScreenGenerator.kt
@@ -8,7 +8,6 @@ import com.freeletics.mad.whetstone.codegen.common.composableName
 import com.freeletics.mad.whetstone.codegen.util.asParameter
 import com.freeletics.mad.whetstone.codegen.util.composable
 import com.freeletics.mad.whetstone.codegen.util.composeNavigationHandler
-import com.freeletics.mad.whetstone.codegen.util.fragmentViewModel
 import com.freeletics.mad.whetstone.codegen.util.navEventNavigator
 import com.freeletics.mad.whetstone.codegen.util.optInAnnotation
 import com.freeletics.mad.whetstone.codegen.util.propertyName

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/fragment/BaseFragmentGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/fragment/BaseFragmentGenerator.kt
@@ -16,13 +16,11 @@ import com.freeletics.mad.whetstone.codegen.util.layoutInflater
 import com.freeletics.mad.whetstone.codegen.util.navEventNavigator
 import com.freeletics.mad.whetstone.codegen.util.optInAnnotation
 import com.freeletics.mad.whetstone.codegen.util.propertyName
-import com.freeletics.mad.whetstone.codegen.util.rememberViewModel
 import com.freeletics.mad.whetstone.codegen.util.view
 import com.freeletics.mad.whetstone.codegen.util.viewGroup
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier.OVERRIDE
-import com.squareup.kotlinpoet.KModifier.PRIVATE
 import com.squareup.kotlinpoet.TypeSpec
 
 internal val Generator<out CommonData>.fragmentName

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/naventry/NavEntrySubcomponentGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/naventry/NavEntrySubcomponentGenerator.kt
@@ -13,7 +13,6 @@ import com.freeletics.mad.whetstone.codegen.util.subcomponentAnnotation
 import com.freeletics.mad.whetstone.codegen.util.subcomponentFactoryAnnotation
 import com.squareup.anvil.annotations.ExperimentalAnvilApi
 import com.squareup.anvil.compiler.internal.decapitalize
-import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.AnnotationSpec.UseSiteTarget.GET
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier.ABSTRACT

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/naventry/NavEntrySubcomponentModuleGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/naventry/NavEntrySubcomponentModuleGenerator.kt
@@ -2,21 +2,12 @@ package com.freeletics.mad.whetstone.codegen.naventry
 
 import com.freeletics.mad.whetstone.NavEntryData
 import com.freeletics.mad.whetstone.codegen.Generator
-import com.freeletics.mad.whetstone.codegen.util.compositeDisposable
 import com.freeletics.mad.whetstone.codegen.util.contributesToAnnotation
-import com.freeletics.mad.whetstone.codegen.util.coroutineScope
-import com.freeletics.mad.whetstone.codegen.util.coroutineScopeCancel
-import com.freeletics.mad.whetstone.codegen.util.intoSet
-import com.freeletics.mad.whetstone.codegen.util.mainScope
 import com.freeletics.mad.whetstone.codegen.util.module
 import com.freeletics.mad.whetstone.codegen.util.multibinds
 import com.freeletics.mad.whetstone.codegen.util.navEntryAnnotation
-import com.freeletics.mad.whetstone.codegen.util.propertyName
-import com.freeletics.mad.whetstone.codegen.util.provides
-import com.freeletics.mad.whetstone.codegen.util.scopeToAnnotation
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier.ABSTRACT
-import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.SET
 import com.squareup.kotlinpoet.TypeSpec
@@ -34,63 +25,6 @@ internal class NavEntrySubcomponentModuleGenerator(
             .addAnnotation(module)
             .addAnnotation(contributesToAnnotation(data.scope))
             .addFunction(multibindsFunction())
-            .apply {
-                val companionFunctions = mutableListOf<FunSpec>()
-                if (data.rxJavaEnabled) {
-                    companionFunctions += FunSpec.builder("provideCompositeDisposable")
-                        .addAnnotation(provides)
-                        .addAnnotation(scopeToAnnotation(data.scope))
-                        .addAnnotation(navEntryAnnotation(data.scope))
-                        .returns(compositeDisposable)
-                        .addStatement("return %T()", compositeDisposable)
-                        .build()
-
-                    val parameter = ParameterSpec.builder(compositeDisposable.propertyName, compositeDisposable)
-                        .addAnnotation(navEntryAnnotation(data.scope))
-                        .build()
-                    companionFunctions += FunSpec.builder("bindCompositeDisposable")
-                        .addAnnotation(provides)
-                        .addAnnotation(intoSet)
-                        .addAnnotation(navEntryAnnotation(data.scope))
-                        .addParameter(parameter)
-                        .returns(Closeable::class.asClassName())
-                        .beginControlFlow("return %T", Closeable::class.asClassName())
-                        .addStatement("%L.clear()", compositeDisposable.propertyName)
-                        .endControlFlow()
-                        .build()
-                }
-                if (data.coroutinesEnabled) {
-                    companionFunctions += FunSpec.builder("provideCoroutineScope")
-                        .addAnnotation(provides)
-                        .addAnnotation(scopeToAnnotation(data.scope))
-                        .addAnnotation(navEntryAnnotation(data.scope))
-                        .returns(coroutineScope)
-                        .addStatement("return %M()", mainScope)
-                        .build()
-
-                    val parameter = ParameterSpec.builder(coroutineScope.propertyName, coroutineScope)
-                        .addAnnotation(navEntryAnnotation(data.scope))
-                        .build()
-                    companionFunctions += FunSpec.builder("bindCoroutineScope")
-                        .addAnnotation(provides)
-                        .addAnnotation(intoSet)
-                        .addAnnotation(navEntryAnnotation(data.scope))
-                        .addParameter(parameter)
-                        .returns(Closeable::class.asClassName())
-                        .beginControlFlow("return %T", Closeable::class.asClassName())
-                        .addStatement("%L.%M()", coroutineScope.propertyName, coroutineScopeCancel)
-                        .endControlFlow()
-                        .build()
-                }
-
-                if (companionFunctions.isNotEmpty()) {
-                    addType(
-                        TypeSpec.companionObjectBuilder()
-                            .addFunctions(companionFunctions)
-                            .build()
-                    )
-                }
-            }
             .build()
     }
 

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/Annotations.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/Annotations.kt
@@ -30,7 +30,3 @@ internal fun AnnotationReference.requireEnumArgument(name: String, index: Int): 
     return argumentAt(name, index)?.value<FqName>()?.shortName()?.asString() ?:
         throw AnvilCompilationExceptionAnnotationReference(this, "Couldn't find $name for $fqName")
 }
-
-internal fun AnnotationReference.optionalBooleanArgument(name: String, index: Int): Boolean? {
-    return argumentAt(name, index)?.value()
-}

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
@@ -58,13 +58,7 @@ internal val rendererConnect = MemberName("com.gabrielittner.renderer.connect", 
 internal val optIn = ClassName("kotlin", "OptIn")
 
 // Coroutines
-internal val coroutineScope = ClassName("kotlinx.coroutines", "CoroutineScope")
-internal val coroutineScopeCancel = MemberName("kotlinx.coroutines", "cancel")
-internal val mainScope = MemberName("kotlinx.coroutines", "MainScope")
 internal val launch = MemberName("kotlinx.coroutines", "launch")
-
-// RxJava
-internal val compositeDisposable = ClassName("io.reactivex.disposables", "CompositeDisposable")
 
 // Dagger
 internal val inject = ClassName("javax.inject", "Inject")

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
@@ -15,20 +15,130 @@ internal class FileGeneratorTestCompose {
         navEntryData = null,
     )
 
-    private val full = ComposeScreenData(
+    private val data = ComposeScreenData(
         baseName = "Test",
         packageName = "com.test",
         scope = ClassName("com.test", "TestScreen"),
         parentScope = ClassName("com.test.parent", "TestParentScope"),
         stateMachine = ClassName("com.test", "TestStateMachine"),
-        navigation = navigation,
-        coroutinesEnabled = true,
-        rxJavaEnabled = true,
+        navigation = null,
     )
 
     @Test
     fun `generates code for ComposeScreenData`() {
-        val actual = FileGenerator().generate(full).toString()
+        val actual = FileGenerator().generate(data).toString()
+
+        val expected = """
+            package com.test
+
+            import android.os.Bundle
+            import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.CompositionLocalProvider
+            import androidx.compose.runtime.ProvidedValue
+            import androidx.compose.runtime.rememberCoroutineScope
+            import androidx.lifecycle.SavedStateHandle
+            import androidx.lifecycle.ViewModel
+            import com.freeletics.mad.whetstone.ScopeTo
+            import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
+            import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
+            import com.freeletics.mad.whetstone.`internal`.asComposeState
+            import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
+            import com.squareup.anvil.annotations.ContributesSubcomponent
+            import com.squareup.anvil.annotations.ContributesTo
+            import com.test.parent.TestParentScope
+            import dagger.BindsInstance
+            import dagger.Module
+            import dagger.multibindings.Multibinds
+            import java.io.Closeable
+            import kotlin.OptIn
+            import kotlin.Unit
+            import kotlin.collections.Set
+            import kotlinx.coroutines.launch
+
+            @OptIn(InternalWhetstoneApi::class)
+            @ScopeTo(TestScreen::class)
+            @ContributesSubcomponent(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+              modules = [ComposeProviderValueModule::class],
+            )
+            public interface RetainedTestComponent {
+              public val testStateMachine: TestStateMachine
+    
+              public val closeables: Set<Closeable>
+
+              public val providedValues: Set<ProvidedValue<*>>
+
+              @ContributesSubcomponent.Factory
+              public interface Factory {
+                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
+                    arguments: Bundle): RetainedTestComponent
+              }
+
+              @ContributesTo(TestParentScope::class)
+              public interface ParentComponent {
+                public fun retainedTestComponentFactory(): Factory
+              }
+            }
+
+            @Module
+            @ContributesTo(TestScreen::class)
+            public interface RetainedTestModule {
+              @Multibinds
+              public fun bindCancellable(): Set<Closeable>
+            }
+
+            @InternalWhetstoneApi
+            internal class TestViewModel(
+              parentComponent: RetainedTestComponent.ParentComponent,
+              savedStateHandle: SavedStateHandle,
+              arguments: Bundle,
+            ) : ViewModel() {
+              public val component: RetainedTestComponent =
+                  parentComponent.retainedTestComponentFactory().create(savedStateHandle, arguments)
+
+              public override fun onCleared(): Unit {
+                component.closeables.forEach {
+                  it.close()
+                }
+              }
+            }
+
+            @Composable
+            @OptIn(InternalWhetstoneApi::class)
+            public fun TestScreen(arguments: Bundle): Unit {
+              val viewModel = rememberViewModel(TestParentScope::class, arguments, ::TestViewModel)
+              val component = viewModel.component
+
+              TestScreen(component)
+            }
+            
+            @Composable
+            @OptIn(InternalWhetstoneApi::class)
+            private fun TestScreen(component: RetainedTestComponent): Unit {
+              val providedValues = component.providedValues
+              CompositionLocalProvider(*providedValues.toTypedArray()) {
+                val stateMachine = component.testStateMachine
+                val state = stateMachine.asComposeState()
+                val currentState = state.value
+                if (currentState != null) {
+                  val scope = rememberCoroutineScope()
+                  Test(currentState) { action ->
+                    scope.launch { stateMachine.dispatch(action) }
+                  }
+                }
+              }
+            }
+            
+        """.trimIndent()
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `generates code for ComposeScreenData with navigation`() {
+        val withNavigation = data.copy(navigation = navigation)
+        val actual = FileGenerator().generate(withNavigation).toString()
 
         val expected = """
             package com.test
@@ -53,17 +163,11 @@ internal class FileGeneratorTestCompose {
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
             import dagger.Module
-            import dagger.Provides
-            import dagger.multibindings.IntoSet
             import dagger.multibindings.Multibinds
-            import io.reactivex.disposables.CompositeDisposable
             import java.io.Closeable
             import kotlin.OptIn
             import kotlin.Unit
             import kotlin.collections.Set
-            import kotlinx.coroutines.CoroutineScope
-            import kotlinx.coroutines.MainScope
-            import kotlinx.coroutines.cancel
             import kotlinx.coroutines.launch
 
             @OptIn(InternalWhetstoneApi::class)
@@ -99,29 +203,6 @@ internal class FileGeneratorTestCompose {
             public interface RetainedTestModule {
               @Multibinds
               public fun bindCancellable(): Set<Closeable>
-
-              public companion object {
-                @Provides
-                @ScopeTo(TestScreen::class)
-                public fun provideCompositeDisposable(): CompositeDisposable = CompositeDisposable()
-
-                @Provides
-                @IntoSet
-                public fun bindCompositeDisposable(compositeDisposable: CompositeDisposable): Closeable =
-                    Closeable {
-                  compositeDisposable.clear()
-                }
-            
-                @Provides
-                @ScopeTo(TestScreen::class)
-                public fun provideCoroutineScope(): CoroutineScope = MainScope()
-
-                @Provides
-                @IntoSet
-                public fun bindCoroutineScope(coroutineScope: CoroutineScope): Closeable = Closeable {
-                  coroutineScope.cancel()
-                }
-              }
             }
 
             @InternalWhetstoneApi
@@ -179,8 +260,8 @@ internal class FileGeneratorTestCompose {
     }
 
     @Test
-    fun `generates code for ComposeScreenData with destination`() {
-        val withDestination = full.copy(navigation = navigation.copy(destinationType = "SCREEN"))
+    fun `generates code for ComposeScreenData with navigationd and destination`() {
+        val withDestination = data.copy(navigation = navigation.copy(destinationType = "SCREEN"))
         val actual = FileGenerator().generate(withDestination).toString()
 
         val expected = """
@@ -211,14 +292,10 @@ internal class FileGeneratorTestCompose {
             import dagger.Provides
             import dagger.multibindings.IntoSet
             import dagger.multibindings.Multibinds
-            import io.reactivex.disposables.CompositeDisposable
             import java.io.Closeable
             import kotlin.OptIn
             import kotlin.Unit
             import kotlin.collections.Set
-            import kotlinx.coroutines.CoroutineScope
-            import kotlinx.coroutines.MainScope
-            import kotlinx.coroutines.cancel
             import kotlinx.coroutines.launch
 
             @OptIn(InternalWhetstoneApi::class)
@@ -254,29 +331,6 @@ internal class FileGeneratorTestCompose {
             public interface RetainedTestModule {
               @Multibinds
               public fun bindCancellable(): Set<Closeable>
-
-              public companion object {
-                @Provides
-                @ScopeTo(TestScreen::class)
-                public fun provideCompositeDisposable(): CompositeDisposable = CompositeDisposable()
-
-                @Provides
-                @IntoSet
-                public fun bindCompositeDisposable(compositeDisposable: CompositeDisposable): Closeable =
-                    Closeable {
-                  compositeDisposable.clear()
-                }
-            
-                @Provides
-                @ScopeTo(TestScreen::class)
-                public fun provideCoroutineScope(): CoroutineScope = MainScope()
-
-                @Provides
-                @IntoSet
-                public fun bindCoroutineScope(coroutineScope: CoroutineScope): Closeable = Closeable {
-                  coroutineScope.cancel()
-                }
-              }
             }
 
             @InternalWhetstoneApi
@@ -337,552 +391,6 @@ internal class FileGeneratorTestCompose {
                 TestScreen(it)
               }
             }
-            
-        """.trimIndent()
-
-        assertThat(actual).isEqualTo(expected)
-    }
-
-    @Test
-    fun `generates code for ComposeScreenData, no navigation`() {
-        val noNavigation = full.copy(navigation = null)
-        val actual = FileGenerator().generate(noNavigation).toString()
-
-        val expected = """
-            package com.test
-
-            import android.os.Bundle
-            import androidx.compose.runtime.Composable
-            import androidx.compose.runtime.CompositionLocalProvider
-            import androidx.compose.runtime.ProvidedValue
-            import androidx.compose.runtime.rememberCoroutineScope
-            import androidx.lifecycle.SavedStateHandle
-            import androidx.lifecycle.ViewModel
-            import com.freeletics.mad.whetstone.ScopeTo
-            import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
-            import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
-            import com.freeletics.mad.whetstone.`internal`.asComposeState
-            import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
-            import com.squareup.anvil.annotations.ContributesSubcomponent
-            import com.squareup.anvil.annotations.ContributesTo
-            import com.test.parent.TestParentScope
-            import dagger.BindsInstance
-            import dagger.Module
-            import dagger.Provides
-            import dagger.multibindings.IntoSet
-            import dagger.multibindings.Multibinds
-            import io.reactivex.disposables.CompositeDisposable
-            import java.io.Closeable
-            import kotlin.OptIn
-            import kotlin.Unit
-            import kotlin.collections.Set
-            import kotlinx.coroutines.CoroutineScope
-            import kotlinx.coroutines.MainScope
-            import kotlinx.coroutines.cancel
-            import kotlinx.coroutines.launch
-
-            @OptIn(InternalWhetstoneApi::class)
-            @ScopeTo(TestScreen::class)
-            @ContributesSubcomponent(
-              scope = TestScreen::class,
-              parentScope = TestParentScope::class,
-              modules = [ComposeProviderValueModule::class],
-            )
-            public interface RetainedTestComponent {
-              public val testStateMachine: TestStateMachine
-    
-              public val closeables: Set<Closeable>
-
-              public val providedValues: Set<ProvidedValue<*>>
-
-              @ContributesSubcomponent.Factory
-              public interface Factory {
-                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
-                    arguments: Bundle): RetainedTestComponent
-              }
-
-              @ContributesTo(TestParentScope::class)
-              public interface ParentComponent {
-                public fun retainedTestComponentFactory(): Factory
-              }
-            }
-
-            @Module
-            @ContributesTo(TestScreen::class)
-            public interface RetainedTestModule {
-              @Multibinds
-              public fun bindCancellable(): Set<Closeable>
-
-              public companion object {
-                @Provides
-                @ScopeTo(TestScreen::class)
-                public fun provideCompositeDisposable(): CompositeDisposable = CompositeDisposable()
-
-                @Provides
-                @IntoSet
-                public fun bindCompositeDisposable(compositeDisposable: CompositeDisposable): Closeable =
-                    Closeable {
-                  compositeDisposable.clear()
-                }
-            
-                @Provides
-                @ScopeTo(TestScreen::class)
-                public fun provideCoroutineScope(): CoroutineScope = MainScope()
-
-                @Provides
-                @IntoSet
-                public fun bindCoroutineScope(coroutineScope: CoroutineScope): Closeable = Closeable {
-                  coroutineScope.cancel()
-                }
-              }
-            }
-
-            @InternalWhetstoneApi
-            internal class TestViewModel(
-              parentComponent: RetainedTestComponent.ParentComponent,
-              savedStateHandle: SavedStateHandle,
-              arguments: Bundle,
-            ) : ViewModel() {
-              public val component: RetainedTestComponent =
-                  parentComponent.retainedTestComponentFactory().create(savedStateHandle, arguments)
-
-              public override fun onCleared(): Unit {
-                component.closeables.forEach {
-                  it.close()
-                }
-              }
-            }
-
-            @Composable
-            @OptIn(InternalWhetstoneApi::class)
-            public fun TestScreen(arguments: Bundle): Unit {
-              val viewModel = rememberViewModel(TestParentScope::class, arguments, ::TestViewModel)
-              val component = viewModel.component
-
-              TestScreen(component)
-            }
-            
-            @Composable
-            @OptIn(InternalWhetstoneApi::class)
-            private fun TestScreen(component: RetainedTestComponent): Unit {
-              val providedValues = component.providedValues
-              CompositionLocalProvider(*providedValues.toTypedArray()) {
-                val stateMachine = component.testStateMachine
-                val state = stateMachine.asComposeState()
-                val currentState = state.value
-                if (currentState != null) {
-                  val scope = rememberCoroutineScope()
-                  Test(currentState) { action ->
-                    scope.launch { stateMachine.dispatch(action) }
-                  }
-                }
-              }
-            }
-            
-        """.trimIndent()
-
-        assertThat(actual).isEqualTo(expected)
-    }
-
-    @Test
-    fun `generates code for ComposeScreenData, without coroutines`() {
-        val withoutCoroutines = full.copy(coroutinesEnabled = false)
-        val actual = FileGenerator().generate(withoutCoroutines).toString()
-
-        val expected = """
-            package com.test
-
-            import androidx.compose.runtime.Composable
-            import androidx.compose.runtime.CompositionLocalProvider
-            import androidx.compose.runtime.ProvidedValue
-            import androidx.compose.runtime.rememberCoroutineScope
-            import androidx.lifecycle.SavedStateHandle
-            import androidx.lifecycle.ViewModel
-            import com.freeletics.mad.navigator.NavEventNavigator
-            import com.freeletics.mad.navigator.compose.NavigationSetup
-            import com.freeletics.mad.whetstone.ScopeTo
-            import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
-            import com.freeletics.mad.whetstone.`internal`.DestinationComponent
-            import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
-            import com.freeletics.mad.whetstone.`internal`.asComposeState
-            import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
-            import com.squareup.anvil.annotations.ContributesSubcomponent
-            import com.squareup.anvil.annotations.ContributesTo
-            import com.test.destination.TestDestinationScope
-            import com.test.parent.TestParentScope
-            import dagger.BindsInstance
-            import dagger.Module
-            import dagger.Provides
-            import dagger.multibindings.IntoSet
-            import dagger.multibindings.Multibinds
-            import io.reactivex.disposables.CompositeDisposable
-            import java.io.Closeable
-            import kotlin.OptIn
-            import kotlin.Unit
-            import kotlin.collections.Set
-            import kotlinx.coroutines.launch
-
-            @OptIn(InternalWhetstoneApi::class)
-            @ScopeTo(TestScreen::class)
-            @ContributesSubcomponent(
-              scope = TestScreen::class,
-              parentScope = TestParentScope::class,
-              modules = [ComposeProviderValueModule::class],
-            )
-            public interface RetainedTestComponent {
-              public val testStateMachine: TestStateMachine
-
-              public val navEventNavigator: NavEventNavigator
-    
-              public val closeables: Set<Closeable>
-
-              public val providedValues: Set<ProvidedValue<*>>
-
-              @ContributesSubcomponent.Factory
-              public interface Factory {
-                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
-                    testRoute: TestRoute): RetainedTestComponent
-              }
-
-              @ContributesTo(TestParentScope::class)
-              public interface ParentComponent {
-                public fun retainedTestComponentFactory(): Factory
-              }
-            }
-
-            @Module
-            @ContributesTo(TestScreen::class)
-            public interface RetainedTestModule {
-              @Multibinds
-              public fun bindCancellable(): Set<Closeable>
-
-              public companion object {
-                @Provides
-                @ScopeTo(TestScreen::class)
-                public fun provideCompositeDisposable(): CompositeDisposable = CompositeDisposable()
-
-                @Provides
-                @IntoSet
-                public fun bindCompositeDisposable(compositeDisposable: CompositeDisposable): Closeable =
-                    Closeable {
-                  compositeDisposable.clear()
-                }
-              }
-            }
-
-            @InternalWhetstoneApi
-            internal class TestViewModel(
-              parentComponent: RetainedTestComponent.ParentComponent,
-              savedStateHandle: SavedStateHandle,
-              testRoute: TestRoute,
-            ) : ViewModel() {
-              public val component: RetainedTestComponent =
-                  parentComponent.retainedTestComponentFactory().create(savedStateHandle, testRoute)
-
-              public override fun onCleared(): Unit {
-                component.closeables.forEach {
-                  it.close()
-                }
-              }
-            }
-
-            @Composable
-            @OptIn(InternalWhetstoneApi::class)
-            public fun TestScreen(testRoute: TestRoute): Unit {
-              val viewModel = rememberViewModel(TestParentScope::class, TestDestinationScope::class, testRoute,
-                  ::TestViewModel)
-              val component = viewModel.component
-
-              NavigationSetup(component.navEventNavigator)
-
-              TestScreen(component)
-            }
-            
-            @Composable
-            @OptIn(InternalWhetstoneApi::class)
-            private fun TestScreen(component: RetainedTestComponent): Unit {
-              val providedValues = component.providedValues
-              CompositionLocalProvider(*providedValues.toTypedArray()) {
-                val stateMachine = component.testStateMachine
-                val state = stateMachine.asComposeState()
-                val currentState = state.value
-                if (currentState != null) {
-                  val scope = rememberCoroutineScope()
-                  Test(currentState) { action ->
-                    scope.launch { stateMachine.dispatch(action) }
-                  }
-                }
-              }
-            }
-            
-            @ContributesTo(TestDestinationScope::class)
-            @OptIn(InternalWhetstoneApi::class)
-            public interface NavEntryTestDestinationComponent : DestinationComponent
-            
-        """.trimIndent()
-
-        assertThat(actual).isEqualTo(expected)
-    }
-
-    @Test
-    fun `generates code for ComposeScreenData, without rxjava`() {
-        val withoutRxJava = full.copy(rxJavaEnabled = false)
-        val actual = FileGenerator().generate(withoutRxJava).toString()
-
-        val expected = """
-            package com.test
-
-            import androidx.compose.runtime.Composable
-            import androidx.compose.runtime.CompositionLocalProvider
-            import androidx.compose.runtime.ProvidedValue
-            import androidx.compose.runtime.rememberCoroutineScope
-            import androidx.lifecycle.SavedStateHandle
-            import androidx.lifecycle.ViewModel
-            import com.freeletics.mad.navigator.NavEventNavigator
-            import com.freeletics.mad.navigator.compose.NavigationSetup
-            import com.freeletics.mad.whetstone.ScopeTo
-            import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
-            import com.freeletics.mad.whetstone.`internal`.DestinationComponent
-            import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
-            import com.freeletics.mad.whetstone.`internal`.asComposeState
-            import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
-            import com.squareup.anvil.annotations.ContributesSubcomponent
-            import com.squareup.anvil.annotations.ContributesTo
-            import com.test.destination.TestDestinationScope
-            import com.test.parent.TestParentScope
-            import dagger.BindsInstance
-            import dagger.Module
-            import dagger.Provides
-            import dagger.multibindings.IntoSet
-            import dagger.multibindings.Multibinds
-            import java.io.Closeable
-            import kotlin.OptIn
-            import kotlin.Unit
-            import kotlin.collections.Set
-            import kotlinx.coroutines.CoroutineScope
-            import kotlinx.coroutines.MainScope
-            import kotlinx.coroutines.cancel
-            import kotlinx.coroutines.launch
-
-            @OptIn(InternalWhetstoneApi::class)
-            @ScopeTo(TestScreen::class)
-            @ContributesSubcomponent(
-              scope = TestScreen::class,
-              parentScope = TestParentScope::class,
-              modules = [ComposeProviderValueModule::class],
-            )
-            public interface RetainedTestComponent {
-              public val testStateMachine: TestStateMachine
-
-              public val navEventNavigator: NavEventNavigator
-    
-              public val closeables: Set<Closeable>
-
-              public val providedValues: Set<ProvidedValue<*>>
-
-              @ContributesSubcomponent.Factory
-              public interface Factory {
-                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
-                    testRoute: TestRoute): RetainedTestComponent
-              }
-
-              @ContributesTo(TestParentScope::class)
-              public interface ParentComponent {
-                public fun retainedTestComponentFactory(): Factory
-              }
-            }
-
-            @Module
-            @ContributesTo(TestScreen::class)
-            public interface RetainedTestModule {
-              @Multibinds
-              public fun bindCancellable(): Set<Closeable>
-
-              public companion object {
-                @Provides
-                @ScopeTo(TestScreen::class)
-                public fun provideCoroutineScope(): CoroutineScope = MainScope()
-
-                @Provides
-                @IntoSet
-                public fun bindCoroutineScope(coroutineScope: CoroutineScope): Closeable = Closeable {
-                  coroutineScope.cancel()
-                }
-              }
-            }
-
-            @InternalWhetstoneApi
-            internal class TestViewModel(
-              parentComponent: RetainedTestComponent.ParentComponent,
-              savedStateHandle: SavedStateHandle,
-              testRoute: TestRoute,
-            ) : ViewModel() {
-              public val component: RetainedTestComponent =
-                  parentComponent.retainedTestComponentFactory().create(savedStateHandle, testRoute)
-
-              public override fun onCleared(): Unit {
-                component.closeables.forEach {
-                  it.close()
-                }
-              }
-            }
-
-            @Composable
-            @OptIn(InternalWhetstoneApi::class)
-            public fun TestScreen(testRoute: TestRoute): Unit {
-              val viewModel = rememberViewModel(TestParentScope::class, TestDestinationScope::class, testRoute,
-                  ::TestViewModel)
-              val component = viewModel.component
-
-              NavigationSetup(component.navEventNavigator)
-
-              TestScreen(component)
-            }
-            
-            @Composable
-            @OptIn(InternalWhetstoneApi::class)
-            private fun TestScreen(component: RetainedTestComponent): Unit {
-              val providedValues = component.providedValues
-              CompositionLocalProvider(*providedValues.toTypedArray()) {
-                val stateMachine = component.testStateMachine
-                val state = stateMachine.asComposeState()
-                val currentState = state.value
-                if (currentState != null) {
-                  val scope = rememberCoroutineScope()
-                  Test(currentState) { action ->
-                    scope.launch { stateMachine.dispatch(action) }
-                  }
-                }
-              }
-            }
-            
-            @ContributesTo(TestDestinationScope::class)
-            @OptIn(InternalWhetstoneApi::class)
-            public interface NavEntryTestDestinationComponent : DestinationComponent
-            
-        """.trimIndent()
-
-        assertThat(actual).isEqualTo(expected)
-    }
-
-    @Test
-    fun `generates code for ComposeScreenData, without rxjava and coroutines`() {
-        val withoutRxJava = full.copy(rxJavaEnabled = false, coroutinesEnabled = false)
-        val actual = FileGenerator().generate(withoutRxJava).toString()
-
-        val expected = """
-            package com.test
-
-            import androidx.compose.runtime.Composable
-            import androidx.compose.runtime.CompositionLocalProvider
-            import androidx.compose.runtime.ProvidedValue
-            import androidx.compose.runtime.rememberCoroutineScope
-            import androidx.lifecycle.SavedStateHandle
-            import androidx.lifecycle.ViewModel
-            import com.freeletics.mad.navigator.NavEventNavigator
-            import com.freeletics.mad.navigator.compose.NavigationSetup
-            import com.freeletics.mad.whetstone.ScopeTo
-            import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
-            import com.freeletics.mad.whetstone.`internal`.DestinationComponent
-            import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
-            import com.freeletics.mad.whetstone.`internal`.asComposeState
-            import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
-            import com.squareup.anvil.annotations.ContributesSubcomponent
-            import com.squareup.anvil.annotations.ContributesTo
-            import com.test.destination.TestDestinationScope
-            import com.test.parent.TestParentScope
-            import dagger.BindsInstance
-            import dagger.Module
-            import dagger.multibindings.Multibinds
-            import java.io.Closeable
-            import kotlin.OptIn
-            import kotlin.Unit
-            import kotlin.collections.Set
-            import kotlinx.coroutines.launch
-
-            @OptIn(InternalWhetstoneApi::class)
-            @ScopeTo(TestScreen::class)
-            @ContributesSubcomponent(
-              scope = TestScreen::class,
-              parentScope = TestParentScope::class,
-              modules = [ComposeProviderValueModule::class],
-            )
-            public interface RetainedTestComponent {
-              public val testStateMachine: TestStateMachine
-
-              public val navEventNavigator: NavEventNavigator
-    
-              public val closeables: Set<Closeable>
-
-              public val providedValues: Set<ProvidedValue<*>>
-
-              @ContributesSubcomponent.Factory
-              public interface Factory {
-                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
-                    testRoute: TestRoute): RetainedTestComponent
-              }
-
-              @ContributesTo(TestParentScope::class)
-              public interface ParentComponent {
-                public fun retainedTestComponentFactory(): Factory
-              }
-            }
-
-            @Module
-            @ContributesTo(TestScreen::class)
-            public interface RetainedTestModule {
-              @Multibinds
-              public fun bindCancellable(): Set<Closeable>
-            }
-
-            @InternalWhetstoneApi
-            internal class TestViewModel(
-              parentComponent: RetainedTestComponent.ParentComponent,
-              savedStateHandle: SavedStateHandle,
-              testRoute: TestRoute,
-            ) : ViewModel() {
-              public val component: RetainedTestComponent =
-                  parentComponent.retainedTestComponentFactory().create(savedStateHandle, testRoute)
-
-              public override fun onCleared(): Unit {
-                component.closeables.forEach {
-                  it.close()
-                }
-              }
-            }
-
-            @Composable
-            @OptIn(InternalWhetstoneApi::class)
-            public fun TestScreen(testRoute: TestRoute): Unit {
-              val viewModel = rememberViewModel(TestParentScope::class, TestDestinationScope::class, testRoute,
-                  ::TestViewModel)
-              val component = viewModel.component
-
-              NavigationSetup(component.navEventNavigator)
-
-              TestScreen(component)
-            }
-            
-            @Composable
-            @OptIn(InternalWhetstoneApi::class)
-            private fun TestScreen(component: RetainedTestComponent): Unit {
-              val providedValues = component.providedValues
-              CompositionLocalProvider(*providedValues.toTypedArray()) {
-                val stateMachine = component.testStateMachine
-                val state = stateMachine.asComposeState()
-                val currentState = state.value
-                if (currentState != null) {
-                  val scope = rememberCoroutineScope()
-                  Test(currentState) { action ->
-                    scope.launch { stateMachine.dispatch(action) }
-                  }
-                }
-              }
-            }
-            
-            @ContributesTo(TestDestinationScope::class)
-            @OptIn(InternalWhetstoneApi::class)
-            public interface NavEntryTestDestinationComponent : DestinationComponent
             
         """.trimIndent()
 

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
@@ -17,21 +17,153 @@ internal class FileGeneratorTestComposeFragment {
         navEntryData = null,
     )
 
-    private val full = ComposeFragmentData(
+    private val data = ComposeFragmentData(
         baseName = "Test",
         packageName = "com.test",
         scope = ClassName("com.test", "TestScreen"),
         parentScope = ClassName("com.test.parent", "TestParentScope"),
         stateMachine = ClassName("com.test", "TestStateMachine"),
         fragmentBaseClass = fragment,
-        navigation = navigation,
-        coroutinesEnabled = true,
-        rxJavaEnabled = true,
+        navigation = null,
     )
 
     @Test
     fun `generates code for ComposeFragmentData`() {
-        val actual = FileGenerator().generate(full).toString()
+        val actual = FileGenerator().generate(data).toString()
+
+        val expected = """
+            package com.test
+
+            import android.os.Bundle
+            import android.view.LayoutInflater
+            import android.view.View
+            import android.view.ViewGroup
+            import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.CompositionLocalProvider
+            import androidx.compose.runtime.ProvidedValue
+            import androidx.compose.runtime.rememberCoroutineScope
+            import androidx.compose.ui.platform.ComposeView
+            import androidx.compose.ui.platform.ViewCompositionStrategy
+            import androidx.fragment.app.Fragment
+            import androidx.lifecycle.SavedStateHandle
+            import androidx.lifecycle.ViewModel
+            import com.freeletics.mad.whetstone.ScopeTo
+            import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
+            import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
+            import com.freeletics.mad.whetstone.`internal`.asComposeState
+            import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
+            import com.squareup.anvil.annotations.ContributesSubcomponent
+            import com.squareup.anvil.annotations.ContributesTo
+            import com.test.parent.TestParentScope
+            import dagger.BindsInstance
+            import dagger.Module
+            import dagger.multibindings.Multibinds
+            import java.io.Closeable
+            import kotlin.OptIn
+            import kotlin.Unit
+            import kotlin.collections.Set
+            import kotlinx.coroutines.launch
+
+            @OptIn(InternalWhetstoneApi::class)
+            @ScopeTo(TestScreen::class)
+            @ContributesSubcomponent(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+              modules = [ComposeProviderValueModule::class],
+            )
+            public interface RetainedTestComponent {
+              public val testStateMachine: TestStateMachine
+
+              public val closeables: Set<Closeable>
+
+              public val providedValues: Set<ProvidedValue<*>>
+
+              @ContributesSubcomponent.Factory
+              public interface Factory {
+                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
+                    arguments: Bundle): RetainedTestComponent
+              }
+
+              @ContributesTo(TestParentScope::class)
+              public interface ParentComponent {
+                public fun retainedTestComponentFactory(): Factory
+              }
+            }
+
+            @Module
+            @ContributesTo(TestScreen::class)
+            public interface RetainedTestModule {
+              @Multibinds
+              public fun bindCancellable(): Set<Closeable>
+            }
+
+            @InternalWhetstoneApi
+            internal class TestViewModel(
+              parentComponent: RetainedTestComponent.ParentComponent,
+              savedStateHandle: SavedStateHandle,
+              arguments: Bundle,
+            ) : ViewModel() {
+              public val component: RetainedTestComponent =
+                  parentComponent.retainedTestComponentFactory().create(savedStateHandle, arguments)
+
+              public override fun onCleared(): Unit {
+                component.closeables.forEach {
+                  it.close()
+                }
+              }
+            }
+            
+            @OptIn(InternalWhetstoneApi::class)
+            public class TestFragment : Fragment() {
+              private lateinit var retainedTestComponent: RetainedTestComponent
+            
+              public override fun onCreateView(
+                inflater: LayoutInflater,
+                container: ViewGroup?,
+                savedInstanceState: Bundle?,
+              ): View {
+                if (!::retainedTestComponent.isInitialized) {
+                  val arguments = requireArguments()
+                  val viewModel = viewModel(TestParentScope::class, arguments, ::TestViewModel)
+                  retainedTestComponent = viewModel.component
+                }
+
+                return ComposeView(requireContext()).apply {
+                  setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnLifecycleDestroyed(viewLifecycleOwner))
+
+                  setContent {
+                    TestScreen(retainedTestComponent)
+                  }
+                }
+              }
+            }
+
+            @Composable
+            @OptIn(InternalWhetstoneApi::class)
+            private fun TestScreen(component: RetainedTestComponent): Unit {
+              val providedValues = component.providedValues
+              CompositionLocalProvider(*providedValues.toTypedArray()) {
+                val stateMachine = component.testStateMachine
+                val state = stateMachine.asComposeState()
+                val currentState = state.value
+                if (currentState != null) {
+                  val scope = rememberCoroutineScope()
+                  Test(currentState) { action ->
+                    scope.launch { stateMachine.dispatch(action) }
+                  }
+                }
+              }
+            }
+            
+        """.trimIndent()
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `generates code for ComposeFragmentData with navigation`() {
+        val withNavigation = data.copy(navigation =  navigation)
+        val actual = FileGenerator().generate(withNavigation).toString()
 
         val expected = """
             package com.test
@@ -64,17 +196,11 @@ internal class FileGeneratorTestComposeFragment {
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
             import dagger.Module
-            import dagger.Provides
-            import dagger.multibindings.IntoSet
             import dagger.multibindings.Multibinds
-            import io.reactivex.disposables.CompositeDisposable
             import java.io.Closeable
             import kotlin.OptIn
             import kotlin.Unit
             import kotlin.collections.Set
-            import kotlinx.coroutines.CoroutineScope
-            import kotlinx.coroutines.MainScope
-            import kotlinx.coroutines.cancel
             import kotlinx.coroutines.launch
 
             @OptIn(InternalWhetstoneApi::class)
@@ -110,29 +236,6 @@ internal class FileGeneratorTestComposeFragment {
             public interface RetainedTestModule {
               @Multibinds
               public fun bindCancellable(): Set<Closeable>
-
-              public companion object {
-                @Provides
-                @ScopeTo(TestScreen::class)
-                public fun provideCompositeDisposable(): CompositeDisposable = CompositeDisposable()
-
-                @Provides
-                @IntoSet
-                public fun bindCompositeDisposable(compositeDisposable: CompositeDisposable): Closeable =
-                    Closeable {
-                  compositeDisposable.clear()
-                }
-            
-                @Provides
-                @ScopeTo(TestScreen::class)
-                public fun provideCoroutineScope(): CoroutineScope = MainScope()
-
-                @Provides
-                @IntoSet
-                public fun bindCoroutineScope(coroutineScope: CoroutineScope): Closeable = Closeable {
-                  coroutineScope.cancel()
-                }
-              }
             }
 
             @InternalWhetstoneApi
@@ -206,8 +309,8 @@ internal class FileGeneratorTestComposeFragment {
     }
 
     @Test
-    fun `generates code for ComposeFragmentData with destination`() {
-        val withDestination = full.copy(navigation = navigation.copy(destinationType = "SCREEN"))
+    fun `generates code for ComposeFragmentData with navigation and destination`() {
+        val withDestination = data.copy(navigation = navigation.copy(destinationType = "SCREEN"))
         val actual = FileGenerator().generate(withDestination).toString()
 
         val expected = """
@@ -246,14 +349,10 @@ internal class FileGeneratorTestComposeFragment {
             import dagger.Provides
             import dagger.multibindings.IntoSet
             import dagger.multibindings.Multibinds
-            import io.reactivex.disposables.CompositeDisposable
             import java.io.Closeable
             import kotlin.OptIn
             import kotlin.Unit
             import kotlin.collections.Set
-            import kotlinx.coroutines.CoroutineScope
-            import kotlinx.coroutines.MainScope
-            import kotlinx.coroutines.cancel
             import kotlinx.coroutines.launch
 
             @OptIn(InternalWhetstoneApi::class)
@@ -289,29 +388,6 @@ internal class FileGeneratorTestComposeFragment {
             public interface RetainedTestModule {
               @Multibinds
               public fun bindCancellable(): Set<Closeable>
-
-              public companion object {
-                @Provides
-                @ScopeTo(TestScreen::class)
-                public fun provideCompositeDisposable(): CompositeDisposable = CompositeDisposable()
-
-                @Provides
-                @IntoSet
-                public fun bindCompositeDisposable(compositeDisposable: CompositeDisposable): Closeable =
-                    Closeable {
-                  compositeDisposable.clear()
-                }
-            
-                @Provides
-                @ScopeTo(TestScreen::class)
-                public fun provideCoroutineScope(): CoroutineScope = MainScope()
-
-                @Provides
-                @IntoSet
-                public fun bindCoroutineScope(coroutineScope: CoroutineScope): Closeable = Closeable {
-                  coroutineScope.cancel()
-                }
-              }
             }
 
             @InternalWhetstoneApi
@@ -394,9 +470,7 @@ internal class FileGeneratorTestComposeFragment {
 
     @Test
     fun `generates code for ComposeFragmentData, dialog fragment`() {
-        val dialogFragment = full.copy(
-            fragmentBaseClass = dialogFragment
-        )
+        val dialogFragment = data.copy(fragmentBaseClass = dialogFragment)
         val actual = FileGenerator().generate(dialogFragment).toString()
 
         val expected = """
@@ -415,183 +489,6 @@ internal class FileGeneratorTestComposeFragment {
             import androidx.fragment.app.DialogFragment
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
-            import com.freeletics.mad.navigator.NavEventNavigator
-            import com.freeletics.mad.navigator.fragment.handleNavigation
-            import com.freeletics.mad.navigator.fragment.requireRoute
-            import com.freeletics.mad.whetstone.ScopeTo
-            import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
-            import com.freeletics.mad.whetstone.`internal`.DestinationComponent
-            import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
-            import com.freeletics.mad.whetstone.`internal`.asComposeState
-            import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
-            import com.squareup.anvil.annotations.ContributesSubcomponent
-            import com.squareup.anvil.annotations.ContributesTo
-            import com.test.destination.TestDestinationScope
-            import com.test.parent.TestParentScope
-            import dagger.BindsInstance
-            import dagger.Module
-            import dagger.Provides
-            import dagger.multibindings.IntoSet
-            import dagger.multibindings.Multibinds
-            import io.reactivex.disposables.CompositeDisposable
-            import java.io.Closeable
-            import kotlin.OptIn
-            import kotlin.Unit
-            import kotlin.collections.Set
-            import kotlinx.coroutines.CoroutineScope
-            import kotlinx.coroutines.MainScope
-            import kotlinx.coroutines.cancel
-            import kotlinx.coroutines.launch
-
-            @OptIn(InternalWhetstoneApi::class)
-            @ScopeTo(TestScreen::class)
-            @ContributesSubcomponent(
-              scope = TestScreen::class,
-              parentScope = TestParentScope::class,
-              modules = [ComposeProviderValueModule::class],
-            )
-            public interface RetainedTestComponent {
-              public val testStateMachine: TestStateMachine
-
-              public val navEventNavigator: NavEventNavigator
-
-              public val closeables: Set<Closeable>
-
-              public val providedValues: Set<ProvidedValue<*>>
-
-              @ContributesSubcomponent.Factory
-              public interface Factory {
-                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
-                    testRoute: TestRoute): RetainedTestComponent
-              }
-
-              @ContributesTo(TestParentScope::class)
-              public interface ParentComponent {
-                public fun retainedTestComponentFactory(): Factory
-              }
-            }
-
-            @Module
-            @ContributesTo(TestScreen::class)
-            public interface RetainedTestModule {
-              @Multibinds
-              public fun bindCancellable(): Set<Closeable>
-
-              public companion object {
-                @Provides
-                @ScopeTo(TestScreen::class)
-                public fun provideCompositeDisposable(): CompositeDisposable = CompositeDisposable()
-
-                @Provides
-                @IntoSet
-                public fun bindCompositeDisposable(compositeDisposable: CompositeDisposable): Closeable =
-                    Closeable {
-                  compositeDisposable.clear()
-                }
-            
-                @Provides
-                @ScopeTo(TestScreen::class)
-                public fun provideCoroutineScope(): CoroutineScope = MainScope()
-
-                @Provides
-                @IntoSet
-                public fun bindCoroutineScope(coroutineScope: CoroutineScope): Closeable = Closeable {
-                  coroutineScope.cancel()
-                }
-              }
-            }
-
-            @InternalWhetstoneApi
-            internal class TestViewModel(
-              parentComponent: RetainedTestComponent.ParentComponent,
-              savedStateHandle: SavedStateHandle,
-              testRoute: TestRoute,
-            ) : ViewModel() {
-              public val component: RetainedTestComponent =
-                  parentComponent.retainedTestComponentFactory().create(savedStateHandle, testRoute)
-
-              public override fun onCleared(): Unit {
-                component.closeables.forEach {
-                  it.close()
-                }
-              }
-            }
-            
-            @OptIn(InternalWhetstoneApi::class)
-            public class TestFragment : DialogFragment() {
-              private lateinit var retainedTestComponent: RetainedTestComponent
-            
-              public override fun onCreateView(
-                inflater: LayoutInflater,
-                container: ViewGroup?,
-                savedInstanceState: Bundle?,
-              ): View {
-                if (!::retainedTestComponent.isInitialized) {
-                  val testRoute = requireRoute<TestRoute>()
-                  val viewModel = viewModel(TestParentScope::class, TestDestinationScope::class, testRoute,
-                      ::TestViewModel)
-                  retainedTestComponent = viewModel.component
-            
-                  handleNavigation(this, retainedTestComponent.navEventNavigator)
-                }
-            
-                return ComposeView(requireContext()).apply {
-                  setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnLifecycleDestroyed(viewLifecycleOwner))
-
-                  setContent {
-                    TestScreen(retainedTestComponent)
-                  }
-                }
-              }
-            }
-
-            @Composable
-            @OptIn(InternalWhetstoneApi::class)
-            private fun TestScreen(component: RetainedTestComponent): Unit {
-              val providedValues = component.providedValues
-              CompositionLocalProvider(*providedValues.toTypedArray()) {
-                val stateMachine = component.testStateMachine
-                val state = stateMachine.asComposeState()
-                val currentState = state.value
-                if (currentState != null) {
-                  val scope = rememberCoroutineScope()
-                  Test(currentState) { action ->
-                    scope.launch { stateMachine.dispatch(action) }
-                  }
-                }
-              }
-            }
-            
-            @ContributesTo(TestDestinationScope::class)
-            @OptIn(InternalWhetstoneApi::class)
-            public interface NavEntryTestDestinationComponent : DestinationComponent
-            
-        """.trimIndent()
-
-        assertThat(actual).isEqualTo(expected)
-    }
-
-    @Test
-    fun `generates code for ComposeFragmentData, no navigation`() {
-        val noNavigation = full.copy(navigation = null)
-        val actual = FileGenerator().generate(noNavigation).toString()
-
-        val expected = """
-            package com.test
-
-            import android.os.Bundle
-            import android.view.LayoutInflater
-            import android.view.View
-            import android.view.ViewGroup
-            import androidx.compose.runtime.Composable
-            import androidx.compose.runtime.CompositionLocalProvider
-            import androidx.compose.runtime.ProvidedValue
-            import androidx.compose.runtime.rememberCoroutineScope
-            import androidx.compose.ui.platform.ComposeView
-            import androidx.compose.ui.platform.ViewCompositionStrategy
-            import androidx.fragment.app.Fragment
-            import androidx.lifecycle.SavedStateHandle
-            import androidx.lifecycle.ViewModel
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
@@ -602,17 +499,11 @@ internal class FileGeneratorTestComposeFragment {
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
             import dagger.Module
-            import dagger.Provides
-            import dagger.multibindings.IntoSet
             import dagger.multibindings.Multibinds
-            import io.reactivex.disposables.CompositeDisposable
             import java.io.Closeable
             import kotlin.OptIn
             import kotlin.Unit
             import kotlin.collections.Set
-            import kotlinx.coroutines.CoroutineScope
-            import kotlinx.coroutines.MainScope
-            import kotlinx.coroutines.cancel
             import kotlinx.coroutines.launch
 
             @OptIn(InternalWhetstoneApi::class)
@@ -646,29 +537,6 @@ internal class FileGeneratorTestComposeFragment {
             public interface RetainedTestModule {
               @Multibinds
               public fun bindCancellable(): Set<Closeable>
-
-              public companion object {
-                @Provides
-                @ScopeTo(TestScreen::class)
-                public fun provideCompositeDisposable(): CompositeDisposable = CompositeDisposable()
-
-                @Provides
-                @IntoSet
-                public fun bindCompositeDisposable(compositeDisposable: CompositeDisposable): Closeable =
-                    Closeable {
-                  compositeDisposable.clear()
-                }
-            
-                @Provides
-                @ScopeTo(TestScreen::class)
-                public fun provideCoroutineScope(): CoroutineScope = MainScope()
-
-                @Provides
-                @IntoSet
-                public fun bindCoroutineScope(coroutineScope: CoroutineScope): Closeable = Closeable {
-                  coroutineScope.cancel()
-                }
-              }
             }
 
             @InternalWhetstoneApi
@@ -688,9 +556,9 @@ internal class FileGeneratorTestComposeFragment {
             }
             
             @OptIn(InternalWhetstoneApi::class)
-            public class TestFragment : Fragment() {
+            public class TestFragment : DialogFragment() {
               private lateinit var retainedTestComponent: RetainedTestComponent
-
+            
               public override fun onCreateView(
                 inflater: LayoutInflater,
                 container: ViewGroup?,

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestRendererFragment.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestRendererFragment.kt
@@ -15,7 +15,7 @@ internal class FileGeneratorTestRendererFragment {
         navEntryData = null,
     )
 
-    private val full = RendererFragmentData(
+    private val data = RendererFragmentData(
         baseName = "Test",
         packageName = "com.test",
         scope = ClassName("com.test", "TestScreen"),
@@ -23,14 +23,116 @@ internal class FileGeneratorTestRendererFragment {
         stateMachine = ClassName("com.test", "TestStateMachine"),
         factory = ClassName("com.test", "RendererFactory"),
         fragmentBaseClass = ClassName("androidx.fragment.app", "Fragment"),
-        navigation = navigation,
-        coroutinesEnabled = true,
-        rxJavaEnabled = true,
+        navigation = null,
     )
 
     @Test
     fun `generates code for RendererFragmentData`() {
-        val actual = FileGenerator().generate(full).toString()
+        val actual = FileGenerator().generate(data).toString()
+
+        val expected = """
+            package com.test
+
+            import android.os.Bundle
+            import android.view.LayoutInflater
+            import android.view.View
+            import android.view.ViewGroup
+            import androidx.fragment.app.Fragment
+            import androidx.lifecycle.SavedStateHandle
+            import androidx.lifecycle.ViewModel
+            import com.freeletics.mad.whetstone.ScopeTo
+            import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
+            import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
+            import com.gabrielittner.renderer.connect.connect
+            import com.squareup.anvil.annotations.ContributesSubcomponent
+            import com.squareup.anvil.annotations.ContributesTo
+            import com.test.parent.TestParentScope
+            import dagger.BindsInstance
+            import dagger.Module
+            import dagger.multibindings.Multibinds
+            import java.io.Closeable
+            import kotlin.OptIn
+            import kotlin.Unit
+            import kotlin.collections.Set
+
+            @OptIn(InternalWhetstoneApi::class)
+            @ScopeTo(TestScreen::class)
+            @ContributesSubcomponent(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+            )
+            public interface RetainedTestComponent {
+              public val testStateMachine: TestStateMachine
+            
+              public val closeables: Set<Closeable>
+
+              public val rendererFactory: RendererFactory
+
+              @ContributesSubcomponent.Factory
+              public interface Factory {
+                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
+                    arguments: Bundle): RetainedTestComponent
+              }
+
+              @ContributesTo(TestParentScope::class)
+              public interface ParentComponent {
+                public fun retainedTestComponentFactory(): Factory
+              }
+            }
+
+            @Module
+            @ContributesTo(TestScreen::class)
+            public interface RetainedTestModule {
+              @Multibinds
+              public fun bindCancellable(): Set<Closeable>
+            }
+
+            @InternalWhetstoneApi
+            internal class TestViewModel(
+              parentComponent: RetainedTestComponent.ParentComponent,
+              savedStateHandle: SavedStateHandle,
+              arguments: Bundle,
+            ) : ViewModel() {
+              public val component: RetainedTestComponent =
+                  parentComponent.retainedTestComponentFactory().create(savedStateHandle, arguments)
+
+              public override fun onCleared(): Unit {
+                component.closeables.forEach {
+                  it.close()
+                }
+              }
+            }
+            
+            @OptIn(InternalWhetstoneApi::class)
+            public class TestFragment : Fragment() {
+              private lateinit var retainedTestComponent: RetainedTestComponent
+
+              public override fun onCreateView(
+                inflater: LayoutInflater,
+                container: ViewGroup?,
+                savedInstanceState: Bundle?,
+              ): View {
+                if (!::retainedTestComponent.isInitialized) {
+                  val arguments = requireArguments()
+                  val viewModel = viewModel(TestParentScope::class, arguments, ::TestViewModel)
+                  retainedTestComponent = viewModel.component
+                }
+            
+                val renderer = retainedTestComponent.rendererFactory.inflate(inflater, container)
+                connect(renderer, retainedTestComponent.testStateMachine)
+                return renderer.rootView
+              }
+            }
+            
+        """.trimIndent()
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `generates code for RendererFragmentData with navigation`() {
+        val withNavigation = data.copy(navigation = navigation)
+        val actual = FileGenerator().generate(withNavigation).toString()
 
         val expected = """
             package com.test
@@ -56,17 +158,11 @@ internal class FileGeneratorTestRendererFragment {
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
             import dagger.Module
-            import dagger.Provides
-            import dagger.multibindings.IntoSet
             import dagger.multibindings.Multibinds
-            import io.reactivex.disposables.CompositeDisposable
             import java.io.Closeable
             import kotlin.OptIn
             import kotlin.Unit
             import kotlin.collections.Set
-            import kotlinx.coroutines.CoroutineScope
-            import kotlinx.coroutines.MainScope
-            import kotlinx.coroutines.cancel
 
             @OptIn(InternalWhetstoneApi::class)
             @ScopeTo(TestScreen::class)
@@ -100,29 +196,6 @@ internal class FileGeneratorTestRendererFragment {
             public interface RetainedTestModule {
               @Multibinds
               public fun bindCancellable(): Set<Closeable>
-
-              public companion object {
-                @Provides
-                @ScopeTo(TestScreen::class)
-                public fun provideCompositeDisposable(): CompositeDisposable = CompositeDisposable()
-
-                @Provides
-                @IntoSet
-                public fun bindCompositeDisposable(compositeDisposable: CompositeDisposable): Closeable =
-                    Closeable {
-                  compositeDisposable.clear()
-                }
-            
-                @Provides
-                @ScopeTo(TestScreen::class)
-                public fun provideCoroutineScope(): CoroutineScope = MainScope()
-
-                @Provides
-                @IntoSet
-                public fun bindCoroutineScope(coroutineScope: CoroutineScope): Closeable = Closeable {
-                  coroutineScope.cancel()
-                }
-              }
             }
 
             @InternalWhetstoneApi
@@ -175,8 +248,8 @@ internal class FileGeneratorTestRendererFragment {
     }
 
     @Test
-    fun `generates code for RendererFragmentData with destination`() {
-        val withDestination = full.copy(navigation = navigation.copy(destinationType = "SCREEN"))
+    fun `generates code for RendererFragmentData with navigation and destination`() {
+        val withDestination = data.copy(navigation = navigation.copy(destinationType = "SCREEN"))
         val actual = FileGenerator().generate(withDestination).toString()
 
         val expected = """
@@ -208,14 +281,10 @@ internal class FileGeneratorTestRendererFragment {
             import dagger.Provides
             import dagger.multibindings.IntoSet
             import dagger.multibindings.Multibinds
-            import io.reactivex.disposables.CompositeDisposable
             import java.io.Closeable
             import kotlin.OptIn
             import kotlin.Unit
             import kotlin.collections.Set
-            import kotlinx.coroutines.CoroutineScope
-            import kotlinx.coroutines.MainScope
-            import kotlinx.coroutines.cancel
 
             @OptIn(InternalWhetstoneApi::class)
             @ScopeTo(TestScreen::class)
@@ -249,29 +318,6 @@ internal class FileGeneratorTestRendererFragment {
             public interface RetainedTestModule {
               @Multibinds
               public fun bindCancellable(): Set<Closeable>
-
-              public companion object {
-                @Provides
-                @ScopeTo(TestScreen::class)
-                public fun provideCompositeDisposable(): CompositeDisposable = CompositeDisposable()
-
-                @Provides
-                @IntoSet
-                public fun bindCompositeDisposable(compositeDisposable: CompositeDisposable): Closeable =
-                    Closeable {
-                  compositeDisposable.clear()
-                }
-            
-                @Provides
-                @ScopeTo(TestScreen::class)
-                public fun provideCoroutineScope(): CoroutineScope = MainScope()
-
-                @Provides
-                @IntoSet
-                public fun bindCoroutineScope(coroutineScope: CoroutineScope): Closeable = Closeable {
-                  coroutineScope.cancel()
-                }
-              }
             }
 
             @InternalWhetstoneApi
@@ -332,9 +378,11 @@ internal class FileGeneratorTestRendererFragment {
     }
 
     @Test
-    fun `generates code for RendererFragmentData, no navigation`() {
-        val noNavigation = full.copy(navigation = null)
-        val actual = FileGenerator().generate(noNavigation).toString()
+    fun `generates code for RendererFragmentData, dialog fragment`() {
+        val dialogFragment = data.copy(
+            fragmentBaseClass = ClassName("androidx.fragment.app", "DialogFragment")
+        )
+        val actual = FileGenerator().generate(dialogFragment).toString()
 
         val expected = """
             package com.test
@@ -343,7 +391,7 @@ internal class FileGeneratorTestRendererFragment {
             import android.view.LayoutInflater
             import android.view.View
             import android.view.ViewGroup
-            import androidx.fragment.app.Fragment
+            import androidx.fragment.app.DialogFragment
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
             import com.freeletics.mad.whetstone.ScopeTo
@@ -355,17 +403,11 @@ internal class FileGeneratorTestRendererFragment {
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
             import dagger.Module
-            import dagger.Provides
-            import dagger.multibindings.IntoSet
             import dagger.multibindings.Multibinds
-            import io.reactivex.disposables.CompositeDisposable
             import java.io.Closeable
             import kotlin.OptIn
             import kotlin.Unit
             import kotlin.collections.Set
-            import kotlinx.coroutines.CoroutineScope
-            import kotlinx.coroutines.MainScope
-            import kotlinx.coroutines.cancel
 
             @OptIn(InternalWhetstoneApi::class)
             @ScopeTo(TestScreen::class)
@@ -397,29 +439,6 @@ internal class FileGeneratorTestRendererFragment {
             public interface RetainedTestModule {
               @Multibinds
               public fun bindCancellable(): Set<Closeable>
-
-              public companion object {
-                @Provides
-                @ScopeTo(TestScreen::class)
-                public fun provideCompositeDisposable(): CompositeDisposable = CompositeDisposable()
-
-                @Provides
-                @IntoSet
-                public fun bindCompositeDisposable(compositeDisposable: CompositeDisposable): Closeable =
-                    Closeable {
-                  compositeDisposable.clear()
-                }
-            
-                @Provides
-                @ScopeTo(TestScreen::class)
-                public fun provideCoroutineScope(): CoroutineScope = MainScope()
-
-                @Provides
-                @IntoSet
-                public fun bindCoroutineScope(coroutineScope: CoroutineScope): Closeable = Closeable {
-                  coroutineScope.cancel()
-                }
-              }
             }
 
             @InternalWhetstoneApi
@@ -439,7 +458,7 @@ internal class FileGeneratorTestRendererFragment {
             }
             
             @OptIn(InternalWhetstoneApi::class)
-            public class TestFragment : Fragment() {
+            public class TestFragment : DialogFragment() {
               private lateinit var retainedTestComponent: RetainedTestComponent
 
               public override fun onCreateView(
@@ -458,156 +477,7 @@ internal class FileGeneratorTestRendererFragment {
                 return renderer.rootView
               }
             }
-            
-        """.trimIndent()
 
-        assertThat(actual).isEqualTo(expected)
-    }
-
-    @Test
-    fun `generates code for RendererFragmentData, dialog fragment`() {
-        val dialogFragment = full.copy(
-            fragmentBaseClass = ClassName("androidx.fragment.app", "DialogFragment")
-        )
-        val actual = FileGenerator().generate(dialogFragment).toString()
-
-        val expected = """
-            package com.test
-
-            import android.os.Bundle
-            import android.view.LayoutInflater
-            import android.view.View
-            import android.view.ViewGroup
-            import androidx.fragment.app.DialogFragment
-            import androidx.lifecycle.SavedStateHandle
-            import androidx.lifecycle.ViewModel
-            import com.freeletics.mad.navigator.NavEventNavigator
-            import com.freeletics.mad.navigator.fragment.handleNavigation
-            import com.freeletics.mad.navigator.fragment.requireRoute
-            import com.freeletics.mad.whetstone.ScopeTo
-            import com.freeletics.mad.whetstone.`internal`.DestinationComponent
-            import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
-            import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
-            import com.gabrielittner.renderer.connect.connect
-            import com.squareup.anvil.annotations.ContributesSubcomponent
-            import com.squareup.anvil.annotations.ContributesTo
-            import com.test.destination.TestDestinationScope
-            import com.test.parent.TestParentScope
-            import dagger.BindsInstance
-            import dagger.Module
-            import dagger.Provides
-            import dagger.multibindings.IntoSet
-            import dagger.multibindings.Multibinds
-            import io.reactivex.disposables.CompositeDisposable
-            import java.io.Closeable
-            import kotlin.OptIn
-            import kotlin.Unit
-            import kotlin.collections.Set
-            import kotlinx.coroutines.CoroutineScope
-            import kotlinx.coroutines.MainScope
-            import kotlinx.coroutines.cancel
-
-            @OptIn(InternalWhetstoneApi::class)
-            @ScopeTo(TestScreen::class)
-            @ContributesSubcomponent(
-              scope = TestScreen::class,
-              parentScope = TestParentScope::class,
-            )
-            public interface RetainedTestComponent {
-              public val testStateMachine: TestStateMachine
-
-              public val navEventNavigator: NavEventNavigator
-            
-              public val closeables: Set<Closeable>
-
-              public val rendererFactory: RendererFactory
-
-              @ContributesSubcomponent.Factory
-              public interface Factory {
-                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
-                    testRoute: TestRoute): RetainedTestComponent
-              }
-
-              @ContributesTo(TestParentScope::class)
-              public interface ParentComponent {
-                public fun retainedTestComponentFactory(): Factory
-              }
-            }
-
-            @Module
-            @ContributesTo(TestScreen::class)
-            public interface RetainedTestModule {
-              @Multibinds
-              public fun bindCancellable(): Set<Closeable>
-
-              public companion object {
-                @Provides
-                @ScopeTo(TestScreen::class)
-                public fun provideCompositeDisposable(): CompositeDisposable = CompositeDisposable()
-
-                @Provides
-                @IntoSet
-                public fun bindCompositeDisposable(compositeDisposable: CompositeDisposable): Closeable =
-                    Closeable {
-                  compositeDisposable.clear()
-                }
-            
-                @Provides
-                @ScopeTo(TestScreen::class)
-                public fun provideCoroutineScope(): CoroutineScope = MainScope()
-
-                @Provides
-                @IntoSet
-                public fun bindCoroutineScope(coroutineScope: CoroutineScope): Closeable = Closeable {
-                  coroutineScope.cancel()
-                }
-              }
-            }
-
-            @InternalWhetstoneApi
-            internal class TestViewModel(
-              parentComponent: RetainedTestComponent.ParentComponent,
-              savedStateHandle: SavedStateHandle,
-              testRoute: TestRoute,
-            ) : ViewModel() {
-              public val component: RetainedTestComponent =
-                  parentComponent.retainedTestComponentFactory().create(savedStateHandle, testRoute)
-
-              public override fun onCleared(): Unit {
-                component.closeables.forEach {
-                  it.close()
-                }
-              }
-            }
-            
-            @OptIn(InternalWhetstoneApi::class)
-            public class TestFragment : DialogFragment() {
-              private lateinit var retainedTestComponent: RetainedTestComponent
-
-              public override fun onCreateView(
-                inflater: LayoutInflater,
-                container: ViewGroup?,
-                savedInstanceState: Bundle?,
-              ): View {
-                if (!::retainedTestComponent.isInitialized) {
-                  val testRoute = requireRoute<TestRoute>()
-                  val viewModel = viewModel(TestParentScope::class, TestDestinationScope::class, testRoute,
-                      ::TestViewModel)
-                  retainedTestComponent = viewModel.component
-            
-                  handleNavigation(this, retainedTestComponent.navEventNavigator)
-                }
-            
-                val renderer = retainedTestComponent.rendererFactory.inflate(inflater, container)
-                connect(renderer, retainedTestComponent.testStateMachine)
-                return renderer.rootView
-              }
-            }
-            
-            @ContributesTo(TestDestinationScope::class)
-            @OptIn(InternalWhetstoneApi::class)
-            public interface NavEntryTestDestinationComponent : DestinationComponent
-            
         """.trimIndent()
 
         assertThat(actual).isEqualTo(expected)

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/NavEntryFileGeneratorTest.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/NavEntryFileGeneratorTest.kt
@@ -7,19 +7,17 @@ import org.junit.Test
 
 internal class NavEntryFileGeneratorTest {
 
-    private val full = NavEntryData(
+    private val data = NavEntryData(
         packageName = "com.test",
         scope = ClassName("com.test", "TestFlowScope"),
         parentScope = ClassName("com.test.parent", "TestParentScope"),
         destinationScope = ClassName("com.test", "TestDestinationScope"),
         route = ClassName("com.test", "TestRoute"),
-        coroutinesEnabled = true,
-        rxJavaEnabled = true,
     )
 
     @Test
-    fun `generates code for full NavEntryData`() {
-        val actual = FileGenerator().generate(full).toString()
+    fun `generates code for NavEntryData`() {
+        val actual = FileGenerator().generate(data).toString()
 
         val expected = """
             package com.test
@@ -43,10 +41,7 @@ internal class NavEntryFileGeneratorTest {
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
             import dagger.Module
-            import dagger.Provides
-            import dagger.multibindings.IntoSet
             import dagger.multibindings.Multibinds
-            import io.reactivex.disposables.CompositeDisposable
             import java.io.Closeable
             import javax.inject.Inject
             import kotlin.Any
@@ -54,9 +49,6 @@ internal class NavEntryFileGeneratorTest {
             import kotlin.OptIn
             import kotlin.Unit
             import kotlin.collections.Set
-            import kotlinx.coroutines.CoroutineScope
-            import kotlinx.coroutines.MainScope
-            import kotlinx.coroutines.cancel
 
             @ScopeTo(TestFlowScope::class)
             @ContributesSubcomponent(
@@ -86,280 +78,6 @@ internal class NavEntryFileGeneratorTest {
               @Multibinds
               @NavEntry(TestFlowScope::class)
               public fun bindCancellable(): Set<Closeable>
-
-              public companion object {
-                @Provides
-                @ScopeTo(TestFlowScope::class)
-                @NavEntry(TestFlowScope::class)
-                public fun provideCompositeDisposable(): CompositeDisposable = CompositeDisposable()
-
-                @Provides
-                @IntoSet
-                @NavEntry(TestFlowScope::class)
-                public fun bindCompositeDisposable(@NavEntry(TestFlowScope::class)
-                    compositeDisposable: CompositeDisposable): Closeable = Closeable {
-                  compositeDisposable.clear()
-                }
-            
-                @Provides
-                @ScopeTo(TestFlowScope::class)
-                @NavEntry(TestFlowScope::class)
-                public fun provideCoroutineScope(): CoroutineScope = MainScope()
-
-                @Provides
-                @IntoSet
-                @NavEntry(TestFlowScope::class)
-                public fun bindCoroutineScope(@NavEntry(TestFlowScope::class) coroutineScope: CoroutineScope):
-                    Closeable = Closeable {
-                  coroutineScope.cancel()
-                }
-              }
-            }
-
-            @InternalWhetstoneApi
-            internal class TestFlowScopeViewModel(
-              parentComponent: NavEntryTestFlowScopeComponent.ParentComponent,
-              savedStateHandle: SavedStateHandle,
-              testRoute: TestRoute,
-            ) : ViewModel() {
-              public val component: NavEntryTestFlowScopeComponent =
-                  parentComponent.navEntryTestFlowScopeComponentFactory().create(savedStateHandle, testRoute)
-
-              public override fun onCleared(): Unit {
-                component.closeables.forEach {
-                  it.close()
-                }
-              }
-            }
-
-            @OptIn(InternalWhetstoneApi::class)
-            @NavEntryComponentGetterKey(TestFlowScope::class)
-            @ContributesMultibinding(
-              TestDestinationScope::class,
-              NavEntryComponentGetter::class,
-            )
-            public class TestFlowScopeComponentGetter @Inject constructor() : NavEntryComponentGetter {
-              @OptIn(InternalWhetstoneApi::class, InternalNavigatorApi::class)
-              public override fun retrieve(findEntry: (Int) -> NavBackStackEntry, context: Context): Any {
-                val entry = findEntry(TestRoute::class.destinationId())
-                val route: TestRoute = entry.arguments!!.toRoute()
-                val viewModel = viewModel(entry, context, TestParentScope::class, TestDestinationScope::class,
-                    route, findEntry, ::TestFlowScopeViewModel)
-                return viewModel.component
-              }
-            }
-
-        """.trimIndent()
-
-        assertThat(actual).isEqualTo(expected)
-    }
-
-    @Test
-    fun `generates code for NavEntryData without coroutines`() {
-        val withoutCoroutines = full.copy(coroutinesEnabled = false)
-        val actual = FileGenerator().generate(withoutCoroutines).toString()
-
-        val expected = """
-            package com.test
-
-            import android.content.Context
-            import androidx.lifecycle.SavedStateHandle
-            import androidx.lifecycle.ViewModel
-            import androidx.navigation.NavBackStackEntry
-            import com.freeletics.mad.navigator.`internal`.InternalNavigatorApi
-            import com.freeletics.mad.navigator.`internal`.destinationId
-            import com.freeletics.mad.navigator.`internal`.toRoute
-            import com.freeletics.mad.whetstone.NavEntry
-            import com.freeletics.mad.whetstone.ScopeTo
-            import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
-            import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetter
-            import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetterKey
-            import com.freeletics.mad.whetstone.`internal`.viewModel
-            import com.squareup.anvil.annotations.ContributesMultibinding
-            import com.squareup.anvil.annotations.ContributesSubcomponent
-            import com.squareup.anvil.annotations.ContributesTo
-            import com.test.parent.TestParentScope
-            import dagger.BindsInstance
-            import dagger.Module
-            import dagger.Provides
-            import dagger.multibindings.IntoSet
-            import dagger.multibindings.Multibinds
-            import io.reactivex.disposables.CompositeDisposable
-            import java.io.Closeable
-            import javax.inject.Inject
-            import kotlin.Any
-            import kotlin.Int
-            import kotlin.OptIn
-            import kotlin.Unit
-            import kotlin.collections.Set
-
-            @ScopeTo(TestFlowScope::class)
-            @ContributesSubcomponent(
-              scope = TestFlowScope::class,
-              parentScope = TestParentScope::class,
-            )
-            public interface NavEntryTestFlowScopeComponent {
-              @get:NavEntry(TestFlowScope::class)
-              public val closeables: Set<Closeable>
-
-              @ContributesSubcomponent.Factory
-              public interface Factory {
-                public fun create(@BindsInstance @NavEntry(TestFlowScope::class)
-                    savedStateHandle: SavedStateHandle, @BindsInstance @NavEntry(TestFlowScope::class)
-                    testRoute: TestRoute): NavEntryTestFlowScopeComponent
-              }
-
-              @ContributesTo(TestParentScope::class)
-              public interface ParentComponent {
-                public fun navEntryTestFlowScopeComponentFactory(): Factory
-              }
-            }
-
-            @Module
-            @ContributesTo(TestFlowScope::class)
-            public interface NavEntryTestFlowScopeModule {
-              @Multibinds
-              @NavEntry(TestFlowScope::class)
-              public fun bindCancellable(): Set<Closeable>
-
-              public companion object {
-                @Provides
-                @ScopeTo(TestFlowScope::class)
-                @NavEntry(TestFlowScope::class)
-                public fun provideCompositeDisposable(): CompositeDisposable = CompositeDisposable()
-
-                @Provides
-                @IntoSet
-                @NavEntry(TestFlowScope::class)
-                public fun bindCompositeDisposable(@NavEntry(TestFlowScope::class)
-                    compositeDisposable: CompositeDisposable): Closeable = Closeable {
-                  compositeDisposable.clear()
-                }
-              }
-            }
-
-            @InternalWhetstoneApi
-            internal class TestFlowScopeViewModel(
-              parentComponent: NavEntryTestFlowScopeComponent.ParentComponent,
-              savedStateHandle: SavedStateHandle,
-              testRoute: TestRoute,
-            ) : ViewModel() {
-              public val component: NavEntryTestFlowScopeComponent =
-                  parentComponent.navEntryTestFlowScopeComponentFactory().create(savedStateHandle, testRoute)
-
-              public override fun onCleared(): Unit {
-                component.closeables.forEach {
-                  it.close()
-                }
-              }
-            }
-
-            @OptIn(InternalWhetstoneApi::class)
-            @NavEntryComponentGetterKey(TestFlowScope::class)
-            @ContributesMultibinding(
-              TestDestinationScope::class,
-              NavEntryComponentGetter::class,
-            )
-            public class TestFlowScopeComponentGetter @Inject constructor() : NavEntryComponentGetter {
-              @OptIn(InternalWhetstoneApi::class, InternalNavigatorApi::class)
-              public override fun retrieve(findEntry: (Int) -> NavBackStackEntry, context: Context): Any {
-                val entry = findEntry(TestRoute::class.destinationId())
-                val route: TestRoute = entry.arguments!!.toRoute()
-                val viewModel = viewModel(entry, context, TestParentScope::class, TestDestinationScope::class,
-                    route, findEntry, ::TestFlowScopeViewModel)
-                return viewModel.component
-              }
-            }
-
-        """.trimIndent()
-
-        assertThat(actual).isEqualTo(expected)
-    }
-
-    @Test
-    fun `generates code for NavEntryData without rxjava`() {
-        val withoutRxJava = full.copy(rxJavaEnabled = false)
-        val actual = FileGenerator().generate(withoutRxJava).toString()
-
-        val expected = """
-            package com.test
-
-            import android.content.Context
-            import androidx.lifecycle.SavedStateHandle
-            import androidx.lifecycle.ViewModel
-            import androidx.navigation.NavBackStackEntry
-            import com.freeletics.mad.navigator.`internal`.InternalNavigatorApi
-            import com.freeletics.mad.navigator.`internal`.destinationId
-            import com.freeletics.mad.navigator.`internal`.toRoute
-            import com.freeletics.mad.whetstone.NavEntry
-            import com.freeletics.mad.whetstone.ScopeTo
-            import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
-            import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetter
-            import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetterKey
-            import com.freeletics.mad.whetstone.`internal`.viewModel
-            import com.squareup.anvil.annotations.ContributesMultibinding
-            import com.squareup.anvil.annotations.ContributesSubcomponent
-            import com.squareup.anvil.annotations.ContributesTo
-            import com.test.parent.TestParentScope
-            import dagger.BindsInstance
-            import dagger.Module
-            import dagger.Provides
-            import dagger.multibindings.IntoSet
-            import dagger.multibindings.Multibinds
-            import java.io.Closeable
-            import javax.inject.Inject
-            import kotlin.Any
-            import kotlin.Int
-            import kotlin.OptIn
-            import kotlin.Unit
-            import kotlin.collections.Set
-            import kotlinx.coroutines.CoroutineScope
-            import kotlinx.coroutines.MainScope
-            import kotlinx.coroutines.cancel
-
-            @ScopeTo(TestFlowScope::class)
-            @ContributesSubcomponent(
-              scope = TestFlowScope::class,
-              parentScope = TestParentScope::class,
-            )
-            public interface NavEntryTestFlowScopeComponent {
-              @get:NavEntry(TestFlowScope::class)
-              public val closeables: Set<Closeable>
-
-              @ContributesSubcomponent.Factory
-              public interface Factory {
-                public fun create(@BindsInstance @NavEntry(TestFlowScope::class)
-                    savedStateHandle: SavedStateHandle, @BindsInstance @NavEntry(TestFlowScope::class)
-                    testRoute: TestRoute): NavEntryTestFlowScopeComponent
-              }
-
-              @ContributesTo(TestParentScope::class)
-              public interface ParentComponent {
-                public fun navEntryTestFlowScopeComponentFactory(): Factory
-              }
-            }
-
-            @Module
-            @ContributesTo(TestFlowScope::class)
-            public interface NavEntryTestFlowScopeModule {
-              @Multibinds
-              @NavEntry(TestFlowScope::class)
-              public fun bindCancellable(): Set<Closeable>
-
-              public companion object {
-                @Provides
-                @ScopeTo(TestFlowScope::class)
-                @NavEntry(TestFlowScope::class)
-                public fun provideCoroutineScope(): CoroutineScope = MainScope()
-
-                @Provides
-                @IntoSet
-                @NavEntry(TestFlowScope::class)
-                public fun bindCoroutineScope(@NavEntry(TestFlowScope::class) coroutineScope: CoroutineScope):
-                    Closeable = Closeable {
-                  coroutineScope.cancel()
-                }
-              }
             }
 
             @InternalWhetstoneApi

--- a/whetstone/navigation-compose/src/main/java/com/freeletics/mad/whetstone/compose/NavDestination.kt
+++ b/whetstone/navigation-compose/src/main/java/com/freeletics/mad/whetstone/compose/NavDestination.kt
@@ -7,7 +7,8 @@ import kotlin.reflect.KClass
 /**
  * This annotation can be used in combination with [ComposeScreen] to
  * enable the integration of a `FragmentNavEventNavigator` into the generated code. The navigator
- * will automatically be set up so that it's ready to handle events.
+ * will automatically be set up so that it's ready to handle events. It will also make the instance
+ * of [route] that was used to navigate to this destination available for injection.
  *
  * The `NavEventNavigator` subclass is expected to be bound to `NavEventNavigator` and available
  * in the [ComposeScreen.scope] scoped generated component. This can be achieved by adding

--- a/whetstone/navigation-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/NavDestination.kt
+++ b/whetstone/navigation-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/NavDestination.kt
@@ -7,7 +7,8 @@ import kotlin.reflect.KClass
 /**
  * This annotation can be used in combination with [ComposeFragment] and [RendererFragment] to
  * enable the integration of a `FragmentNavEventNavigator` into the generated code. The navigator
- * will automatically be set up so that it's ready to handle events.
+ * will automatically be set up so that it's ready to handle events. It will also make the instance
+ * of [route] that was used to navigate to this destination available for injection.
  *
  * The `FragmentNavEventNavigator` subclass is expected to be bound to `NavEventNavigator` and
  * available in the [ComposeFragment.scope]/[RendererFragment.scope] scoped generated component.

--- a/whetstone/navigation/api/navigation.api
+++ b/whetstone/navigation/api/navigation.api
@@ -3,9 +3,7 @@ public abstract interface annotation class com/freeletics/mad/whetstone/NavEntry
 }
 
 public abstract interface annotation class com/freeletics/mad/whetstone/NavEntryComponent : java/lang/annotation/Annotation {
-	public abstract fun coroutinesEnabled ()Z
 	public abstract fun parentScope ()Ljava/lang/Class;
-	public abstract fun rxJavaEnabled ()Z
 	public abstract fun scope ()Ljava/lang/Class;
 }
 

--- a/whetstone/navigation/src/main/java/com/freeletics/mad/whetstone/NavEntry.kt
+++ b/whetstone/navigation/src/main/java/com/freeletics/mad/whetstone/NavEntry.kt
@@ -10,7 +10,8 @@ import kotlin.annotation.AnnotationTarget.VALUE_PARAMETER
 import kotlin.reflect.KClass
 
 /**
- * TODO
+ * This [Qualifier] is used for objects automatically provided inside a generated
+ * subcomponent for [NavEntryComponent].
  */
 @Qualifier
 @Target(CLASS, FUNCTION, PROPERTY, PROPERTY_GETTER, FUNCTION, VALUE_PARAMETER)

--- a/whetstone/navigation/src/main/java/com/freeletics/mad/whetstone/NavEntryComponent.kt
+++ b/whetstone/navigation/src/main/java/com/freeletics/mad/whetstone/NavEntryComponent.kt
@@ -1,51 +1,50 @@
 package com.freeletics.mad.whetstone
 
-import android.content.Context
-import androidx.navigation.NavBackStackEntry
-import com.freeletics.mad.whetstone.internal.NavEntryComponentGetter
-import javax.inject.Inject
 import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.annotation.AnnotationTarget.CLASS
 import kotlin.annotation.AnnotationTarget.FUNCTION
 import kotlin.reflect.KClass
 
 /**
- * Annotate a function in a Dagger [dagger.Module] to enable generating a Dagger component that
- * survives configuration changes and is kept as long as a specific `NavBackStackEntry`
- * is on the back stack.
+ * Add this annotation in addition to the `@NavDestination` annotation to a screen to enable
+ * generating a Dagger component that survives configuration changes and is kept as long as a
+ * specific `NavBackStackEntry` is on the back stack. This allows to create an extra scope that is
+ * shared between multiple screens of a flow.
  *
- * The generated component uses [ScopeTo] as its scope where the [ScopeTo.marker]
- * parameter is the specified [scope] class. This scope can be used to scope classes
- * in the component and tie them to to component's life time. The annotated class is also used as
- * [com.squareup.anvil.annotations.MergeComponent.scope], so it can be used to contribute modules
- * and bindings to the generated component.
+ * To use the nav entry component as a parent the relevant screens should use the [scope] of this
+ * ANNOTATION AS THEIR PARENT SCOPE.
  *
- * E.g. for `@NavEntryComponent(scope = CoachFlow::class, ...)` the scope of the generated
- * component will be `ScopeTo(CoachFlow::class)`, modules can be contributed with
- * `@ContributesTo(CoachFlow::class)` and bindings with
- * `@ContributesBinding(CoachFlow::class, ...)`.
+ * **Scopes, Dagger and Anvil**
+ *
+ * The generated component uses [com.freeletics.mad.whetstone.ScopeTo] as it's scope where the
+ * [com.freeletics.mad.whetstone.ScopeTo.marker] parameter is the specified [scope] class. This
+ * scope can be used to scope classes in the component an tie them to to component's life time,
+ * effectively making them survive configuration changes. The  annotated class is also used as
+ * [com.squareup.anvil.annotations.ContributesSubcomponent.scope], so it can be used to contribute
+ * modulesc and bindings to the generated component.
+ *
+ * E.g. for `@NavEntryComponent(scope = CoachScreen::class, ...)` the scope of the generated
+ * component will be `@ScopeTo(CoachScreen::class)`, modules can be contributed with
+ * `@ContributesTo(CoachScreen::class)` and bindings with
+ * `@ContributesBinding(CoachScreen::class, ...)`.
  *
  * By default the following classes are available for injection in the component:
  * - a [androidx.lifecycle.SavedStateHandle]
- * - a [android.os.Bundle] obtained from [androidx.navigation.NavController.currentBackStackEntry]
- * - if [coroutinesEnabled] is `true`, a [kotlinx.coroutines.CoroutineScope] that will be cancelled automatically
- * - if [rxJavaEnabled] is `true`, a [io.reactivex.disposables.CompositeDisposable] that will be cleared automatically
+ * - a [android.os.Bundle] with arguments passed to the screen
  *
- * The component that uses [parentScope] as its scope will be used as parent component. That
- * component will be looked up by calling `getSystemService` on the current `Activity` and
- * the `Application`. The parameter passed to `getSystemService` is the fully qualified name of
- * the [parentScope] class. It is recommended to use the same marker class that is used as Anvil
- * scope for the parent component.
+ * These automatically available classes use [NavEntry] as a qualifier where the [scope] is the
+ * parameter. So for the [androidx.lifecycle.SavedStateHandle] to be injected
+ * `@NavEntry(CoachScreen::class) val savedStateHandle: SavedStateHandle` needs to be used.
  *
- * The generated component can be accessed through a `Map<Class<*>, NavEntryComponentGetter` that
- * will automatically be available in the parent component. See [NavEntryComponentGetter].
+ * A factory for the generated subcomponent is automatically generated and contributed to
+ * the component that uses [parentScope` as its own scope. This component will be looked up internally
+ * with `Context.getSystemService(name)` using the fully qualified name of the given [parentScope] as
+ * key for the lookup. It is expected that the app will provide it through its `Application` class or an
+ * `Activity`.
  */
 @Target(CLASS, FUNCTION)
 @Retention(RUNTIME)
 public annotation class NavEntryComponent(
     val scope: KClass<*>,
     val parentScope: KClass<*>,
-
-    val coroutinesEnabled: Boolean = false,
-    val rxJavaEnabled: Boolean = false,
 )

--- a/whetstone/navigation/src/main/java/com/freeletics/mad/whetstone/internal/DestinationComponent.kt
+++ b/whetstone/navigation/src/main/java/com/freeletics/mad/whetstone/internal/DestinationComponent.kt
@@ -1,6 +1,5 @@
 package com.freeletics.mad.whetstone.internal
 
-//TODO generate something that extends this and is contributed to destination component
 @InternalWhetstoneApi
 public interface DestinationComponent {
     public val navEntryComponentGetters: @JvmSuppressWildcards Map<Class<*>, NavEntryComponentGetter>

--- a/whetstone/runtime-compose/api/runtime-compose.api
+++ b/whetstone/runtime-compose/api/runtime-compose.api
@@ -1,8 +1,5 @@
 public abstract interface annotation class com/freeletics/mad/whetstone/compose/ComposeScreen : java/lang/annotation/Annotation {
-	public abstract fun coroutinesEnabled ()Z
-	public abstract fun dependencies ()Ljava/lang/Class;
 	public abstract fun parentScope ()Ljava/lang/Class;
-	public abstract fun rxJavaEnabled ()Z
 	public abstract fun scope ()Ljava/lang/Class;
 	public abstract fun stateMachine ()Ljava/lang/Class;
 }

--- a/whetstone/runtime-compose/src/main/java/com/freeletics/mad/whetstone/compose/ComposeScreen.kt
+++ b/whetstone/runtime-compose/src/main/java/com/freeletics/mad/whetstone/compose/ComposeScreen.kt
@@ -6,8 +6,8 @@ import kotlin.reflect.KClass
 /**
  * By adding this annotation to a [androidx.compose.runtime.Composable] function, another
  * Composable is generated that will have the same name with `Screen` as suffix. The generated
- * function has [androidx.navigation.NavController] as it's sole parameter. It will internally
- * call the annotated composable. It is required that the annotated function has `State` as first
+ * function has [android.os.Bundle] as it's sole parameter and will internally call the annotated
+ * composable. It is required that the annotated function has `State` as first
  * parameter and `(Action) -> Unit` as second parameter, where `State` and `Action` match the given
  * `StateMachine`.
  *
@@ -22,15 +22,16 @@ import kotlin.reflect.KClass
  *
  * **Scopes, Dagger and Anvil**
  *
- * There will also be a generated Dagger component that is tied to the composable function but
+ * There will also be a generated Dagger subcomponent that is tied to the composable function but
  * survives configuration changes and stays alive while the composable destination is on the
  * backstack.
  *
- * The generated component uses [ScopeTo] as it's scope where the [ScopeTo.marker]
- * parameter is the specified [scope] class. This scope can be used to scope classes
- * in the component an tie them to to component's life time. The annotated class is also used as
- * [com.squareup.anvil.annotations.MergeComponent.scope], so it can be used to contribute modules
- * and bindings to the generated component.
+ * The generated component uses [com.freeletics.mad.whetstone.ScopeTo] as it's scope where the
+ * [com.freeletics.mad.whetstone.ScopeTo.marker] parameter is the specified [scope] class. This
+ * scope can be used to scope classes in the component an tie them to to component's life time,
+ * effectively making them survive configuration changes. The  annotated class is also used as
+ * [com.squareup.anvil.annotations.ContributesSubcomponent.scope], so it can be used to contribute
+ * modulesc and bindings to the generated component.
  *
  * E.g. for `@ComposeScreen(scope = CoachScreen::class, ...)` the scope of the generated
  * component will be `@ScopeTo(CoachScreen::class)`, modules can be contributed with
@@ -38,17 +39,14 @@ import kotlin.reflect.KClass
  * `@ContributesBinding(CoachScreen::class, ...)`.
  *
  * By default the following classes are available for injection in the component:
- * - everything accessible through the provided [dependencies] interface
  * - a [androidx.lifecycle.SavedStateHandle]
- * - a [android.os.Bundle] obtained from [androidx.navigation.NavController.currentBackStackEntry]
- * - if [coroutinesEnabled] is `true`, a [kotlinx.coroutines.CoroutineScope] that will be cancelled automatically
- * - if [rxJavaEnabled] is `true`, a [io.reactivex.disposables.CompositeDisposable] that will be cleared automatically
+ * - a [android.os.Bundle] with arguments passed to the screen
  *
- * The mentioned [dependencies] interface will be looked up by calling
- * [android.content.Context.getSystemService] on either the [android.app.Activity] context or the
- * [android.app.Application] context. The parameter passed to `getSystemService` is the fully
- * qualified name of [parentScope]. It is recommended to use the same marker class that is used as
- * Anvil scope for the [parentScope].
+ * A factory for the generated subcomponent is automatically generated and contributed to
+ * the component that uses [parentScope` as its own scope. This component will be looked up internally
+ * with `Context.getSystemService(name)` using the fully qualified name of the given [parentScope] as
+ * key for the lookup. It is expected that the app will provide it through its `Application` class or an
+ * `Activity`.
  *
  * **Example**
  *
@@ -75,10 +73,5 @@ import kotlin.reflect.KClass
 public annotation class ComposeScreen(
     val scope: KClass<*>,
     val parentScope: KClass<*>,
-    val dependencies: KClass<*>,
-
     val stateMachine: KClass<out StateMachine<*, *>>,
-
-    val coroutinesEnabled: Boolean = false,
-    val rxJavaEnabled: Boolean = false,
 )

--- a/whetstone/runtime-fragment/api/runtime-fragment.api
+++ b/whetstone/runtime-fragment/api/runtime-fragment.api
@@ -1,20 +1,14 @@
 public abstract interface annotation class com/freeletics/mad/whetstone/fragment/ComposeFragment : java/lang/annotation/Annotation {
-	public abstract fun coroutinesEnabled ()Z
-	public abstract fun dependencies ()Ljava/lang/Class;
 	public abstract fun fragmentBaseClass ()Ljava/lang/Class;
 	public abstract fun parentScope ()Ljava/lang/Class;
-	public abstract fun rxJavaEnabled ()Z
 	public abstract fun scope ()Ljava/lang/Class;
 	public abstract fun stateMachine ()Ljava/lang/Class;
 }
 
 public abstract interface annotation class com/freeletics/mad/whetstone/fragment/RendererFragment : java/lang/annotation/Annotation {
-	public abstract fun coroutinesEnabled ()Z
-	public abstract fun dependencies ()Ljava/lang/Class;
 	public abstract fun fragmentBaseClass ()Ljava/lang/Class;
 	public abstract fun parentScope ()Ljava/lang/Class;
 	public abstract fun rendererFactory ()Ljava/lang/Class;
-	public abstract fun rxJavaEnabled ()Z
 	public abstract fun scope ()Ljava/lang/Class;
 	public abstract fun stateMachine ()Ljava/lang/Class;
 }

--- a/whetstone/runtime-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/ComposeFragment.kt
+++ b/whetstone/runtime-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/ComposeFragment.kt
@@ -25,15 +25,16 @@ import kotlin.reflect.KClass
  *
  * **Scopes, Dagger and Anvil**
  *
- * There will also be a generated Dagger component that is tied to the composable function but
- * survives configuration changes and stays alive while the composable destination is on the
+ * There will also be a generated Dagger subcomponent that is tied to the Fragment but
+ * survives configuration changes and stays alive while the Fragment destination is on the
  * backstack.
  *
- * The generated component uses [ScopeTo] as it's scope where the [ScopeTo.marker]
- * parameter is the specified [scope] class. This scope can be used to scope classes
- * in the component an tie them to to component's life time. The annotated class is also used as
- * [com.squareup.anvil.annotations.MergeComponent.scope], so it can be used to contribute modules
- * and bindings to the generated component.
+ * The generated component uses [com.freeletics.mad.whetstone.ScopeTo] as it's scope where the
+ * [com.freeletics.mad.whetstone.ScopeTo.marker] parameter is the specified [scope] class. This
+ * scope can be used to scope classes in the component an tie them to to component's life time,
+ * effectively making them survive configuration changes. The  annotated class is also used as
+ * [com.squareup.anvil.annotations.ContributesSubcomponent.scope], so it can be used to contribute
+ * modulesc and bindings to the generated component.
  *
  * E.g. for `@ComposeFragment(scope = CoachScreen::class, ...)` the scope of the generated
  * component will be `@ScopeTo(CoachScreen::class)`, modules can be contributed with
@@ -41,29 +42,20 @@ import kotlin.reflect.KClass
  * `@ContributesBinding(CoachScreen::class, ...)`.
  *
  * By default the following classes are available for injection in the component:
- * - everything accessible through the provided [dependencies] interface
  * - a [androidx.lifecycle.SavedStateHandle]
- * - a [android.os.Bundle] obtained from [androidx.navigation.NavController.currentBackStackEntry]
- * - if [coroutinesEnabled] is `true`, a [kotlinx.coroutines.CoroutineScope] that will be cancelled automatically
- * - if [rxJavaEnabled] is `true`, a [io.reactivex.disposables.CompositeDisposable] that will be cleared automatically
+ * - a [android.os.Bundle] with arguments passed to the screen
  *
- * The mentioned [dependencies] interface will be looked up by calling
- * [android.content.Context.getSystemService] on either the [android.app.Activity] context or the
- * [android.app.Application] context. The parameter passed to `getSystemService` is the fully
- * qualified name of [parentScope]. It is recommended to use the same marker class that is used as
- * Anvil scope for the [parentScope].
+ * A factory for the generated subcomponent is automatically generated and contributed to
+ * the component that uses [parentScope` as its own scope. This component will be looked up internally
+ * with `Context.getSystemService(name)` using the fully qualified name of the given [parentScope] as
+ * key for the lookup. It is expected that the app will provide it through its `Application` class or an
+ * `Activity`.
  */
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
 public annotation class ComposeFragment(
     val scope: KClass<*>,
     val parentScope: KClass<*>,
-    val dependencies: KClass<*>,
-
     val stateMachine: KClass<out StateMachine<*, *>>,
-
     val fragmentBaseClass: KClass<out Fragment> = Fragment::class,
-
-    val coroutinesEnabled: Boolean = false,
-    val rxJavaEnabled: Boolean = false,
 )

--- a/whetstone/runtime-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/RendererFragment.kt
+++ b/whetstone/runtime-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/RendererFragment.kt
@@ -23,15 +23,16 @@ import kotlin.reflect.KClass
  *
  * **Scopes, Dagger and Anvil**
  *
- * There will also be a generated Dagger component that is tied to the composable function but
- * survives configuration changes and stays alive while the composable destination is on the
+ * There will also be a generated Dagger subcomponent that is tied to the Fragment but
+ * survives configuration changes and stays alive while the Fragment destination is on the
  * backstack.
  *
- * The generated component uses [ScopeTo] as it's scope where the [ScopeTo.marker]
- * parameter is the specified [scope] class. This scope can be used to scope classes
- * in the component an tie them to to component's life time. The annotated class is also used as
- * [com.squareup.anvil.annotations.MergeComponent.scope], so it can be used to contribute modules
- * and bindings to the generated component.
+ * The generated component uses [com.freeletics.mad.whetstone.ScopeTo] as it's scope where the
+ * [com.freeletics.mad.whetstone.ScopeTo.marker] parameter is the specified [scope] class. This
+ * scope can be used to scope classes in the component an tie them to to component's life time,
+ * effectively making them survive configuration changes. The  annotated class is also used as
+ * [com.squareup.anvil.annotations.ContributesSubcomponent.scope], so it can be used to contribute
+ * modulesc and bindings to the generated component.
  *
  * E.g. for `@RendererFragment(scope = CoachScreen::class, ...)` the scope of the generated
  * component will be `@ScopeTo(CoachScreen::class)`, modules can be contributed with
@@ -39,32 +40,23 @@ import kotlin.reflect.KClass
  * `@ContributesBinding(CoachScreen::class, ...)`.
  *
  * By default the following classes are available for injection in the component:
- * - everything accessible through the provided [dependencies] interface
  * - a [androidx.lifecycle.SavedStateHandle]
- * - a [android.os.Bundle] obtained from [androidx.navigation.NavController.currentBackStackEntry]
- * - if [coroutinesEnabled] is `true`, a [io.reactivex.disposables.CompositeDisposable] that will be cleared automatically
- * - if [rxJavaEnabled] is `true`, a [kotlinx.coroutines.CoroutineScope] that will be cancelled automatically
+ * - a [android.os.Bundle] with arguments passed to the screen
  *
- * The mentioned [dependencies] interface will be looked up by calling
- * [android.content.Context.getSystemService] on either the [android.app.Activity] context or the
- * [android.app.Application] context. The parameter passed to `getSystemService` is the fully
- * qualified name of [parentScope]. It is recommended to use the same marker class that is used as
- * Anvil scope for the [parentScope].
+ * A factory for the generated subcomponent is automatically generated and contributed to
+ * the component that uses [parentScope` as its own scope. This component will be looked up internally
+ * with `Context.getSystemService(name)` using the fully qualified name of the given [parentScope] as
+ * key for the lookup. It is expected that the app will provide it through its `Application` class or an
+ * `Activity`.
  */
 @Target(CLASS)
 @Retention(RUNTIME)
 public annotation class RendererFragment(
     val scope: KClass<*>,
     val parentScope: KClass<*>,
-    val dependencies: KClass<*>,
-
     val stateMachine: KClass<out StateMachine<*, *>>,
     //TODO should be KClass<out ViewRenderer.Factory<*, *>>
     // leaving out the constraint for now to be compatible with some custom factories using the same signature
     val rendererFactory: KClass<*>,
-
     val fragmentBaseClass: KClass<out Fragment> = Fragment::class,
-
-    val coroutinesEnabled: Boolean = false,
-    val rxJavaEnabled: Boolean = false,
 )

--- a/whetstone/runtime/src/main/java/com/freeletics/mad/whetstone/internal/WhetstoneViewModelFactory.kt
+++ b/whetstone/runtime/src/main/java/com/freeletics/mad/whetstone/internal/WhetstoneViewModelFactory.kt
@@ -12,7 +12,7 @@ public class WhetstoneViewModelFactory(
 ) : AbstractSavedStateViewModelFactory(savedStateRegistryOwner, null) {
 
     @Suppress("UNCHECKED_CAST")
-    public override fun <T : ViewModel?> create(
+    public override fun <T : ViewModel> create(
         key: String,
         modelClass: Class<T>,
         handle: SavedStateHandle


### PR DESCRIPTION
Removes the `rxJavaEnabled`, `coroutinesEnabled` and `dependencies` parameters and updates the documentation. I will have additional prs to further clean up the codegen and the tests, I wanted to keep this one limited to deleting code.