### PR TITLE
explicitly require a renderer factory to extend ViewRenderer.Factory

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ accompanist = "0.25.1"
 inject = "1"
 dagger = "2.44"
 anvil = "2.4.2"
+renderer = "0.12.0"
 kotlinpoet = "1.12.0"
 auto-service = "1.0.1"
 
@@ -69,6 +70,7 @@ dagger = { module = "com.google.dagger:dagger", version.ref = "dagger" }
 anvil-compiler = { module = "com.squareup.anvil:compiler-api", version.ref = "anvil" }
 anvil-annotations = { module = "com.squareup.anvil:annotations", version.ref = "anvil" }
 anvil-utils = { module = "com.squareup.anvil:compiler-utils", version.ref = "anvil" }
+renderer = { module = "com.gabrielittner.renderer:renderer", version.ref = "renderer" }
 kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinpoet" }
 auto-service-annotations = { module = "com.google.auto.service:auto-service-annotations", version.ref = "auto-service" }
 auto-service-compiler = { module = "com.google.auto.service:auto-service", version.ref = "auto-service" }

--- a/whetstone/runtime-fragment/build.gradle
+++ b/whetstone/runtime-fragment/build.gradle
@@ -56,4 +56,6 @@ dependencies {
     implementation libs.androidx.compose.runtime
     implementation libs.androidx.viewmodel
     implementation libs.androidx.viewmodel.savedstate
+
+    compileOnly libs.renderer
 }

--- a/whetstone/runtime-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/RendererFragment.kt
+++ b/whetstone/runtime-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/RendererFragment.kt
@@ -2,6 +2,7 @@ package com.freeletics.mad.whetstone.fragment
 
 import androidx.fragment.app.Fragment
 import com.freeletics.mad.statemachine.StateMachine
+import com.gabrielittner.renderer.ViewRenderer
 import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.annotation.AnnotationTarget.CLASS
 import kotlin.reflect.KClass
@@ -55,8 +56,6 @@ public annotation class RendererFragment(
     val scope: KClass<*>,
     val parentScope: KClass<*>,
     val stateMachine: KClass<out StateMachine<*, *>>,
-    //TODO should be KClass<out ViewRenderer.Factory<*, *>>
-    // leaving out the constraint for now to be compatible with some custom factories using the same signature
-    val rendererFactory: KClass<*>,
+    val rendererFactory: KClass<out ViewRenderer.Factory<*, *>>,
     val fragmentBaseClass: KClass<out Fragment> = Fragment::class,
 )


### PR DESCRIPTION
We relied on some custom factories internally. Those are not necessary anymore and we can add the constraint to the annotation.