### PR TITLE
Navigator runtime module refactor.

### DIFF
--- a/navigator/androidx-nav/build.gradle
+++ b/navigator/androidx-nav/build.gradle
@@ -52,4 +52,5 @@ dependencies {
     implementation project(":navigator:navigator-runtime")
     implementation libs.androidx.navigation.common
     implementation libs.androidx.navigation.runtime
+    implementation libs.androidx.viewmodel.savedstate
 }

--- a/navigator/androidx-nav/src/main/java/com/freeletics/mad/navigator/internal/AndroidXNavigationExecutor.kt
+++ b/navigator/androidx-nav/src/main/java/com/freeletics/mad/navigator/internal/AndroidXNavigationExecutor.kt
@@ -1,0 +1,56 @@
+package com.freeletics.mad.navigator.internal
+
+import android.os.Parcelable
+import androidx.navigation.NavController
+import androidx.navigation.NavOptions
+import com.freeletics.mad.navigator.ActivityRoute
+import com.freeletics.mad.navigator.BaseRoute
+import com.freeletics.mad.navigator.NavRoot
+import com.freeletics.mad.navigator.NavRoute
+import com.freeletics.mad.navigator.NavigationResultRequest
+import kotlin.reflect.KClass
+
+@InternalNavigatorApi
+public class AndroidXNavigationExecutor(
+    private val controller: NavController
+) : NavigationExecutor {
+
+    override fun navigate(route: NavRoute) {
+        controller.navigate(route.destinationId(), route.getArguments())
+    }
+
+    override fun navigate(route: ActivityRoute) {
+        controller.navigate(route.destinationId(), route.getArguments())
+    }
+
+    override fun navigate(root: NavRoot, restoreRootState: Boolean) {
+        val options = NavOptions.Builder()
+            // save the state of the current root before leaving it
+            .setPopUpTo(controller.graph.startDestinationId, inclusive = false, saveState = true)
+            // restoring the state of the target root
+            .setRestoreState(restoreRootState)
+            // makes sure that if the destination is already on the backstack, it and
+            // everything above it gets removed
+            .setLaunchSingleTop(true)
+            .build()
+        controller.navigate(root.destinationId(), root.getArguments(), options)
+    }
+
+    override fun navigateBack() {
+        controller.popBackStack()
+    }
+
+    override fun navigateUp() {
+        controller.navigateUp()
+    }
+
+    override fun deliverResult(key: NavigationResultRequest.Key<*>, result: Parcelable) {
+        val entry = controller.getBackStackEntry(key.destinationId)
+        entry.savedStateHandle.set(key.requestKey, result)
+    }
+
+    override fun navigateBackTo(route: KClass<out BaseRoute>, isInclusive: Boolean) {
+        controller.popBackStack(route.destinationId(), isInclusive)
+    }
+
+}

--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavigationSetup.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavigationSetup.kt
@@ -3,7 +3,6 @@ package com.freeletics.mad.navigator.compose
 import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
-import android.os.Bundle
 import android.os.Parcelable
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -20,6 +19,7 @@ import com.freeletics.mad.navigator.ActivityResultRequest
 import com.freeletics.mad.navigator.NavEventNavigator
 import com.freeletics.mad.navigator.NavigationResultRequest
 import com.freeletics.mad.navigator.PermissionsResultRequest
+import com.freeletics.mad.navigator.internal.AndroidXNavigationExecutor
 import com.freeletics.mad.navigator.internal.RequestPermissionsContract
 import com.freeletics.mad.navigator.internal.navigate
 import kotlinx.parcelize.Parcelize
@@ -54,10 +54,11 @@ public fun NavigationSetup(navigator: NavEventNavigator) {
     }
 
     LaunchedEffect(lifecycleOwner, controller, navigator) {
+        val navigationExecutor = AndroidXNavigationExecutor(controller)
         navigator.navEvents
             .flowWithLifecycle(lifecycleOwner.lifecycle, minActiveState = RESUMED)
             .collect { event ->
-                navigate(event, controller, activityLaunchers, permissionLaunchers)
+                navigate(event, navigationExecutor, activityLaunchers, permissionLaunchers)
             }
     }
 }

--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/HandleNavigation.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/HandleNavigation.kt
@@ -1,7 +1,6 @@
 package com.freeletics.mad.navigator.fragment
 
 import android.app.Activity
-import android.os.Bundle
 import android.os.Parcelable
 import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
@@ -15,6 +14,7 @@ import com.freeletics.mad.navigator.ActivityResultRequest
 import com.freeletics.mad.navigator.NavEventNavigator
 import com.freeletics.mad.navigator.NavigationResultRequest
 import com.freeletics.mad.navigator.PermissionsResultRequest
+import com.freeletics.mad.navigator.internal.AndroidXNavigationExecutor
 import com.freeletics.mad.navigator.internal.RequestPermissionsContract
 import com.freeletics.mad.navigator.internal.navigate
 import kotlinx.coroutines.launch
@@ -42,10 +42,12 @@ public fun handleNavigation(fragment: Fragment, navigator: NavEventNavigator) {
     val dispatcher = fragment.requireActivity().onBackPressedDispatcher
     dispatcher.addCallback(fragment, navigator.onBackPressedCallback)
 
+    val navigationExecutor = AndroidXNavigationExecutor(controller)
+
     lifecycle.coroutineScope.launch {
         lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
             navigator.navEvents.collect { event ->
-                navigate(event, fragment.findNavController(), activityLaunchers, permissionLaunchers)
+                navigate(event, navigationExecutor, activityLaunchers, permissionLaunchers)
             }
         }
     }

--- a/navigator/runtime/build.gradle
+++ b/navigator/runtime/build.gradle
@@ -53,7 +53,6 @@ dependencies {
     api libs.coroutines.core
 
     implementation libs.androidx.core
-    implementation libs.androidx.viewmodel.savedstate
 
     testImplementation libs.junit
     testImplementation libs.truth

--- a/navigator/runtime/build.gradle
+++ b/navigator/runtime/build.gradle
@@ -53,8 +53,6 @@ dependencies {
     api libs.coroutines.core
 
     implementation libs.androidx.core
-    implementation libs.androidx.navigation.common
-    implementation libs.androidx.navigation.runtime
     implementation libs.androidx.viewmodel.savedstate
 
     testImplementation libs.junit

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/NavigationExecutor.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/NavigationExecutor.kt
@@ -1,0 +1,28 @@
+package com.freeletics.mad.navigator.internal
+
+import android.os.Parcelable
+import com.freeletics.mad.navigator.ActivityRoute
+import com.freeletics.mad.navigator.BaseRoute
+import com.freeletics.mad.navigator.NavRoot
+import com.freeletics.mad.navigator.NavRoute
+import com.freeletics.mad.navigator.NavigationResultRequest
+import kotlin.reflect.KClass
+
+@InternalNavigatorApi
+public interface NavigationExecutor {
+
+    public fun navigate(route: NavRoute)
+
+    public fun navigate(route: ActivityRoute)
+
+    public fun navigate(root: NavRoot, restoreRootState: Boolean)
+
+    public fun navigateBack()
+
+    public fun navigateUp()
+
+    public fun deliverResult(key: NavigationResultRequest.Key<*>, result: Parcelable)
+
+    public fun navigateBackTo(route: KClass<out BaseRoute>, isInclusive: Boolean)
+
+}


### PR DESCRIPTION
This PR remove `NavCotroller` from the runtime module and extracts that implementation to a separate class in the `androidx-nav` module