### PR TITLE
Check for route for be not null before adding it to Intent

### DIFF
--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/CustomActivityNavigator.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/CustomActivityNavigator.kt
@@ -93,7 +93,9 @@ public open class CustomActivityNavigator(
             }
 
             val route = args.getParcelable<Parcelable>(EXTRA_ROUTE)
-            intent.putExtra(EXTRA_ROUTE, route)
+            if (route != null) {
+                intent.putExtra(EXTRA_ROUTE, route)
+            }
         }
         if (hostActivity == null) {
             // If we're not launching from an Activity context we have to launch in a new task.


### PR DESCRIPTION
Fixes crashes when route is null for external nav destinations that circle back to app's navigation (e.g. via deeplink).