### PR TITLE
move generated DestinationComponent to the nav entry generator

### DIFF
--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/FileGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/FileGenerator.kt
@@ -72,12 +72,6 @@ internal class FileGenerator{
     }
 
     private fun FileSpec.Builder.addNavDestinationTypes(data: BaseData) = apply {
-        val destinationScope = data.navigation?.destinationScope
-        if (destinationScope != null && destinationScope != data.parentScope) {
-            val destinationComponentGenerator = DestinationComponentGenerator(data)
-            addType(destinationComponentGenerator.generate())
-        }
-
         if (data.navigation?.destinationMethod != null) {
             val navDestinationGenerator = NavDestinationModuleGenerator(data)
             addType(navDestinationGenerator.generate())
@@ -90,11 +84,13 @@ internal class FileGenerator{
             val moduleGenerator = ModuleGenerator(data)
             val viewModelGenerator = ViewModelGenerator(data)
             val componentGetterGenerator = NavEntryComponentGetterGenerator(data)
+            val destinationComponentGenerator = DestinationComponentGenerator(data)
 
             addType(componentGenerator.generate())
             addType(moduleGenerator.generate())
             addType(viewModelGenerator.generate())
             addType(componentGetterGenerator.generate())
+            addType(destinationComponentGenerator.generate())
         }
     }
 

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
@@ -153,7 +153,6 @@ internal class FileGeneratorTestCompose {
             import com.freeletics.mad.navigator.compose.NavigationSetup
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
-            import com.freeletics.mad.whetstone.`internal`.DestinationComponent
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
@@ -250,10 +249,6 @@ internal class FileGeneratorTestCompose {
               }
             }
             
-            @ContributesTo(TestDestinationScope::class)
-            @OptIn(InternalWhetstoneApi::class)
-            public interface WhetstoneTestDestinationComponent : DestinationComponent
-            
         """.trimIndent()
 
         assertThat(actual).isEqualTo(expected)
@@ -279,7 +274,6 @@ internal class FileGeneratorTestCompose {
             import com.freeletics.mad.navigator.compose.ScreenDestination
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
-            import com.freeletics.mad.whetstone.`internal`.DestinationComponent
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
@@ -377,10 +371,6 @@ internal class FileGeneratorTestCompose {
                 }
               }
             }
-            
-            @ContributesTo(TestDestinationScope::class)
-            @OptIn(InternalWhetstoneApi::class)
-            public interface WhetstoneTestDestinationComponent : DestinationComponent
             
             @Module
             @ContributesTo(TestDestinationScope::class)

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
@@ -186,7 +186,6 @@ internal class FileGeneratorTestComposeFragment {
             import com.freeletics.mad.navigator.fragment.requireRoute
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
-            import com.freeletics.mad.whetstone.`internal`.DestinationComponent
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
@@ -299,10 +298,6 @@ internal class FileGeneratorTestComposeFragment {
               }
             }
             
-            @ContributesTo(TestDestinationScope::class)
-            @OptIn(InternalWhetstoneApi::class)
-            public interface WhetstoneTestDestinationComponent : DestinationComponent
-            
         """.trimIndent()
 
         assertThat(actual).isEqualTo(expected)
@@ -336,7 +331,6 @@ internal class FileGeneratorTestComposeFragment {
             import com.freeletics.mad.navigator.fragment.requireRoute
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
-            import com.freeletics.mad.whetstone.`internal`.DestinationComponent
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
@@ -450,10 +444,6 @@ internal class FileGeneratorTestComposeFragment {
                 }
               }
             }
-            
-            @ContributesTo(TestDestinationScope::class)
-            @OptIn(InternalWhetstoneApi::class)
-            public interface WhetstoneTestDestinationComponent : DestinationComponent
             
             @Module
             @ContributesTo(TestDestinationScope::class)

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestRendererFragment.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestRendererFragment.kt
@@ -148,7 +148,6 @@ internal class FileGeneratorTestRendererFragment {
             import com.freeletics.mad.navigator.fragment.handleNavigation
             import com.freeletics.mad.navigator.fragment.requireRoute
             import com.freeletics.mad.whetstone.ScopeTo
-            import com.freeletics.mad.whetstone.`internal`.DestinationComponent
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
             import com.gabrielittner.renderer.connect.connect
@@ -238,10 +237,6 @@ internal class FileGeneratorTestRendererFragment {
               }
             }
             
-            @ContributesTo(TestDestinationScope::class)
-            @OptIn(InternalWhetstoneApi::class)
-            public interface WhetstoneTestDestinationComponent : DestinationComponent
-            
         """.trimIndent()
 
         assertThat(actual).isEqualTo(expected)
@@ -268,7 +263,6 @@ internal class FileGeneratorTestRendererFragment {
             import com.freeletics.mad.navigator.fragment.handleNavigation
             import com.freeletics.mad.navigator.fragment.requireRoute
             import com.freeletics.mad.whetstone.ScopeTo
-            import com.freeletics.mad.whetstone.`internal`.DestinationComponent
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
             import com.gabrielittner.renderer.connect.connect
@@ -359,10 +353,6 @@ internal class FileGeneratorTestRendererFragment {
                 return renderer.rootView
               }
             }
-            
-            @ContributesTo(TestDestinationScope::class)
-            @OptIn(InternalWhetstoneApi::class)
-            public interface WhetstoneTestDestinationComponent : DestinationComponent
             
             @Module
             @ContributesTo(TestDestinationScope::class)

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/NavEntryFileGeneratorTest.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/NavEntryFileGeneratorTest.kt
@@ -37,6 +37,7 @@ internal class NavEntryFileGeneratorTest {
             import com.freeletics.mad.navigator.`internal`.toRoute
             import com.freeletics.mad.whetstone.NavEntry
             import com.freeletics.mad.whetstone.ScopeTo
+            import com.freeletics.mad.whetstone.`internal`.DestinationComponent
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetter
             import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetterKey
@@ -121,6 +122,10 @@ internal class NavEntryFileGeneratorTest {
                 return viewModel.component
               }
             }
+            
+            @ContributesTo(TestDestinationScope::class)
+            @OptIn(InternalWhetstoneApi::class)
+            public interface WhetstoneTestFlowScopeNavEntryDestinationComponent : DestinationComponent
 
         """.trimIndent()
 


### PR DESCRIPTION
This reduces how often we generate the contributed DestinationComponent by generating it only together with the NavEntryComponent that needs it. For example when you have a flow of 5 screens that use a shared parent scope this would only generate it once instead of 5 times.