### PR TITLE
rename findDependencies to findComponentByScope

### DIFF
--- a/whetstone/navigation-compose/src/main/java/com/freeletics/mad/whetstone/compose/internal/NavComposeViewModelProvider.kt
+++ b/whetstone/navigation-compose/src/main/java/com/freeletics/mad/whetstone/compose/internal/NavComposeViewModelProvider.kt
@@ -16,7 +16,7 @@ import com.freeletics.mad.navigator.BaseRoute
 import com.freeletics.mad.navigator.compose.LocalNavController
 import com.freeletics.mad.navigator.internal.InternalNavigatorApi
 import com.freeletics.mad.whetstone.internal.InternalWhetstoneApi
-import com.freeletics.mad.whetstone.internal.findDependencies
+import com.freeletics.mad.whetstone.internal.findComponentByScope
 import kotlin.reflect.KClass
 
 /**
@@ -42,7 +42,7 @@ public inline fun <reified T : ViewModel, D : Any, R : BaseRoute> rememberViewMo
     return remember(viewModelStoreOwner, savedStateRegistryOwner, context, navController, route) {
         val viewModelFactory = viewModelFactory {
             initializer {
-                val dependencies = context.findDependencies<D>(scope, destinationScope, navController::getBackStackEntry)
+                val dependencies = context.findComponentByScope<D>(scope, destinationScope, navController::getBackStackEntry)
                 val savedStateHandle = createSavedStateHandle()
                 factory(dependencies, savedStateHandle, route)
             }

--- a/whetstone/navigation-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/internal/NavFragmentViewModelProvider.kt
+++ b/whetstone/navigation-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/internal/NavFragmentViewModelProvider.kt
@@ -11,7 +11,7 @@ import androidx.lifecycle.viewmodel.viewModelFactory
 import androidx.navigation.fragment.findNavController
 import com.freeletics.mad.navigator.BaseRoute
 import com.freeletics.mad.whetstone.internal.InternalWhetstoneApi
-import com.freeletics.mad.whetstone.internal.findDependencies
+import com.freeletics.mad.whetstone.internal.findComponentByScope
 import kotlin.reflect.KClass
 
 /**
@@ -31,7 +31,7 @@ public inline fun <reified T : ViewModel, D : Any, R : BaseRoute> Fragment.viewM
     val viewModelFactory = viewModelFactory {
         initializer {
             val navController = findNavController()
-            val dependencies = requireContext().findDependencies<D>(scope, destinationScope, navController::getBackStackEntry)
+            val dependencies = requireContext().findComponentByScope<D>(scope, destinationScope, navController::getBackStackEntry)
             val savedStateHandle = createSavedStateHandle()
             factory(dependencies, savedStateHandle, route)
         }

--- a/whetstone/navigation/src/main/java/com/freeletics/mad/whetstone/internal/NavEntryViewModelProvider.kt
+++ b/whetstone/navigation/src/main/java/com/freeletics/mad/whetstone/internal/NavEntryViewModelProvider.kt
@@ -30,7 +30,7 @@ public inline fun <reified T : ViewModel, D : Any, R : BaseRoute> viewModel(
 ): T {
     val viewModelFactory = viewModelFactory {
         initializer {
-            val dependencies = context.findDependencies<D>(scope, destinationScope, findEntry)
+            val dependencies = context.findComponentByScope<D>(scope, destinationScope, findEntry)
             val savedStateHandle = createSavedStateHandle()
             factory(dependencies, savedStateHandle, route)
         }

--- a/whetstone/navigation/src/main/java/com/freeletics/mad/whetstone/internal/NavFind.kt
+++ b/whetstone/navigation/src/main/java/com/freeletics/mad/whetstone/internal/NavFind.kt
@@ -9,7 +9,7 @@ import kotlin.reflect.KClass
  * [Context.getSystemService].
  */
 @InternalWhetstoneApi
-public fun <T : Any> Context.findDependencies(
+public fun <T : Any> Context.findComponentByScope(
     scope: KClass<*>,
     destinationScope: KClass<*>,
     findEntry: (Int) -> NavBackStackEntry

--- a/whetstone/runtime-compose/src/main/java/com/freeletics/mad/whetstone/compose/internal/ComposeViewModelProvider.kt
+++ b/whetstone/runtime-compose/src/main/java/com/freeletics/mad/whetstone/compose/internal/ComposeViewModelProvider.kt
@@ -14,7 +14,7 @@ import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.freeletics.mad.whetstone.internal.InternalWhetstoneApi
-import com.freeletics.mad.whetstone.internal.findDependencies
+import com.freeletics.mad.whetstone.internal.findComponentByScope
 import kotlin.reflect.KClass
 
 /**
@@ -37,7 +37,7 @@ public inline fun <reified T : ViewModel, D : Any> rememberViewModel(
     return remember(viewModelStoreOwner, savedStateRegistryOwner, context, arguments) {
         val viewModelFactory = viewModelFactory {
             initializer {
-                val dependencies = context.findDependencies<D>(scope)
+                val dependencies = context.findComponentByScope<D>(scope)
                 val savedStateHandle = createSavedStateHandle()
                 factory(dependencies, savedStateHandle, arguments)
             }

--- a/whetstone/runtime-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/internal/FragmentViewModelProvider.kt
+++ b/whetstone/runtime-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/internal/FragmentViewModelProvider.kt
@@ -9,7 +9,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewmodel.initializer
 import com.freeletics.mad.whetstone.internal.InternalWhetstoneApi
-import com.freeletics.mad.whetstone.internal.findDependencies
+import com.freeletics.mad.whetstone.internal.findComponentByScope
 import kotlin.reflect.KClass
 
 /**
@@ -27,7 +27,7 @@ public inline fun <reified T : ViewModel, D : Any> Fragment.viewModel(
 ): T {
     val viewModelFactory = androidx.lifecycle.viewmodel.viewModelFactory {
         initializer {
-            val dependencies = requireContext().findDependencies<D>(scope)
+            val dependencies = requireContext().findComponentByScope<D>(scope)
             val savedStateHandle = createSavedStateHandle()
             factory(dependencies, savedStateHandle, arguments)
         }

--- a/whetstone/runtime/src/main/java/com/freeletics/mad/whetstone/internal/Find.kt
+++ b/whetstone/runtime/src/main/java/com/freeletics/mad/whetstone/internal/Find.kt
@@ -4,21 +4,17 @@ import android.content.Context
 import kotlin.reflect.KClass
 
 @InternalWhetstoneApi
-public fun <T> Context.findDependencies(scope: KClass<*>): T {
-    val dependency = find(scope)
-    checkNotNull(dependency) {
+public fun <T> Context.findComponentByScope(scope: KClass<*>): T {
+    val component = find(scope)
+    checkNotNull(component) {
         "Could not find scope ${scope.qualifiedName} through getSystemService"
     }
     @Suppress("UNCHECKED_CAST")
-    return dependency as T
+    return component as T
 }
 
 @InternalWhetstoneApi
 public fun Context.find(service: KClass<*>): Any? {
     val serviceName = service.qualifiedName!!
-    return find(serviceName) ?: applicationContext.find(serviceName)
-}
-
-private fun Context.find(serviceName: String): Any? {
-    return getSystemService(serviceName)
+    return getSystemService(serviceName) ?: applicationContext.getSystemService(serviceName)
 }


### PR DESCRIPTION
After getting rid of component dependencies in favor of subcomponents our find methods were not named correctly anymore.