### PR TITLE
deploy docs directly from Github Actions

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -10,6 +10,11 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -62,9 +67,14 @@ jobs:
           mkdir -p docs/API/whetstone-navigation-fragment
           cp -R whetstone/navigation-fragment/build/dokka/html/. docs/API/whetstone-navigation-fragment/
 
-      - name: Deploy MkDocs
-        run: |
-          git fetch origin gh-pages:gh-pages
-          mkdocs gh-deploy --force
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build MkDocs
+        run: mkdocs build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
This removes the need for the `gh-pages` branch which will then be built and deployed.