### PR TITLE
use different placeholder for default result StateFlow

### DIFF
--- a/navigator/runtime-compose/api/navigator-runtime-compose.api
+++ b/navigator/runtime-compose/api/navigator-runtime-compose.api
@@ -1,3 +1,11 @@
+public final class com/freeletics/mad/navigator/compose/InitialValue$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/freeletics/mad/navigator/compose/InitialValue;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/freeletics/mad/navigator/compose/InitialValue;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public abstract interface class com/freeletics/mad/navigator/compose/NavDestination {
 }
 

--- a/navigator/runtime-compose/build.gradle
+++ b/navigator/runtime-compose/build.gradle
@@ -73,4 +73,5 @@ dependencies {
     implementation "androidx.navigation:navigation-common:2.5.0"
     implementation "androidx.navigation:navigation-compose:2.5.0"
     implementation "com.google.accompanist:accompanist-navigation-material:0.23.1"
+    implementation 'org.jetbrains.kotlin:kotlin-parcelize-runtime:1.7.0'
 }

--- a/navigator/runtime-compose/build.gradle
+++ b/navigator/runtime-compose/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.android'
+apply plugin: 'org.jetbrains.kotlin.plugin.parcelize'
 apply plugin: "org.jetbrains.dokka"
 apply plugin: 'com.vanniktech.maven.publish'
 

--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavigationSetup.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavigationSetup.kt
@@ -22,6 +22,7 @@ import com.freeletics.mad.navigator.NavigationResultRequest
 import com.freeletics.mad.navigator.PermissionsResultRequest
 import com.freeletics.mad.navigator.internal.RequestPermissionsContract
 import com.freeletics.mad.navigator.internal.navigate
+import kotlinx.parcelize.Parcelize
 
 /**
  * Sets up the [NavEventNavigator] inside the current composition so that it's events
@@ -93,15 +94,17 @@ private fun <O : Parcelable> ResultEffect(
     controller: NavController,
 ) {
     LaunchedEffect(request, controller) {
-        val initialValue = Bundle() // initial value marker instance so that we can filter it
         controller.getBackStackEntry(request.key.destinationId)
             .savedStateHandle
-            .getStateFlow<Parcelable>(request.key.requestKey, initialValue)
+            .getStateFlow<Parcelable>(request.key.requestKey, InitialValue)
             .collect { result ->
-                if (result !== initialValue) {
+                if (result != InitialValue) {
                     @Suppress("UNCHECKED_CAST")
                     request.handleResult(result as O)
                 }
             }
     }
 }
+
+@Parcelize
+private object InitialValue : Parcelable

--- a/navigator/runtime-fragment/api/navigator-runtime-fragment.api
+++ b/navigator/runtime-fragment/api/navigator-runtime-fragment.api
@@ -6,6 +6,14 @@ public final class com/freeletics/mad/navigator/fragment/HandleNavigationKt {
 	public static final fun handleNavigation (Landroidx/fragment/app/Fragment;Lcom/freeletics/mad/navigator/NavEventNavigator;)V
 }
 
+public final class com/freeletics/mad/navigator/fragment/InitialValue$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/freeletics/mad/navigator/fragment/InitialValue;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/freeletics/mad/navigator/fragment/InitialValue;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public abstract interface class com/freeletics/mad/navigator/fragment/NavDestination {
 }
 

--- a/navigator/runtime-fragment/build.gradle
+++ b/navigator/runtime-fragment/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.android'
+apply plugin: 'org.jetbrains.kotlin.plugin.parcelize'
 apply plugin: "org.jetbrains.dokka"
 apply plugin: 'com.vanniktech.maven.publish'
 

--- a/navigator/runtime-fragment/build.gradle
+++ b/navigator/runtime-fragment/build.gradle
@@ -59,4 +59,5 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:2.5.0"
     implementation "androidx.navigation:navigation-common:2.5.0"
     implementation "androidx.navigation:navigation-runtime:2.5.0"
+    implementation 'org.jetbrains.kotlin:kotlin-parcelize-runtime:1.7.0'
 }

--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/HandleNavigation.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/HandleNavigation.kt
@@ -18,6 +18,7 @@ import com.freeletics.mad.navigator.PermissionsResultRequest
 import com.freeletics.mad.navigator.internal.RequestPermissionsContract
 import com.freeletics.mad.navigator.internal.navigate
 import kotlinx.coroutines.launch
+import kotlinx.parcelize.Parcelize
 
 /**
  * Handles the [NavEventNavigator] events while the Fragment's lifecycle is at least
@@ -70,16 +71,17 @@ private fun <O : Parcelable> NavigationResultRequest<O>.registerIn(
     lifecycle: Lifecycle,
 ) {
     lifecycle.coroutineScope.launch {
-
-        val initialValue = Bundle() // initial value marker instance so that we can filter it
         controller.getBackStackEntry(key.destinationId)
             .savedStateHandle
-            .getStateFlow<Parcelable>(key.requestKey, initialValue)
+            .getStateFlow<Parcelable>(key.requestKey, InitialValue)
             .collect { result ->
-                if (result !== initialValue) {
+                if (result != InitialValue) {
                     @Suppress("UNCHECKED_CAST")
                     handleResult(result as O)
                 }
             }
     }
 }
+
+@Parcelize
+private object InitialValue : Parcelable


### PR DESCRIPTION
When we switched from `LiveData` to `StateFlow` for observing navigation results through a `SavedStateHandle` (#139) we had to introduce a default placeholder because `StateFlow` requires an initial value. This placeholder would then just get filtered out. The issue is that `getStateFlow` internally will set that initial value on the `SavedStateHandle` which means it will get restored from there as well and our reference based equality doesn't work, resulting in a `ClassCastException`. We stay with the same approach but use a custom parcelable as default value so that we can just do a regular equals check that always works.