### PR TITLE
Reset navigation result after collecting it

### DIFF
--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavigationSetup.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavigationSetup.kt
@@ -94,13 +94,16 @@ private fun <O : Parcelable> ResultEffect(
     controller: NavController,
 ) {
     LaunchedEffect(request, controller) {
-        controller.getBackStackEntry(request.key.destinationId)
+        val backStackEntry = controller.getBackStackEntry(request.key.destinationId)
+
+        backStackEntry
             .savedStateHandle
             .getStateFlow<Parcelable>(request.key.requestKey, InitialValue)
             .collect { result ->
                 if (result != InitialValue) {
                     @Suppress("UNCHECKED_CAST")
                     request.handleResult(result as O)
+                    backStackEntry.savedStateHandle[request.key.requestKey] = InitialValue
                 }
             }
     }

--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/HandleNavigation.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/HandleNavigation.kt
@@ -70,14 +70,17 @@ private fun <O : Parcelable> NavigationResultRequest<O>.registerIn(
     controller: NavController,
     lifecycle: Lifecycle,
 ) {
+    val backStackEntry = controller.getBackStackEntry(key.destinationId)
+
     lifecycle.coroutineScope.launch {
-        controller.getBackStackEntry(key.destinationId)
+        backStackEntry
             .savedStateHandle
             .getStateFlow<Parcelable>(key.requestKey, InitialValue)
             .collect { result ->
                 if (result != InitialValue) {
                     @Suppress("UNCHECKED_CAST")
                     handleResult(result as O)
+                    backStackEntry.savedStateHandle[key.requestKey] = InitialValue
                 }
             }
     }


### PR DESCRIPTION
This resets the value in the savedStateHandle after collecting the result once.
This prevents a scenario, where the last result would be delivered again if the result flow is collected a second time.

Example:
Screen A collects a result from screen B

1. Screen B delivers the result to screen A
2. We navigate to screen B again, but then back without producing a new result
3. Screen A starts collecting the result flow again and receives the same result from step 1 again

This could lead to unwanted duplicated work, so we reset the value to only receive it once.