### PR TITLE
remove unused SavedStateRegistryOwner

### DIFF
--- a/whetstone/navigation-compose/build.gradle
+++ b/whetstone/navigation-compose/build.gradle
@@ -62,7 +62,6 @@ dependencies {
     implementation project(":navigator:navigator-runtime-compose")
     implementation libs.androidx.compose.runtime
     implementation libs.androidx.compose.ui
-    implementation libs.androidx.savedstate
     implementation libs.androidx.viewmodel
     implementation libs.androidx.viewmodel.savedstate
     implementation libs.androidx.viewmodel.compose

--- a/whetstone/navigation-compose/src/main/java/com/freeletics/mad/whetstone/compose/internal/NavComposeViewModelProvider.kt
+++ b/whetstone/navigation-compose/src/main/java/com/freeletics/mad/whetstone/compose/internal/NavComposeViewModelProvider.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisallowComposableCalls
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalSavedStateRegistryOwner
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -36,10 +35,9 @@ public inline fun <reified T : ViewModel, D : Any, R : BaseRoute> rememberViewMo
     crossinline factory: @DisallowComposableCalls (D, SavedStateHandle, R) -> T
 ): T {
     val viewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current)
-    val savedStateRegistryOwner = LocalSavedStateRegistryOwner.current
     val context = LocalContext.current
     val navController = LocalNavController.current
-    return remember(viewModelStoreOwner, savedStateRegistryOwner, context, navController, route) {
+    return remember(viewModelStoreOwner, context, navController, route) {
         val viewModelFactory = viewModelFactory {
             initializer {
                 val dependencies = context.findDependencies<D>(scope, destinationScope, navController::getBackStackEntry)

--- a/whetstone/runtime-compose/build.gradle
+++ b/whetstone/runtime-compose/build.gradle
@@ -59,7 +59,6 @@ dependencies {
     implementation project(":state-machine")
     implementation libs.androidx.compose.runtime
     implementation libs.androidx.compose.ui
-    implementation libs.androidx.savedstate
     implementation libs.androidx.viewmodel
     implementation libs.androidx.viewmodel.savedstate
     implementation libs.androidx.viewmodel.compose

--- a/whetstone/runtime-compose/src/main/java/com/freeletics/mad/whetstone/compose/internal/ComposeViewModelProvider.kt
+++ b/whetstone/runtime-compose/src/main/java/com/freeletics/mad/whetstone/compose/internal/ComposeViewModelProvider.kt
@@ -5,7 +5,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisallowComposableCalls
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalSavedStateRegistryOwner
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -32,9 +31,8 @@ public inline fun <reified T : ViewModel, D : Any> rememberViewModel(
     crossinline factory: @DisallowComposableCalls (D, SavedStateHandle, Bundle) -> T
 ): T {
     val viewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current)
-    val savedStateRegistryOwner = LocalSavedStateRegistryOwner.current
     val context = LocalContext.current
-    return remember(viewModelStoreOwner, savedStateRegistryOwner, context, arguments) {
+    return remember(viewModelStoreOwner, context, arguments) {
         val viewModelFactory = viewModelFactory {
             initializer {
                 val dependencies = context.findDependencies<D>(scope)


### PR DESCRIPTION
`savedStateRegistryOwner` was unused so we can remove it.