### PR TITLE
fix Closeable typo

### DIFF
--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/ModuleGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/ModuleGenerator.kt
@@ -30,7 +30,7 @@ internal class ModuleGenerator(
     }
 
     private fun multibindsFunction(): FunSpec {
-        return FunSpec.builder("bindCancellable")
+        return FunSpec.builder("bindCloseables")
             .addModifiers(ABSTRACT)
             .addAnnotation(multibinds)
             .apply {

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
@@ -85,7 +85,7 @@ internal class FileGeneratorTestCompose {
             @ContributesTo(TestScreen::class)
             public interface WhetstoneTestModule {
               @Multibinds
-              public fun bindCancellable(): Set<Closeable>
+              public fun bindCloseables(): Set<Closeable>
             }
 
             @InternalWhetstoneApi
@@ -202,7 +202,7 @@ internal class FileGeneratorTestCompose {
             @ContributesTo(TestScreen::class)
             public interface WhetstoneTestModule {
               @Multibinds
-              public fun bindCancellable(): Set<Closeable>
+              public fun bindCloseables(): Set<Closeable>
             }
 
             @InternalWhetstoneApi
@@ -330,7 +330,7 @@ internal class FileGeneratorTestCompose {
             @ContributesTo(TestScreen::class)
             public interface WhetstoneTestModule {
               @Multibinds
-              public fun bindCancellable(): Set<Closeable>
+              public fun bindCloseables(): Set<Closeable>
             }
 
             @InternalWhetstoneApi

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
@@ -94,7 +94,7 @@ internal class FileGeneratorTestComposeFragment {
             @ContributesTo(TestScreen::class)
             public interface WhetstoneTestModule {
               @Multibinds
-              public fun bindCancellable(): Set<Closeable>
+              public fun bindCloseables(): Set<Closeable>
             }
 
             @InternalWhetstoneApi
@@ -235,7 +235,7 @@ internal class FileGeneratorTestComposeFragment {
             @ContributesTo(TestScreen::class)
             public interface WhetstoneTestModule {
               @Multibinds
-              public fun bindCancellable(): Set<Closeable>
+              public fun bindCloseables(): Set<Closeable>
             }
 
             @InternalWhetstoneApi
@@ -387,7 +387,7 @@ internal class FileGeneratorTestComposeFragment {
             @ContributesTo(TestScreen::class)
             public interface WhetstoneTestModule {
               @Multibinds
-              public fun bindCancellable(): Set<Closeable>
+              public fun bindCloseables(): Set<Closeable>
             }
 
             @InternalWhetstoneApi
@@ -537,7 +537,7 @@ internal class FileGeneratorTestComposeFragment {
             @ContributesTo(TestScreen::class)
             public interface WhetstoneTestModule {
               @Multibinds
-              public fun bindCancellable(): Set<Closeable>
+              public fun bindCloseables(): Set<Closeable>
             }
 
             @InternalWhetstoneApi

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestRendererFragment.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestRendererFragment.kt
@@ -84,7 +84,7 @@ internal class FileGeneratorTestRendererFragment {
             @ContributesTo(TestScreen::class)
             public interface WhetstoneTestModule {
               @Multibinds
-              public fun bindCancellable(): Set<Closeable>
+              public fun bindCloseables(): Set<Closeable>
             }
 
             @InternalWhetstoneApi
@@ -195,7 +195,7 @@ internal class FileGeneratorTestRendererFragment {
             @ContributesTo(TestScreen::class)
             public interface WhetstoneTestModule {
               @Multibinds
-              public fun bindCancellable(): Set<Closeable>
+              public fun bindCloseables(): Set<Closeable>
             }
 
             @InternalWhetstoneApi
@@ -317,7 +317,7 @@ internal class FileGeneratorTestRendererFragment {
             @ContributesTo(TestScreen::class)
             public interface WhetstoneTestModule {
               @Multibinds
-              public fun bindCancellable(): Set<Closeable>
+              public fun bindCloseables(): Set<Closeable>
             }
 
             @InternalWhetstoneApi
@@ -439,7 +439,7 @@ internal class FileGeneratorTestRendererFragment {
             @ContributesTo(TestScreen::class)
             public interface WhetstoneTestModule {
               @Multibinds
-              public fun bindCancellable(): Set<Closeable>
+              public fun bindCloseables(): Set<Closeable>
             }
 
             @InternalWhetstoneApi

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/NavEntryFileGeneratorTest.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/NavEntryFileGeneratorTest.kt
@@ -85,7 +85,7 @@ internal class NavEntryFileGeneratorTest {
             public interface WhetstoneTestFlowScopeNavEntryModule {
               @Multibinds
               @NavEntry(TestFlowScope::class)
-              public fun bindCancellable(): Set<Closeable>
+              public fun bindCloseables(): Set<Closeable>
             }
 
             @InternalWhetstoneApi


### PR DESCRIPTION
Accidentally called it `Cancellable` instead of `Closeable` in the generated method.