### PR TITLE
Add support for injecting dependencies into Composables

### DIFF
--- a/whetstone/README.md
+++ b/whetstone/README.md
@@ -192,7 +192,8 @@ of all destinations anymore. It can simply be injected.
 ## Dependencies in Compose
 
 The `@ComposeFragment` and `@ComposeScreen` annotations support passing dependencies
-into the annotated function. The dependency has to be available via Dagger.
+into the annotated function. The dependency has to be available for injection in the previously
+mentioned generated component.
 
 ```kotlin
 class ExampleClass @Inject constructor() {

--- a/whetstone/README.md
+++ b/whetstone/README.md
@@ -29,7 +29,7 @@ with views there is `@RendererFragment`.
 
 In a pure compose app the `@ComposeScreen` annotation is added to the
 top level composable that represents your screen. This function should have
-exactly 2 parameters: the state that should be rendered and a lambda that allows
+2 parameters: the state that should be rendered and a lambda that allows
 the composable to send actions for user interactions. This will then generate
 another Composable function called `ExampleUiScreen` and a Dagger component.
 
@@ -42,7 +42,7 @@ another Composable function called `ExampleUiScreen` and a Dagger component.
 @Composable
 internal fun ExampleUi(
   state: ExampleState,
-  actions: (ExampleAction) -> Unit
+  sendAction: (ExampleAction) -> Unit
 ) {
   // composable logic ...
 }
@@ -72,7 +72,7 @@ will then generate a `ExampleUiFragment` class and a Dagger component.
 @Composable
 internal fun ExampleUi(
   state: ExampleState,
-  actions: (ExampleAction) -> Unit
+  sendAction: (ExampleAction) -> Unit
 ) {
   // composable logic ...
 }
@@ -189,6 +189,26 @@ that uses `destinationScope` as its scope (usually an app wide or Activity
 level scope). With that it's not necessary to manually create a `Set`
 of all destinations anymore. It can simply be injected.
 
+## Dependencies in Compose
+
+The `@ComposeFragment` and `@ComposeScreen` annotations support passing dependencies
+into the annotated function. The dependency has to be available via Dagger.
+
+```kotlin
+class ExampleClass @Inject constructor() {
+    // implementation ...
+}
+
+@ComposeScreen(...)
+@Composable
+internal fun ExampleUi(
+  exampleClass: ExampleClass,
+  state: ExampleState,
+  sendAction: (ExampleAction) -> Unit
+) {
+  // composable logic ...
+}
+```
 
 ## Example
 

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/Data.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/Data.kt
@@ -24,6 +24,7 @@ internal sealed interface BaseData {
 internal sealed interface ComposeData : BaseData {
     override val stateMachine: ClassName
     val navEntryData: NavEntryData?
+    val composableParameter: List<ClassName>
 }
 
 internal data class ComposeScreenData(
@@ -37,6 +38,7 @@ internal data class ComposeScreenData(
 
     override val navigation: Navigation.Compose?,
     override val navEntryData: NavEntryData?,
+    override val composableParameter: List<ClassName>,
 ) :  ComposeData
 
 internal sealed interface FragmentData : BaseData {
@@ -57,6 +59,7 @@ internal data class ComposeFragmentData(
 
     override val navigation: Navigation.Fragment?,
     override val navEntryData: NavEntryData?,
+    override val composableParameter: List<ClassName>,
 ) : ComposeData, FragmentData
 
 internal data class RendererFragmentData(

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/Data.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/Data.kt
@@ -24,8 +24,13 @@ internal sealed interface BaseData {
 internal sealed interface ComposeData : BaseData {
     override val stateMachine: ClassName
     val navEntryData: NavEntryData?
-    val composableParameter: List<ClassName>
+    val composableParameter: List<ComposableParameter>
 }
+
+internal data class ComposableParameter(
+    val name: String,
+    val className: ClassName
+)
 
 internal data class ComposeScreenData(
     override val baseName: String,
@@ -38,7 +43,7 @@ internal data class ComposeScreenData(
 
     override val navigation: Navigation.Compose?,
     override val navEntryData: NavEntryData?,
-    override val composableParameter: List<ClassName>,
+    override val composableParameter: List<ComposableParameter>,
 ) :  ComposeData
 
 internal sealed interface FragmentData : BaseData {
@@ -59,7 +64,7 @@ internal data class ComposeFragmentData(
 
     override val navigation: Navigation.Fragment?,
     override val navEntryData: NavEntryData?,
-    override val composableParameter: List<ClassName>,
+    override val composableParameter: List<ComposableParameter>,
 ) : ComposeData, FragmentData
 
 internal data class RendererFragmentData(

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/WhetstoneCodeGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/WhetstoneCodeGenerator.kt
@@ -220,10 +220,10 @@ public class WhetstoneCodeGenerator : CodeGenerator {
 
     private fun TopLevelFunctionReference.parameterTypes(): List<ClassName> {
         return parameters
-            .filter { it.fqName != null && it.name != "state" && it.name != "sendAction" }
+//            .filter { it.name != "state" && it.name != "sendAction" }
             .map {
 //                val typeFqName = it.type().asClassReference().fqName
-                ClassName(it.fqName!!.packageString(), it.fqName!!.shortName().asString())
+                ClassName(it.fqName?.packageString() ?: "FqNameIsNull", it.fqName?.shortName()?.asString() ?: "FqNameIsNull2")
             }
     }
 }

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/WhetstoneCodeGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/WhetstoneCodeGenerator.kt
@@ -103,7 +103,7 @@ public class WhetstoneCodeGenerator : CodeGenerator {
             fragmentBaseClass = compose.optionalClassArgument("fragmentBaseClass", 3) ?: fragment,
             navigation = navigation,
             navEntryData = navEntryData(declaration, declaration.packageName(), navigation),
-            composableParameter = emptyList()
+            composableParameter = declaration.parameterTypes()
         )
 
         val file = FileGenerator().generate(data)
@@ -153,7 +153,7 @@ public class WhetstoneCodeGenerator : CodeGenerator {
             stateMachine = compose.requireClassArgument("stateMachine", 2),
             navigation = navigation,
             navEntryData = navEntryData(declaration, declaration.packageName(), navigation),
-            composableParameter = emptyList()
+            composableParameter = declaration.parameterTypes()
         )
 
         val file = FileGenerator().generate(data)
@@ -216,5 +216,14 @@ public class WhetstoneCodeGenerator : CodeGenerator {
 
     private fun FqName.packageString(): String {
         return pathSegments().joinToString(separator = ".")
+    }
+
+    private fun TopLevelFunctionReference.parameterTypes(): List<ClassName> {
+        return parameters
+            .filter { it.name != "state" && it.name != "sendAction" }
+            .map {
+                val typeFqName = it.type().asClassReference().fqName
+                ClassName(typeFqName.packageString(), typeFqName.shortName().asString())
+            }
     }
 }

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/WhetstoneCodeGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/WhetstoneCodeGenerator.kt
@@ -224,9 +224,9 @@ public class WhetstoneCodeGenerator : CodeGenerator {
         return pathSegments().joinToString(separator = ".")
     }
 
-    private fun TopLevelFunctionReference.parameterTypes(): List<ClassName> {
+    private fun TopLevelFunctionReference.parameterTypes(): List<ComposableParameter> {
         return parameters
-            .filter { it.name != "state" && it.name != "sendAction" }
+            .filter { it.name != null && it.name != "state" && it.name != "sendAction" }
             .map {
                 val fqName = it.typeReference?.fqNameOrNull(module)
                 val packageString = fqName?.packageString()?.substringBeforeLast(".")
@@ -234,11 +234,14 @@ public class WhetstoneCodeGenerator : CodeGenerator {
                 if(packageString == null || shortName == null) {
                     throw AnvilCompilationExceptionTopLevelFunctionReference(
                         functionReference = this,
-                        message = "Could not find class for ${it.name}"
+                        message = "Could not find class for ${it.name} in ${this.name}"
                     )
                 }
 
-                ClassName(packageString, shortName)
+                ComposableParameter(
+                    name = it.name!!,
+                    className = ClassName(packageString, shortName)
+                )
             }
     }
 }

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/WhetstoneCodeGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/WhetstoneCodeGenerator.kt
@@ -220,10 +220,10 @@ public class WhetstoneCodeGenerator : CodeGenerator {
 
     private fun TopLevelFunctionReference.parameterTypes(): List<ClassName> {
         return parameters
-            .filter { it.name != "state" && it.name != "sendAction" }
+            .filter { it.fqName != null && it.name != "state" && it.name != "sendAction" }
             .map {
-                val typeFqName = it.type().asClassReference().fqName
-                ClassName(typeFqName.packageString(), typeFqName.shortName().asString())
+//                val typeFqName = it.type().asClassReference().fqName
+                ClassName(it.fqName!!.packageString(), it.fqName!!.shortName().asString())
             }
     }
 }

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/WhetstoneCodeGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/WhetstoneCodeGenerator.kt
@@ -23,6 +23,7 @@ import com.squareup.anvil.compiler.api.AnvilContext
 import com.squareup.anvil.compiler.api.CodeGenerator
 import com.squareup.anvil.compiler.api.GeneratedFile
 import com.squareup.anvil.compiler.api.createGeneratedFile
+import com.squareup.anvil.compiler.internal.asClassName
 import com.squareup.anvil.compiler.internal.fqNameOrNull
 import com.squareup.anvil.compiler.internal.reference.AnnotatedReference
 import com.squareup.anvil.compiler.internal.reference.AnvilCompilationExceptionAnnotationReference
@@ -229,18 +230,17 @@ public class WhetstoneCodeGenerator : CodeGenerator {
             .filter { it.name != null && it.name != "state" && it.name != "sendAction" }
             .map {
                 val fqName = it.typeReference?.fqNameOrNull(module)
-                val packageString = fqName?.packageString()?.substringBeforeLast(".")
-                val shortName = fqName?.shortName()?.asString()
-                if(packageString == null || shortName == null) {
+                val className = fqName?.asClassName(module)
+                if(className == null) {
                     throw AnvilCompilationExceptionTopLevelFunctionReference(
                         functionReference = this,
-                        message = "Could not find class for ${it.name} in ${this.name}"
+                        message = "Could not find class for parameter '${it.name}' in ${this.name}"
                     )
                 }
 
                 ComposableParameter(
                     name = it.name!!,
-                    className = ClassName(packageString, shortName)
+                    className = className
                 )
             }
     }

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/WhetstoneCodeGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/WhetstoneCodeGenerator.kt
@@ -32,6 +32,7 @@ import org.jetbrains.kotlin.descriptors.containingPackage
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.resolve.calls.util.getType
 
 @OptIn(ExperimentalAnvilApi::class)
 @AutoService(CodeGenerator::class)
@@ -222,8 +223,11 @@ public class WhetstoneCodeGenerator : CodeGenerator {
         return parameters
 //            .filter { it.name != "state" && it.name != "sendAction" }
             .map {
+                val name = it.nameAsName?.asString()
+                val type = it.nameAsName?.identifier
 //                val typeFqName = it.type().asClassReference().fqName
-                ClassName(it.fqName?.packageString() ?: "FqNameIsNull", it.fqName?.shortName()?.asString() ?: "FqNameIsNull2")
+//                ClassName(it.fqName?.packageString() ?: "FqNameIsNull", it.fqName?.shortName()?.asString() ?: "FqNameIsNull2")
+                ClassName(name ?: "NameIsNull", type ?: "TypeIsNull")
             }
     }
 }

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/WhetstoneCodeGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/WhetstoneCodeGenerator.kt
@@ -25,6 +25,7 @@ import com.squareup.anvil.compiler.api.createGeneratedFile
 import com.squareup.anvil.compiler.internal.reference.AnnotatedReference
 import com.squareup.anvil.compiler.internal.reference.ClassReference
 import com.squareup.anvil.compiler.internal.reference.classAndInnerClassReferences
+import com.squareup.kotlinpoet.ClassName
 import java.io.File
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.descriptors.containingPackage
@@ -101,7 +102,8 @@ public class WhetstoneCodeGenerator : CodeGenerator {
             stateMachine = compose.requireClassArgument("stateMachine", 2),
             fragmentBaseClass = compose.optionalClassArgument("fragmentBaseClass", 3) ?: fragment,
             navigation = navigation,
-            navEntryData = navEntryData(declaration, declaration.packageName(), navigation)
+            navEntryData = navEntryData(declaration, declaration.packageName(), navigation),
+            composableParameter = emptyList()
         )
 
         val file = FileGenerator().generate(data)
@@ -151,6 +153,7 @@ public class WhetstoneCodeGenerator : CodeGenerator {
             stateMachine = compose.requireClassArgument("stateMachine", 2),
             navigation = navigation,
             navEntryData = navEntryData(declaration, declaration.packageName(), navigation),
+            composableParameter = emptyList()
         )
 
         val file = FileGenerator().generate(data)

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/WhetstoneCodeGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/WhetstoneCodeGenerator.kt
@@ -22,6 +22,7 @@ import com.squareup.anvil.compiler.api.AnvilContext
 import com.squareup.anvil.compiler.api.CodeGenerator
 import com.squareup.anvil.compiler.api.GeneratedFile
 import com.squareup.anvil.compiler.api.createGeneratedFile
+import com.squareup.anvil.compiler.internal.fqNameOrNull
 import com.squareup.anvil.compiler.internal.reference.AnnotatedReference
 import com.squareup.anvil.compiler.internal.reference.ClassReference
 import com.squareup.anvil.compiler.internal.reference.classAndInnerClassReferences
@@ -223,11 +224,12 @@ public class WhetstoneCodeGenerator : CodeGenerator {
         return parameters
 //            .filter { it.name != "state" && it.name != "sendAction" }
             .map {
+                val fqName = it.typeReference?.fqNameOrNull(module)
                 val name = it.nameAsName?.asString()
                 val type = it.nameAsName?.identifier
 //                val typeFqName = it.type().asClassReference().fqName
-//                ClassName(it.fqName?.packageString() ?: "FqNameIsNull", it.fqName?.shortName()?.asString() ?: "FqNameIsNull2")
-                ClassName(name ?: "NameIsNull", type ?: "TypeIsNull")
+                ClassName(fqName?.packageString() ?: "FqNameIsNull", fqName?.shortName()?.asString() ?: "FqNameIsNull2")
+//                ClassName(name ?: "NameIsNull", type ?: "TypeIsNull")
             }
     }
 }

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/ComponentGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/ComponentGenerator.kt
@@ -92,11 +92,11 @@ internal class ComponentGenerator(
             .build()
         when (data) {
             is ComposeFragmentData -> {
-                properties += data.composableParameter.map { simplePropertySpec(it) }
+                properties += data.composableParameter.map { simplePropertySpec(it.className) }
                 properties += providedValueSetProperty()
             }
             is ComposeScreenData -> {
-                properties += data.composableParameter.map { simplePropertySpec(it) }
+                properties += data.composableParameter.map { simplePropertySpec(it.className) }
                 properties += providedValueSetProperty()
             }
             is RendererFragmentData -> properties += simplePropertySpec(data.factory)

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/ComponentGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/ComponentGenerator.kt
@@ -91,8 +91,14 @@ internal class ComponentGenerator(
             }
             .build()
         when (data) {
-            is ComposeFragmentData -> properties += providedValueSetProperty()
-            is ComposeScreenData -> properties += providedValueSetProperty()
+            is ComposeFragmentData -> {
+                properties += data.composableParameter.map { simplePropertySpec(it) }
+                properties += providedValueSetProperty()
+            }
+            is ComposeScreenData -> {
+                properties += data.composableParameter.map { simplePropertySpec(it) }
+                properties += providedValueSetProperty()
+            }
             is RendererFragmentData -> properties += simplePropertySpec(data.factory)
             is NavEntryData -> {}
         }

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/ComponentGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/ComponentGenerator.kt
@@ -41,7 +41,6 @@ internal const val retainedComponentFactoryCreateName = "create"
 internal val Generator<out BaseData>.retainedComponentFactoryClassName
     get() = retainedComponentClassName.nestedClass("Factory")
 
-internal const val providedValueSetPropertyName = "providedValues"
 internal const val closeableSetPropertyName = "closeables"
 
 internal val Generator<out BaseData>.retainedParentComponentClassName
@@ -93,21 +92,14 @@ internal class ComponentGenerator(
         when (data) {
             is ComposeFragmentData -> {
                 properties += data.composableParameter.map { simplePropertySpec(it.className) }
-                properties += providedValueSetProperty()
             }
             is ComposeScreenData -> {
                 properties += data.composableParameter.map { simplePropertySpec(it.className) }
-                properties += providedValueSetProperty()
             }
             is RendererFragmentData -> properties += simplePropertySpec(data.factory)
             is NavEntryData -> {}
         }
         return properties
-    }
-
-    private fun providedValueSetProperty(): PropertySpec {
-        val type = SET.parameterizedBy(providedValue.parameterizedBy(STAR))
-        return PropertySpec.builder(providedValueSetPropertyName, type).build()
     }
 
     private fun retainedComponentFactory(): TypeSpec {

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/ComposeGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/ComposeGenerator.kt
@@ -5,7 +5,6 @@ import com.freeletics.mad.whetstone.ComposeData
 import com.freeletics.mad.whetstone.codegen.Generator
 import com.freeletics.mad.whetstone.codegen.util.asComposeState
 import com.freeletics.mad.whetstone.codegen.util.composable
-import com.freeletics.mad.whetstone.codegen.util.compositionLocalProvider
 import com.freeletics.mad.whetstone.codegen.util.launch
 import com.freeletics.mad.whetstone.codegen.util.optInAnnotation
 import com.freeletics.mad.whetstone.codegen.util.propertyName
@@ -21,7 +20,6 @@ internal class ComposeGenerator(
 ) : Generator<ComposeData>() {
 
     internal fun generate(): FunSpec {
-//        val composableParameterProperties = data.composableParameter.map { it.className.propertyName }
         val parameterString = data.composableParameter
             .joinToString { "${it.name} = ${it.className.propertyName}" }
             .let { if(it.isNotBlank()) it.plus(", ") else it }
@@ -31,8 +29,6 @@ internal class ComposeGenerator(
             .addAnnotation(optInAnnotation())
             .addModifiers(PRIVATE)
             .addParameter("component", retainedComponentClassName)
-            .addStatement("val providedValues = component.%L", providedValueSetPropertyName)
-            .beginControlFlow("%T(*providedValues.toTypedArray()) {", compositionLocalProvider)
             .apply {
                 data.composableParameter.forEach { parameter ->
                     addStatement("val %L = component.%L", parameter.className.propertyName, parameter.className.propertyName)
@@ -46,7 +42,6 @@ internal class ComposeGenerator(
             .beginControlFlow("%L(%LcurrentState) { action ->", data.baseName, parameterString)
             // dispatch: external method
             .addStatement("scope.%M { stateMachine.dispatch(action) }", launch)
-            .endControlFlow()
             .endControlFlow()
             .endControlFlow()
             .build()

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/ComposeGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/ComposeGenerator.kt
@@ -22,8 +22,8 @@ internal class ComposeGenerator(
 
     internal fun generate(): FunSpec {
         val composableParameterProperties = data.composableParameter.map { it.propertyName }
-        val parameterString = composableParameterProperties.joinToString().apply {
-            if(isNotBlank()) plus(", ")
+        val parameterString = composableParameterProperties.joinToString().let {
+            if(it.isNotBlank()) it.plus(", ") else it
         }
 
         return FunSpec.builder(composableName)

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/ComposeGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/ComposeGenerator.kt
@@ -22,6 +22,9 @@ internal class ComposeGenerator(
 
     internal fun generate(): FunSpec {
         val composableParameterProperties = data.composableParameter.map { it.propertyName }
+        val parameterString = composableParameterProperties.joinToString().apply {
+            if(isNotBlank()) plus(", ")
+        }
 
         return FunSpec.builder(composableName)
             .addAnnotation(composable)
@@ -40,7 +43,7 @@ internal class ComposeGenerator(
             .addStatement("val currentState = state.value")
             .beginControlFlow("if (currentState != null)")
             .addStatement("val scope = %M()", rememberCoroutineScope)
-            .beginControlFlow("%L(%L, currentState) { action ->", data.baseName, composableParameterProperties.joinToString(", "))
+            .beginControlFlow("%L(%LcurrentState) { action ->", data.baseName, parameterString)
             // dispatch: external method
             .addStatement("scope.%M { stateMachine.dispatch(action) }", launch)
             .endControlFlow()

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/ComposeGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/ComposeGenerator.kt
@@ -21,10 +21,10 @@ internal class ComposeGenerator(
 ) : Generator<ComposeData>() {
 
     internal fun generate(): FunSpec {
-        val composableParameterProperties = data.composableParameter.map { it.propertyName }
-        val parameterString = composableParameterProperties.joinToString().let {
-            if(it.isNotBlank()) it.plus(", ") else it
-        }
+//        val composableParameterProperties = data.composableParameter.map { it.className.propertyName }
+        val parameterString = data.composableParameter
+            .joinToString { "${it.name} = ${it.className.propertyName}" }
+            .let { if(it.isNotBlank()) it.plus(", ") else it }
 
         return FunSpec.builder(composableName)
             .addAnnotation(composable)
@@ -34,8 +34,8 @@ internal class ComposeGenerator(
             .addStatement("val providedValues = component.%L", providedValueSetPropertyName)
             .beginControlFlow("%T(*providedValues.toTypedArray()) {", compositionLocalProvider)
             .apply {
-                composableParameterProperties.forEach { propertyName ->
-                    addStatement("val %L = component.%L", propertyName, propertyName)
+                data.composableParameter.forEach { parameter ->
+                    addStatement("val %L = component.%L", parameter.className.propertyName, parameter.className.propertyName)
                 }
             }
             .addStatement("val stateMachine = component.%L", data.stateMachine.propertyName)

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
@@ -81,7 +81,6 @@ internal val navBackStackEntry = ClassName("androidx.navigation", "NavBackStackE
 internal val composable = ClassName("androidx.compose.runtime", "Composable")
 internal val getValue = MemberName("androidx.compose.runtime", "getValue")
 internal val rememberCoroutineScope = MemberName("androidx.compose.runtime", "rememberCoroutineScope")
-internal val compositionLocalProvider = ClassName("androidx.compose.runtime", "CompositionLocalProvider")
 internal val providedValue = ClassName("androidx.compose.runtime", "ProvidedValue")
 internal val composeView = ClassName("androidx.compose.ui.platform", "ComposeView")
 internal val viewCompositionStrategy = ClassName("androidx.compose.ui.platform", "ViewCompositionStrategy")

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/TopLevelFunctionReference.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/TopLevelFunctionReference.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import kotlin.LazyThreadSafetyMode.NONE
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.descriptors.ValueParameterDescriptor
+import org.jetbrains.kotlin.psi.KtCallableDeclaration
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.psiUtil.getValueParameters
 
@@ -64,9 +65,6 @@ internal sealed class TopLevelFunctionReference : AnnotatedReference {
       }
     }
 
-    //    override val parameters: List<ParameterReference.Psi> by lazy(NONE) {
-//      function.valueParameters.map { it.toParameterReference(this.) }
-//    }
     override val parameters: List<KtParameter> by lazy(NONE) {
       val kotlinList = mutableListOf<KtParameter>()
       function.getValueParameters().forEach { kotlinList.add(it) }
@@ -86,15 +84,8 @@ internal sealed class TopLevelFunctionReference : AnnotatedReference {
       }
     }
 
-//    override val parameters: List<ParameterReference.Descriptor> by lazy(NONE) {
-//      function.valueParameters.map { it.toParameterReference(this) }
-//    }
-
     override val parameters: List<KtParameter> by lazy(NONE) {
-      emptyList<KtParameter>()
-//      function.getValueParameters().forEach {
-//        kotlinList.add(it)
-//      }
+      emptyList()
     }
   }
 }
@@ -113,20 +104,6 @@ internal fun FunctionDescriptor.toFunctionReference(
 ): TopLevelFunctionReference.Descriptor {
   return TopLevelFunctionReference.Descriptor(this, module)
 }
-
-//@ExperimentalAnvilApi
-//internal fun KtParameter.toParameterReference(
-//  declaringFunction: TopLevelFunctionReference.Psi
-//): ParameterReference.Psi {
-//  return ParameterReference.Psi(this, declaringFunction)
-//}
-//
-//@ExperimentalAnvilApi
-//internal fun ValueParameterDescriptor.toParameterReference(
-//  declaringFunction: FunctionReference.Descriptor
-//): ParameterReference.Descriptor {
-//  return ParameterReference.Descriptor(this, declaringFunction)
-//}
 
 @ExperimentalAnvilApi
 @Suppress("FunctionName")

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/TopLevelFunctionReference.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/TopLevelFunctionReference.kt
@@ -8,6 +8,7 @@ import com.squareup.anvil.compiler.internal.reference.ClassReference
 import com.squareup.anvil.compiler.internal.reference.FunctionReference
 import com.squareup.anvil.compiler.internal.reference.ParameterReference
 import com.squareup.anvil.compiler.internal.reference.toAnnotationReference
+import com.squareup.anvil.compiler.internal.reference.toFunctionReference
 import com.squareup.anvil.compiler.internal.requireFqName
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.name.FqName
@@ -16,6 +17,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import kotlin.LazyThreadSafetyMode.NONE
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.descriptors.ValueParameterDescriptor
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.psiUtil.getValueParameters
 
@@ -33,7 +35,7 @@ internal sealed class TopLevelFunctionReference : AnnotatedReference {
 
   abstract val module: ModuleDescriptor
 
-  abstract val parameters: List<ParameterReference>
+  abstract val parameters: List<KtParameter>
 
   override fun toString(): String = "$fqName()"
 
@@ -62,8 +64,13 @@ internal sealed class TopLevelFunctionReference : AnnotatedReference {
       }
     }
 
-    override val parameters: List<ParameterReference.Psi> by lazy(NONE) {
-      function.valueParameters.map { it.toParameterReference(this) }
+    //    override val parameters: List<ParameterReference.Psi> by lazy(NONE) {
+//      function.valueParameters.map { it.toParameterReference(this.) }
+//    }
+    override val parameters: List<KtParameter> by lazy(NONE) {
+      val kotlinList = mutableListOf<KtParameter>()
+      function.getValueParameters().forEach { kotlinList.add(it) }
+      kotlinList
     }
   }
 
@@ -79,8 +86,15 @@ internal sealed class TopLevelFunctionReference : AnnotatedReference {
       }
     }
 
-    override val parameters: List<ParameterReference.Descriptor> by lazy(NONE) {
-      function.valueParameters.map { it.toParameterReference(this) }
+//    override val parameters: List<ParameterReference.Descriptor> by lazy(NONE) {
+//      function.valueParameters.map { it.toParameterReference(this) }
+//    }
+
+    override val parameters: List<KtParameter> by lazy(NONE) {
+      emptyList<KtParameter>()
+//      function.getValueParameters().forEach {
+//        kotlinList.add(it)
+//      }
     }
   }
 }
@@ -99,6 +113,20 @@ internal fun FunctionDescriptor.toFunctionReference(
 ): TopLevelFunctionReference.Descriptor {
   return TopLevelFunctionReference.Descriptor(this, module)
 }
+
+//@ExperimentalAnvilApi
+//internal fun KtParameter.toParameterReference(
+//  declaringFunction: TopLevelFunctionReference.Psi
+//): ParameterReference.Psi {
+//  return ParameterReference.Psi(this, declaringFunction)
+//}
+//
+//@ExperimentalAnvilApi
+//internal fun ValueParameterDescriptor.toParameterReference(
+//  declaringFunction: FunctionReference.Descriptor
+//): ParameterReference.Descriptor {
+//  return ParameterReference.Descriptor(this, declaringFunction)
+//}
 
 @ExperimentalAnvilApi
 @Suppress("FunctionName")

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/TopLevelFunctionReference.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/TopLevelFunctionReference.kt
@@ -6,6 +6,7 @@ import com.squareup.anvil.compiler.internal.reference.AnnotatedReference
 import com.squareup.anvil.compiler.internal.reference.AnnotationReference
 import com.squareup.anvil.compiler.internal.reference.ClassReference
 import com.squareup.anvil.compiler.internal.reference.FunctionReference
+import com.squareup.anvil.compiler.internal.reference.ParameterReference
 import com.squareup.anvil.compiler.internal.reference.toAnnotationReference
 import com.squareup.anvil.compiler.internal.requireFqName
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
@@ -15,6 +16,8 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import kotlin.LazyThreadSafetyMode.NONE
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.psi.KtParameter
+import org.jetbrains.kotlin.psi.psiUtil.getValueParameters
 
 /**
  * Simplified of [FunctionReference] from Anvil to support top level functions.
@@ -29,6 +32,8 @@ internal sealed class TopLevelFunctionReference : AnnotatedReference {
   val name: String get() = fqName.shortName().asString()
 
   abstract val module: ModuleDescriptor
+
+  abstract val parameters: List<ParameterReference>
 
   override fun toString(): String = "$fqName()"
 
@@ -56,6 +61,10 @@ internal sealed class TopLevelFunctionReference : AnnotatedReference {
         it.toAnnotationReference(declaringClass = null, module)
       }
     }
+
+    override val parameters: List<ParameterReference.Psi> by lazy(NONE) {
+      function.valueParameters.map { it.toParameterReference(this) }
+    }
   }
 
   class Descriptor internal constructor(
@@ -68,6 +77,10 @@ internal sealed class TopLevelFunctionReference : AnnotatedReference {
       function.annotations.map {
         it.toAnnotationReference(declaringClass = null, module)
       }
+    }
+
+    override val parameters: List<ParameterReference.Descriptor> by lazy(NONE) {
+      function.valueParameters.map { it.toParameterReference(this) }
     }
   }
 }

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
@@ -25,7 +25,7 @@ internal class FileGeneratorTestCompose {
         navEntryData = null,
         composableParameter = listOf(
             ClassName("com.test", "TestClass"),
-            ClassName("com.test", "TestClass2"),
+            ClassName("com.other", "TestClass2"),
         )
     )
 
@@ -55,6 +55,7 @@ internal class FileGeneratorTestCompose {
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
+            import com.other.TestClass2
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
             import com.test.parent.TestParentScope
@@ -174,6 +175,7 @@ internal class FileGeneratorTestCompose {
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
+            import com.other.TestClass2
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
             import com.test.destination.TestDestinationScope
@@ -301,6 +303,7 @@ internal class FileGeneratorTestCompose {
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
+            import com.other.TestClass2
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
             import com.test.destination.TestDestinationScope
@@ -453,6 +456,7 @@ internal class FileGeneratorTestCompose {
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.`internal`.viewModel
             import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
+            import com.other.TestClass2
             import com.squareup.anvil.annotations.ContributesMultibinding
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
@@ -24,16 +24,7 @@ internal class FileGeneratorTestCompose {
         stateMachine = ClassName("com.test", "TestStateMachine"),
         navigation = null,
         navEntryData = null,
-        composableParameter = listOf(
-            ComposableParameter(
-                name = "testClass",
-                className = ClassName("com.test", "TestClass"),
-            ),
-            ComposableParameter(
-                name = "test",
-                className = ClassName("com.other", "TestClass2"),
-            )
-        )
+        composableParameter = emptyList()
     )
 
     private val navEntryData = NavEntryData(
@@ -46,6 +37,579 @@ internal class FileGeneratorTestCompose {
     @Test
     fun `generates code for ComposeScreenData`() {
         val actual = FileGenerator().generate(data).toString()
+
+        val expected = """
+            package com.test
+
+            import android.os.Bundle
+            import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.rememberCoroutineScope
+            import androidx.lifecycle.SavedStateHandle
+            import androidx.lifecycle.ViewModel
+            import com.freeletics.mad.whetstone.ScopeTo
+            import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
+            import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
+            import com.freeletics.mad.whetstone.`internal`.asComposeState
+            import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
+            import com.squareup.anvil.annotations.ContributesSubcomponent
+            import com.squareup.anvil.annotations.ContributesTo
+            import com.test.parent.TestParentScope
+            import dagger.BindsInstance
+            import dagger.Module
+            import dagger.multibindings.Multibinds
+            import java.io.Closeable
+            import kotlin.OptIn
+            import kotlin.Unit
+            import kotlin.collections.Set
+            import kotlinx.coroutines.launch
+
+            @OptIn(InternalWhetstoneApi::class)
+            @ScopeTo(TestScreen::class)
+            @ContributesSubcomponent(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+              modules = [ComposeProviderValueModule::class],
+            )
+            public interface WhetstoneTestComponent {
+              public val testStateMachine: TestStateMachine
+    
+              public val closeables: Set<Closeable>
+
+              @ContributesSubcomponent.Factory
+              public interface Factory {
+                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
+                    arguments: Bundle): WhetstoneTestComponent
+              }
+
+              @ContributesTo(TestParentScope::class)
+              public interface ParentComponent {
+                public fun whetstoneTestComponentFactory(): Factory
+              }
+            }
+
+            @Module
+            @ContributesTo(TestScreen::class)
+            public interface WhetstoneTestModule {
+              @Multibinds
+              public fun bindCloseables(): Set<Closeable>
+            }
+
+            @InternalWhetstoneApi
+            internal class WhetstoneTestViewModel(
+              parentComponent: WhetstoneTestComponent.ParentComponent,
+              savedStateHandle: SavedStateHandle,
+              arguments: Bundle,
+            ) : ViewModel() {
+              public val component: WhetstoneTestComponent =
+                  parentComponent.whetstoneTestComponentFactory().create(savedStateHandle, arguments)
+
+              public override fun onCleared(): Unit {
+                component.closeables.forEach {
+                  it.close()
+                }
+              }
+            }
+
+            @Composable
+            @OptIn(InternalWhetstoneApi::class)
+            public fun WhetstoneTest(arguments: Bundle): Unit {
+              val viewModel = rememberViewModel(TestParentScope::class, arguments, ::WhetstoneTestViewModel)
+              val component = viewModel.component
+
+              WhetstoneTest(component)
+            }
+            
+            @Composable
+            @OptIn(InternalWhetstoneApi::class)
+            private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
+              val stateMachine = component.testStateMachine
+              val state = stateMachine.asComposeState()
+              val currentState = state.value
+              if (currentState != null) {
+                val scope = rememberCoroutineScope()
+                Test(
+                  state = currentState,
+                  sendAction = { scope.launch { stateMachine.dispatch(action) } },
+                )
+              }
+            }
+            
+        """.trimIndent()
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `generates code for ComposeScreenData with navigation`() {
+        val withNavigation = data.copy(navigation = navigation)
+        val actual = FileGenerator().generate(withNavigation).toString()
+
+        val expected = """
+            package com.test
+
+            import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.rememberCoroutineScope
+            import androidx.lifecycle.SavedStateHandle
+            import androidx.lifecycle.ViewModel
+            import com.freeletics.mad.navigator.NavEventNavigator
+            import com.freeletics.mad.navigator.compose.NavigationSetup
+            import com.freeletics.mad.whetstone.ScopeTo
+            import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
+            import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
+            import com.freeletics.mad.whetstone.`internal`.asComposeState
+            import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
+            import com.squareup.anvil.annotations.ContributesSubcomponent
+            import com.squareup.anvil.annotations.ContributesTo
+            import com.test.destination.TestDestinationScope
+            import com.test.parent.TestParentScope
+            import dagger.BindsInstance
+            import dagger.Module
+            import dagger.multibindings.Multibinds
+            import java.io.Closeable
+            import kotlin.OptIn
+            import kotlin.Unit
+            import kotlin.collections.Set
+            import kotlinx.coroutines.launch
+
+            @OptIn(InternalWhetstoneApi::class)
+            @ScopeTo(TestScreen::class)
+            @ContributesSubcomponent(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+              modules = [ComposeProviderValueModule::class],
+            )
+            public interface WhetstoneTestComponent {
+              public val testStateMachine: TestStateMachine
+
+              public val navEventNavigator: NavEventNavigator
+    
+              public val closeables: Set<Closeable>
+
+              @ContributesSubcomponent.Factory
+              public interface Factory {
+                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
+                    testRoute: TestRoute): WhetstoneTestComponent
+              }
+
+              @ContributesTo(TestParentScope::class)
+              public interface ParentComponent {
+                public fun whetstoneTestComponentFactory(): Factory
+              }
+            }
+
+            @Module
+            @ContributesTo(TestScreen::class)
+            public interface WhetstoneTestModule {
+              @Multibinds
+              public fun bindCloseables(): Set<Closeable>
+            }
+
+            @InternalWhetstoneApi
+            internal class WhetstoneTestViewModel(
+              parentComponent: WhetstoneTestComponent.ParentComponent,
+              savedStateHandle: SavedStateHandle,
+              testRoute: TestRoute,
+            ) : ViewModel() {
+              public val component: WhetstoneTestComponent =
+                  parentComponent.whetstoneTestComponentFactory().create(savedStateHandle, testRoute)
+
+              public override fun onCleared(): Unit {
+                component.closeables.forEach {
+                  it.close()
+                }
+              }
+            }
+
+            @Composable
+            @OptIn(InternalWhetstoneApi::class)
+            public fun WhetstoneTest(testRoute: TestRoute): Unit {
+              val viewModel = rememberViewModel(TestParentScope::class, TestDestinationScope::class, testRoute,
+                  ::WhetstoneTestViewModel)
+              val component = viewModel.component
+
+              NavigationSetup(component.navEventNavigator)
+
+              WhetstoneTest(component)
+            }
+            
+            @Composable
+            @OptIn(InternalWhetstoneApi::class)
+            private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
+              val stateMachine = component.testStateMachine
+              val state = stateMachine.asComposeState()
+              val currentState = state.value
+              if (currentState != null) {
+                val scope = rememberCoroutineScope()
+                Test(
+                  state = currentState,
+                  sendAction = { scope.launch { stateMachine.dispatch(action) } },
+                )
+              }
+            }
+            
+        """.trimIndent()
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `generates code for ComposeScreenData with navigation and destination`() {
+        val withDestination = data.copy(navigation = navigation.copy(destinationType = "SCREEN"))
+        val actual = FileGenerator().generate(withDestination).toString()
+
+        val expected = """
+            package com.test
+
+            import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.rememberCoroutineScope
+            import androidx.lifecycle.SavedStateHandle
+            import androidx.lifecycle.ViewModel
+            import com.freeletics.mad.navigator.NavEventNavigator
+            import com.freeletics.mad.navigator.compose.NavDestination
+            import com.freeletics.mad.navigator.compose.NavigationSetup
+            import com.freeletics.mad.navigator.compose.ScreenDestination
+            import com.freeletics.mad.whetstone.ScopeTo
+            import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
+            import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
+            import com.freeletics.mad.whetstone.`internal`.asComposeState
+            import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
+            import com.squareup.anvil.annotations.ContributesSubcomponent
+            import com.squareup.anvil.annotations.ContributesTo
+            import com.test.destination.TestDestinationScope
+            import com.test.parent.TestParentScope
+            import dagger.BindsInstance
+            import dagger.Module
+            import dagger.Provides
+            import dagger.multibindings.IntoSet
+            import dagger.multibindings.Multibinds
+            import java.io.Closeable
+            import kotlin.OptIn
+            import kotlin.Unit
+            import kotlin.collections.Set
+            import kotlinx.coroutines.launch
+
+            @OptIn(InternalWhetstoneApi::class)
+            @ScopeTo(TestScreen::class)
+            @ContributesSubcomponent(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+              modules = [ComposeProviderValueModule::class],
+            )
+            public interface WhetstoneTestComponent {
+              public val testStateMachine: TestStateMachine
+
+              public val navEventNavigator: NavEventNavigator
+    
+              public val closeables: Set<Closeable>
+
+              @ContributesSubcomponent.Factory
+              public interface Factory {
+                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
+                    testRoute: TestRoute): WhetstoneTestComponent
+              }
+
+              @ContributesTo(TestParentScope::class)
+              public interface ParentComponent {
+                public fun whetstoneTestComponentFactory(): Factory
+              }
+            }
+
+            @Module
+            @ContributesTo(TestScreen::class)
+            public interface WhetstoneTestModule {
+              @Multibinds
+              public fun bindCloseables(): Set<Closeable>
+            }
+
+            @InternalWhetstoneApi
+            internal class WhetstoneTestViewModel(
+              parentComponent: WhetstoneTestComponent.ParentComponent,
+              savedStateHandle: SavedStateHandle,
+              testRoute: TestRoute,
+            ) : ViewModel() {
+              public val component: WhetstoneTestComponent =
+                  parentComponent.whetstoneTestComponentFactory().create(savedStateHandle, testRoute)
+
+              public override fun onCleared(): Unit {
+                component.closeables.forEach {
+                  it.close()
+                }
+              }
+            }
+
+            @Composable
+            @OptIn(InternalWhetstoneApi::class)
+            public fun WhetstoneTest(testRoute: TestRoute): Unit {
+              val viewModel = rememberViewModel(TestParentScope::class, TestDestinationScope::class, testRoute,
+                  ::WhetstoneTestViewModel)
+              val component = viewModel.component
+
+              NavigationSetup(component.navEventNavigator)
+
+              WhetstoneTest(component)
+            }
+            
+            @Composable
+            @OptIn(InternalWhetstoneApi::class)
+            private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
+              val stateMachine = component.testStateMachine
+              val state = stateMachine.asComposeState()
+              val currentState = state.value
+              if (currentState != null) {
+                val scope = rememberCoroutineScope()
+                Test(
+                  state = currentState,
+                  sendAction = { scope.launch { stateMachine.dispatch(action) } },
+                )
+              }
+            }
+            
+            @Module
+            @ContributesTo(TestDestinationScope::class)
+            public object WhetstoneTestNavDestinationModule {
+              @Provides
+              @IntoSet
+              public fun provideNavDestination(): NavDestination = ScreenDestination<TestRoute> {
+                WhetstoneTest(it)
+              }
+            }
+            
+        """.trimIndent()
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `generates code for ComposeScreenData with navigation, destination and navEntry`() {
+        val withDestination = data.copy(
+            navigation = navigation.copy(destinationType = "SCREEN"),
+            navEntryData = navEntryData
+        )
+        val actual = FileGenerator().generate(withDestination).toString()
+
+        val expected = """
+            package com.test
+
+            import android.content.Context
+            import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.rememberCoroutineScope
+            import androidx.lifecycle.SavedStateHandle
+            import androidx.lifecycle.ViewModel
+            import androidx.navigation.NavBackStackEntry
+            import com.freeletics.mad.navigator.NavEventNavigator
+            import com.freeletics.mad.navigator.`internal`.InternalNavigatorApi
+            import com.freeletics.mad.navigator.`internal`.destinationId
+            import com.freeletics.mad.navigator.`internal`.requireRoute
+            import com.freeletics.mad.navigator.compose.NavDestination
+            import com.freeletics.mad.navigator.compose.NavigationSetup
+            import com.freeletics.mad.navigator.compose.ScreenDestination
+            import com.freeletics.mad.whetstone.NavEntry
+            import com.freeletics.mad.whetstone.ScopeTo
+            import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
+            import com.freeletics.mad.whetstone.`internal`.DestinationComponent
+            import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
+            import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetter
+            import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetterKey
+            import com.freeletics.mad.whetstone.`internal`.asComposeState
+            import com.freeletics.mad.whetstone.`internal`.viewModel
+            import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
+            import com.squareup.anvil.annotations.ContributesMultibinding
+            import com.squareup.anvil.annotations.ContributesSubcomponent
+            import com.squareup.anvil.annotations.ContributesTo
+            import com.test.destination.TestDestinationScope
+            import com.test.parent.TestParentScope
+            import dagger.BindsInstance
+            import dagger.Module
+            import dagger.Provides
+            import dagger.multibindings.IntoSet
+            import dagger.multibindings.Multibinds
+            import java.io.Closeable
+            import javax.inject.Inject
+            import kotlin.Any
+            import kotlin.Int
+            import kotlin.OptIn
+            import kotlin.Unit
+            import kotlin.collections.Set
+            import kotlinx.coroutines.launch
+
+            @OptIn(InternalWhetstoneApi::class)
+            @ScopeTo(TestScreen::class)
+            @ContributesSubcomponent(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+              modules = [ComposeProviderValueModule::class],
+            )
+            public interface WhetstoneTestComponent {
+              public val testStateMachine: TestStateMachine
+
+              public val navEventNavigator: NavEventNavigator
+
+              public val closeables: Set<Closeable>
+
+              @ContributesSubcomponent.Factory
+              public interface Factory {
+                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
+                    testRoute: TestRoute): WhetstoneTestComponent
+              }
+
+              @ContributesTo(TestParentScope::class)
+              public interface ParentComponent {
+                public fun whetstoneTestComponentFactory(): Factory
+              }
+            }
+
+            @Module
+            @ContributesTo(TestScreen::class)
+            public interface WhetstoneTestModule {
+              @Multibinds
+              public fun bindCloseables(): Set<Closeable>
+            }
+
+            @InternalWhetstoneApi
+            internal class WhetstoneTestViewModel(
+              parentComponent: WhetstoneTestComponent.ParentComponent,
+              savedStateHandle: SavedStateHandle,
+              testRoute: TestRoute,
+            ) : ViewModel() {
+              public val component: WhetstoneTestComponent =
+                  parentComponent.whetstoneTestComponentFactory().create(savedStateHandle, testRoute)
+
+              public override fun onCleared(): Unit {
+                component.closeables.forEach {
+                  it.close()
+                }
+              }
+            }
+
+            @Composable
+            @OptIn(InternalWhetstoneApi::class)
+            public fun WhetstoneTest(testRoute: TestRoute): Unit {
+              val viewModel = rememberViewModel(TestParentScope::class, TestDestinationScope::class, testRoute,
+                  ::WhetstoneTestViewModel)
+              val component = viewModel.component
+
+              NavigationSetup(component.navEventNavigator)
+
+              WhetstoneTest(component)
+            }
+
+            @Composable
+            @OptIn(InternalWhetstoneApi::class)
+            private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
+              val stateMachine = component.testStateMachine
+              val state = stateMachine.asComposeState()
+              val currentState = state.value
+              if (currentState != null) {
+                val scope = rememberCoroutineScope()
+                Test(
+                  state = currentState,
+                  sendAction = { scope.launch { stateMachine.dispatch(action) } },
+                )
+              }
+            }
+
+            @Module
+            @ContributesTo(TestDestinationScope::class)
+            public object WhetstoneTestNavDestinationModule {
+              @Provides
+              @IntoSet
+              public fun provideNavDestination(): NavDestination = ScreenDestination<TestRoute> {
+                WhetstoneTest(it)
+              }
+            }
+
+            @OptIn(InternalWhetstoneApi::class)
+            @ScopeTo(TestScreen::class)
+            @ContributesSubcomponent(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+            )
+            public interface WhetstoneTestScreenNavEntryComponent {
+              @get:NavEntry(TestScreen::class)
+              public val closeables: Set<Closeable>
+
+              @ContributesSubcomponent.Factory
+              public interface Factory {
+                public fun create(@BindsInstance @NavEntry(TestScreen::class)
+                    savedStateHandle: SavedStateHandle, @BindsInstance @NavEntry(TestScreen::class)
+                    testRoute: TestRoute): WhetstoneTestScreenNavEntryComponent
+              }
+
+              @ContributesTo(TestParentScope::class)
+              public interface ParentComponent {
+                public fun whetstoneTestScreenNavEntryComponentFactory(): Factory
+              }
+            }
+
+            @Module
+            @ContributesTo(TestScreen::class)
+            public interface WhetstoneTestScreenNavEntryModule {
+              @Multibinds
+              @NavEntry(TestScreen::class)
+              public fun bindCloseables(): Set<Closeable>
+            }
+
+            @InternalWhetstoneApi
+            internal class WhetstoneTestScreenNavEntryViewModel(
+              parentComponent: WhetstoneTestScreenNavEntryComponent.ParentComponent,
+              savedStateHandle: SavedStateHandle,
+              testRoute: TestRoute,
+            ) : ViewModel() {
+              public val component: WhetstoneTestScreenNavEntryComponent =
+                  parentComponent.whetstoneTestScreenNavEntryComponentFactory().create(savedStateHandle,
+                  testRoute)
+
+              public override fun onCleared(): Unit {
+                component.closeables.forEach {
+                  it.close()
+                }
+              }
+            }
+
+            @OptIn(InternalWhetstoneApi::class)
+            @NavEntryComponentGetterKey(TestScreen::class)
+            @ContributesMultibinding(
+              TestDestinationScope::class,
+              NavEntryComponentGetter::class,
+            )
+            public class TestScreenNavEntryComponentGetter @Inject constructor() : NavEntryComponentGetter {
+              @OptIn(InternalWhetstoneApi::class, InternalNavigatorApi::class)
+              public override fun retrieve(findEntry: (Int) -> NavBackStackEntry, context: Context): Any {
+                val entry = findEntry(TestRoute::class.destinationId())
+                val route: TestRoute = entry.arguments.requireRoute()
+                val viewModel = viewModel(entry, context, TestParentScope::class, TestDestinationScope::class,
+                    route, findEntry, ::WhetstoneTestScreenNavEntryViewModel)
+                return viewModel.component
+              }
+            }
+
+            @ContributesTo(TestDestinationScope::class)
+            @OptIn(InternalWhetstoneApi::class)
+            public interface WhetstoneTestScreenNavEntryDestinationComponent : DestinationComponent
+
+        """.trimIndent()
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `generates code for ComposeScreenData with Composable Dependencies`() {
+        val actual = FileGenerator()
+            .generate(
+                data.copy(
+                    composableParameter = listOf(
+                        ComposableParameter(
+                            name = "testClass",
+                            className = ClassName("com.test", "TestClass"),
+                        ),
+                        ComposableParameter(
+                            name = "test",
+                            className = ClassName("com.other", "TestClass2"),
+                        )
+                    )
+                )
+            )
+            .toString()
 
         val expected = """
             package com.test
@@ -143,483 +707,15 @@ internal class FileGeneratorTestCompose {
               val currentState = state.value
               if (currentState != null) {
                 val scope = rememberCoroutineScope()
-                Test(testClass = testClass, test = testClass2, currentState) { action ->
-                  scope.launch { stateMachine.dispatch(action) }
-                }
+                Test(
+                  testClass = testClass,
+                  test = testClass2,
+                  state = currentState,
+                  sendAction = { scope.launch { stateMachine.dispatch(action) } },
+                )
               }
             }
             
-        """.trimIndent()
-
-        assertThat(actual).isEqualTo(expected)
-    }
-
-    @Test
-    fun `generates code for ComposeScreenData with navigation`() {
-        val withNavigation = data.copy(navigation = navigation)
-        val actual = FileGenerator().generate(withNavigation).toString()
-
-        val expected = """
-            package com.test
-
-            import androidx.compose.runtime.Composable
-            import androidx.compose.runtime.rememberCoroutineScope
-            import androidx.lifecycle.SavedStateHandle
-            import androidx.lifecycle.ViewModel
-            import com.freeletics.mad.navigator.NavEventNavigator
-            import com.freeletics.mad.navigator.compose.NavigationSetup
-            import com.freeletics.mad.whetstone.ScopeTo
-            import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
-            import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
-            import com.freeletics.mad.whetstone.`internal`.asComposeState
-            import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
-            import com.other.TestClass2
-            import com.squareup.anvil.annotations.ContributesSubcomponent
-            import com.squareup.anvil.annotations.ContributesTo
-            import com.test.destination.TestDestinationScope
-            import com.test.parent.TestParentScope
-            import dagger.BindsInstance
-            import dagger.Module
-            import dagger.multibindings.Multibinds
-            import java.io.Closeable
-            import kotlin.OptIn
-            import kotlin.Unit
-            import kotlin.collections.Set
-            import kotlinx.coroutines.launch
-
-            @OptIn(InternalWhetstoneApi::class)
-            @ScopeTo(TestScreen::class)
-            @ContributesSubcomponent(
-              scope = TestScreen::class,
-              parentScope = TestParentScope::class,
-              modules = [ComposeProviderValueModule::class],
-            )
-            public interface WhetstoneTestComponent {
-              public val testStateMachine: TestStateMachine
-
-              public val navEventNavigator: NavEventNavigator
-    
-              public val closeables: Set<Closeable>
-
-              public val testClass: TestClass
-
-              public val testClass2: TestClass2
-
-              @ContributesSubcomponent.Factory
-              public interface Factory {
-                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
-                    testRoute: TestRoute): WhetstoneTestComponent
-              }
-
-              @ContributesTo(TestParentScope::class)
-              public interface ParentComponent {
-                public fun whetstoneTestComponentFactory(): Factory
-              }
-            }
-
-            @Module
-            @ContributesTo(TestScreen::class)
-            public interface WhetstoneTestModule {
-              @Multibinds
-              public fun bindCloseables(): Set<Closeable>
-            }
-
-            @InternalWhetstoneApi
-            internal class WhetstoneTestViewModel(
-              parentComponent: WhetstoneTestComponent.ParentComponent,
-              savedStateHandle: SavedStateHandle,
-              testRoute: TestRoute,
-            ) : ViewModel() {
-              public val component: WhetstoneTestComponent =
-                  parentComponent.whetstoneTestComponentFactory().create(savedStateHandle, testRoute)
-
-              public override fun onCleared(): Unit {
-                component.closeables.forEach {
-                  it.close()
-                }
-              }
-            }
-
-            @Composable
-            @OptIn(InternalWhetstoneApi::class)
-            public fun WhetstoneTest(testRoute: TestRoute): Unit {
-              val viewModel = rememberViewModel(TestParentScope::class, TestDestinationScope::class, testRoute,
-                  ::WhetstoneTestViewModel)
-              val component = viewModel.component
-
-              NavigationSetup(component.navEventNavigator)
-
-              WhetstoneTest(component)
-            }
-            
-            @Composable
-            @OptIn(InternalWhetstoneApi::class)
-            private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
-              val testClass = component.testClass
-              val testClass2 = component.testClass2
-              val stateMachine = component.testStateMachine
-              val state = stateMachine.asComposeState()
-              val currentState = state.value
-              if (currentState != null) {
-                val scope = rememberCoroutineScope()
-                Test(testClass = testClass, test = testClass2, currentState) { action ->
-                  scope.launch { stateMachine.dispatch(action) }
-                }
-              }
-            }
-            
-        """.trimIndent()
-
-        assertThat(actual).isEqualTo(expected)
-    }
-
-    @Test
-    fun `generates code for ComposeScreenData with navigation and destination`() {
-        val withDestination = data.copy(navigation = navigation.copy(destinationType = "SCREEN"))
-        val actual = FileGenerator().generate(withDestination).toString()
-
-        val expected = """
-            package com.test
-
-            import androidx.compose.runtime.Composable
-            import androidx.compose.runtime.rememberCoroutineScope
-            import androidx.lifecycle.SavedStateHandle
-            import androidx.lifecycle.ViewModel
-            import com.freeletics.mad.navigator.NavEventNavigator
-            import com.freeletics.mad.navigator.compose.NavDestination
-            import com.freeletics.mad.navigator.compose.NavigationSetup
-            import com.freeletics.mad.navigator.compose.ScreenDestination
-            import com.freeletics.mad.whetstone.ScopeTo
-            import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
-            import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
-            import com.freeletics.mad.whetstone.`internal`.asComposeState
-            import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
-            import com.other.TestClass2
-            import com.squareup.anvil.annotations.ContributesSubcomponent
-            import com.squareup.anvil.annotations.ContributesTo
-            import com.test.destination.TestDestinationScope
-            import com.test.parent.TestParentScope
-            import dagger.BindsInstance
-            import dagger.Module
-            import dagger.Provides
-            import dagger.multibindings.IntoSet
-            import dagger.multibindings.Multibinds
-            import java.io.Closeable
-            import kotlin.OptIn
-            import kotlin.Unit
-            import kotlin.collections.Set
-            import kotlinx.coroutines.launch
-
-            @OptIn(InternalWhetstoneApi::class)
-            @ScopeTo(TestScreen::class)
-            @ContributesSubcomponent(
-              scope = TestScreen::class,
-              parentScope = TestParentScope::class,
-              modules = [ComposeProviderValueModule::class],
-            )
-            public interface WhetstoneTestComponent {
-              public val testStateMachine: TestStateMachine
-
-              public val navEventNavigator: NavEventNavigator
-    
-              public val closeables: Set<Closeable>
-
-              public val testClass: TestClass
-
-              public val testClass2: TestClass2
-
-              @ContributesSubcomponent.Factory
-              public interface Factory {
-                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
-                    testRoute: TestRoute): WhetstoneTestComponent
-              }
-
-              @ContributesTo(TestParentScope::class)
-              public interface ParentComponent {
-                public fun whetstoneTestComponentFactory(): Factory
-              }
-            }
-
-            @Module
-            @ContributesTo(TestScreen::class)
-            public interface WhetstoneTestModule {
-              @Multibinds
-              public fun bindCloseables(): Set<Closeable>
-            }
-
-            @InternalWhetstoneApi
-            internal class WhetstoneTestViewModel(
-              parentComponent: WhetstoneTestComponent.ParentComponent,
-              savedStateHandle: SavedStateHandle,
-              testRoute: TestRoute,
-            ) : ViewModel() {
-              public val component: WhetstoneTestComponent =
-                  parentComponent.whetstoneTestComponentFactory().create(savedStateHandle, testRoute)
-
-              public override fun onCleared(): Unit {
-                component.closeables.forEach {
-                  it.close()
-                }
-              }
-            }
-
-            @Composable
-            @OptIn(InternalWhetstoneApi::class)
-            public fun WhetstoneTest(testRoute: TestRoute): Unit {
-              val viewModel = rememberViewModel(TestParentScope::class, TestDestinationScope::class, testRoute,
-                  ::WhetstoneTestViewModel)
-              val component = viewModel.component
-
-              NavigationSetup(component.navEventNavigator)
-
-              WhetstoneTest(component)
-            }
-            
-            @Composable
-            @OptIn(InternalWhetstoneApi::class)
-            private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
-              val testClass = component.testClass
-              val testClass2 = component.testClass2
-              val stateMachine = component.testStateMachine
-              val state = stateMachine.asComposeState()
-              val currentState = state.value
-              if (currentState != null) {
-                val scope = rememberCoroutineScope()
-                Test(testClass = testClass, test = testClass2, currentState) { action ->
-                  scope.launch { stateMachine.dispatch(action) }
-                }
-              }
-            }
-            
-            @Module
-            @ContributesTo(TestDestinationScope::class)
-            public object WhetstoneTestNavDestinationModule {
-              @Provides
-              @IntoSet
-              public fun provideNavDestination(): NavDestination = ScreenDestination<TestRoute> {
-                WhetstoneTest(it)
-              }
-            }
-            
-        """.trimIndent()
-
-        assertThat(actual).isEqualTo(expected)
-    }
-
-    @Test
-    fun `generates code for ComposeScreenData with navigation, destination and navEntry`() {
-        val withDestination = data.copy(
-            navigation = navigation.copy(destinationType = "SCREEN"),
-            navEntryData = navEntryData
-        )
-        val actual = FileGenerator().generate(withDestination).toString()
-
-        val expected = """
-            package com.test
-
-            import android.content.Context
-            import androidx.compose.runtime.Composable
-            import androidx.compose.runtime.rememberCoroutineScope
-            import androidx.lifecycle.SavedStateHandle
-            import androidx.lifecycle.ViewModel
-            import androidx.navigation.NavBackStackEntry
-            import com.freeletics.mad.navigator.NavEventNavigator
-            import com.freeletics.mad.navigator.`internal`.InternalNavigatorApi
-            import com.freeletics.mad.navigator.`internal`.destinationId
-            import com.freeletics.mad.navigator.`internal`.requireRoute
-            import com.freeletics.mad.navigator.compose.NavDestination
-            import com.freeletics.mad.navigator.compose.NavigationSetup
-            import com.freeletics.mad.navigator.compose.ScreenDestination
-            import com.freeletics.mad.whetstone.NavEntry
-            import com.freeletics.mad.whetstone.ScopeTo
-            import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
-            import com.freeletics.mad.whetstone.`internal`.DestinationComponent
-            import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
-            import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetter
-            import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetterKey
-            import com.freeletics.mad.whetstone.`internal`.asComposeState
-            import com.freeletics.mad.whetstone.`internal`.viewModel
-            import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
-            import com.other.TestClass2
-            import com.squareup.anvil.annotations.ContributesMultibinding
-            import com.squareup.anvil.annotations.ContributesSubcomponent
-            import com.squareup.anvil.annotations.ContributesTo
-            import com.test.destination.TestDestinationScope
-            import com.test.parent.TestParentScope
-            import dagger.BindsInstance
-            import dagger.Module
-            import dagger.Provides
-            import dagger.multibindings.IntoSet
-            import dagger.multibindings.Multibinds
-            import java.io.Closeable
-            import javax.inject.Inject
-            import kotlin.Any
-            import kotlin.Int
-            import kotlin.OptIn
-            import kotlin.Unit
-            import kotlin.collections.Set
-            import kotlinx.coroutines.launch
-
-            @OptIn(InternalWhetstoneApi::class)
-            @ScopeTo(TestScreen::class)
-            @ContributesSubcomponent(
-              scope = TestScreen::class,
-              parentScope = TestParentScope::class,
-              modules = [ComposeProviderValueModule::class],
-            )
-            public interface WhetstoneTestComponent {
-              public val testStateMachine: TestStateMachine
-
-              public val navEventNavigator: NavEventNavigator
-
-              public val closeables: Set<Closeable>
-
-              public val testClass: TestClass
-
-              public val testClass2: TestClass2
-
-              @ContributesSubcomponent.Factory
-              public interface Factory {
-                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
-                    testRoute: TestRoute): WhetstoneTestComponent
-              }
-
-              @ContributesTo(TestParentScope::class)
-              public interface ParentComponent {
-                public fun whetstoneTestComponentFactory(): Factory
-              }
-            }
-
-            @Module
-            @ContributesTo(TestScreen::class)
-            public interface WhetstoneTestModule {
-              @Multibinds
-              public fun bindCloseables(): Set<Closeable>
-            }
-
-            @InternalWhetstoneApi
-            internal class WhetstoneTestViewModel(
-              parentComponent: WhetstoneTestComponent.ParentComponent,
-              savedStateHandle: SavedStateHandle,
-              testRoute: TestRoute,
-            ) : ViewModel() {
-              public val component: WhetstoneTestComponent =
-                  parentComponent.whetstoneTestComponentFactory().create(savedStateHandle, testRoute)
-
-              public override fun onCleared(): Unit {
-                component.closeables.forEach {
-                  it.close()
-                }
-              }
-            }
-
-            @Composable
-            @OptIn(InternalWhetstoneApi::class)
-            public fun WhetstoneTest(testRoute: TestRoute): Unit {
-              val viewModel = rememberViewModel(TestParentScope::class, TestDestinationScope::class, testRoute,
-                  ::WhetstoneTestViewModel)
-              val component = viewModel.component
-
-              NavigationSetup(component.navEventNavigator)
-
-              WhetstoneTest(component)
-            }
-
-            @Composable
-            @OptIn(InternalWhetstoneApi::class)
-            private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
-              val testClass = component.testClass
-              val testClass2 = component.testClass2
-              val stateMachine = component.testStateMachine
-              val state = stateMachine.asComposeState()
-              val currentState = state.value
-              if (currentState != null) {
-                val scope = rememberCoroutineScope()
-                Test(testClass = testClass, test = testClass2, currentState) { action ->
-                  scope.launch { stateMachine.dispatch(action) }
-                }
-              }
-            }
-
-            @Module
-            @ContributesTo(TestDestinationScope::class)
-            public object WhetstoneTestNavDestinationModule {
-              @Provides
-              @IntoSet
-              public fun provideNavDestination(): NavDestination = ScreenDestination<TestRoute> {
-                WhetstoneTest(it)
-              }
-            }
-
-            @OptIn(InternalWhetstoneApi::class)
-            @ScopeTo(TestScreen::class)
-            @ContributesSubcomponent(
-              scope = TestScreen::class,
-              parentScope = TestParentScope::class,
-            )
-            public interface WhetstoneTestScreenNavEntryComponent {
-              @get:NavEntry(TestScreen::class)
-              public val closeables: Set<Closeable>
-
-              @ContributesSubcomponent.Factory
-              public interface Factory {
-                public fun create(@BindsInstance @NavEntry(TestScreen::class)
-                    savedStateHandle: SavedStateHandle, @BindsInstance @NavEntry(TestScreen::class)
-                    testRoute: TestRoute): WhetstoneTestScreenNavEntryComponent
-              }
-
-              @ContributesTo(TestParentScope::class)
-              public interface ParentComponent {
-                public fun whetstoneTestScreenNavEntryComponentFactory(): Factory
-              }
-            }
-
-            @Module
-            @ContributesTo(TestScreen::class)
-            public interface WhetstoneTestScreenNavEntryModule {
-              @Multibinds
-              @NavEntry(TestScreen::class)
-              public fun bindCloseables(): Set<Closeable>
-            }
-
-            @InternalWhetstoneApi
-            internal class WhetstoneTestScreenNavEntryViewModel(
-              parentComponent: WhetstoneTestScreenNavEntryComponent.ParentComponent,
-              savedStateHandle: SavedStateHandle,
-              testRoute: TestRoute,
-            ) : ViewModel() {
-              public val component: WhetstoneTestScreenNavEntryComponent =
-                  parentComponent.whetstoneTestScreenNavEntryComponentFactory().create(savedStateHandle,
-                  testRoute)
-
-              public override fun onCleared(): Unit {
-                component.closeables.forEach {
-                  it.close()
-                }
-              }
-            }
-
-            @OptIn(InternalWhetstoneApi::class)
-            @NavEntryComponentGetterKey(TestScreen::class)
-            @ContributesMultibinding(
-              TestDestinationScope::class,
-              NavEntryComponentGetter::class,
-            )
-            public class TestScreenNavEntryComponentGetter @Inject constructor() : NavEntryComponentGetter {
-              @OptIn(InternalWhetstoneApi::class, InternalNavigatorApi::class)
-              public override fun retrieve(findEntry: (Int) -> NavBackStackEntry, context: Context): Any {
-                val entry = findEntry(TestRoute::class.destinationId())
-                val route: TestRoute = entry.arguments.requireRoute()
-                val viewModel = viewModel(entry, context, TestParentScope::class, TestDestinationScope::class,
-                    route, findEntry, ::WhetstoneTestScreenNavEntryViewModel)
-                return viewModel.component
-              }
-            }
-
-            @ContributesTo(TestDestinationScope::class)
-            @OptIn(InternalWhetstoneApi::class)
-            public interface WhetstoneTestScreenNavEntryDestinationComponent : DestinationComponent
-
         """.trimIndent()
 
         assertThat(actual).isEqualTo(expected)

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
@@ -52,8 +52,6 @@ internal class FileGeneratorTestCompose {
 
             import android.os.Bundle
             import androidx.compose.runtime.Composable
-            import androidx.compose.runtime.CompositionLocalProvider
-            import androidx.compose.runtime.ProvidedValue
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
@@ -90,8 +88,6 @@ internal class FileGeneratorTestCompose {
               public val testClass: TestClass
 
               public val testClass2: TestClass2
-
-              public val providedValues: Set<ProvidedValue<*>>
 
               @ContributesSubcomponent.Factory
               public interface Factory {
@@ -140,18 +136,15 @@ internal class FileGeneratorTestCompose {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
-              val providedValues = component.providedValues
-              CompositionLocalProvider(*providedValues.toTypedArray()) {
-                val testClass = component.testClass
-                val testClass2 = component.testClass2
-                val stateMachine = component.testStateMachine
-                val state = stateMachine.asComposeState()
-                val currentState = state.value
-                if (currentState != null) {
-                  val scope = rememberCoroutineScope()
-                  Test(testClass = testClass, test = testClass2, currentState) { action ->
-                    scope.launch { stateMachine.dispatch(action) }
-                  }
+              val testClass = component.testClass
+              val testClass2 = component.testClass2
+              val stateMachine = component.testStateMachine
+              val state = stateMachine.asComposeState()
+              val currentState = state.value
+              if (currentState != null) {
+                val scope = rememberCoroutineScope()
+                Test(testClass = testClass, test = testClass2, currentState) { action ->
+                  scope.launch { stateMachine.dispatch(action) }
                 }
               }
             }
@@ -170,8 +163,6 @@ internal class FileGeneratorTestCompose {
             package com.test
 
             import androidx.compose.runtime.Composable
-            import androidx.compose.runtime.CompositionLocalProvider
-            import androidx.compose.runtime.ProvidedValue
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
@@ -213,8 +204,6 @@ internal class FileGeneratorTestCompose {
               public val testClass: TestClass
 
               public val testClass2: TestClass2
-
-              public val providedValues: Set<ProvidedValue<*>>
 
               @ContributesSubcomponent.Factory
               public interface Factory {
@@ -266,18 +255,15 @@ internal class FileGeneratorTestCompose {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
-              val providedValues = component.providedValues
-              CompositionLocalProvider(*providedValues.toTypedArray()) {
-                val testClass = component.testClass
-                val testClass2 = component.testClass2
-                val stateMachine = component.testStateMachine
-                val state = stateMachine.asComposeState()
-                val currentState = state.value
-                if (currentState != null) {
-                  val scope = rememberCoroutineScope()
-                  Test(testClass = testClass, test = testClass2, currentState) { action ->
-                    scope.launch { stateMachine.dispatch(action) }
-                  }
+              val testClass = component.testClass
+              val testClass2 = component.testClass2
+              val stateMachine = component.testStateMachine
+              val state = stateMachine.asComposeState()
+              val currentState = state.value
+              if (currentState != null) {
+                val scope = rememberCoroutineScope()
+                Test(testClass = testClass, test = testClass2, currentState) { action ->
+                  scope.launch { stateMachine.dispatch(action) }
                 }
               }
             }
@@ -296,8 +282,6 @@ internal class FileGeneratorTestCompose {
             package com.test
 
             import androidx.compose.runtime.Composable
-            import androidx.compose.runtime.CompositionLocalProvider
-            import androidx.compose.runtime.ProvidedValue
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
@@ -344,8 +328,6 @@ internal class FileGeneratorTestCompose {
 
               public val testClass2: TestClass2
 
-              public val providedValues: Set<ProvidedValue<*>>
-
               @ContributesSubcomponent.Factory
               public interface Factory {
                 public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
@@ -396,18 +378,15 @@ internal class FileGeneratorTestCompose {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
-              val providedValues = component.providedValues
-              CompositionLocalProvider(*providedValues.toTypedArray()) {
-                val testClass = component.testClass
-                val testClass2 = component.testClass2
-                val stateMachine = component.testStateMachine
-                val state = stateMachine.asComposeState()
-                val currentState = state.value
-                if (currentState != null) {
-                  val scope = rememberCoroutineScope()
-                  Test(testClass = testClass, test = testClass2, currentState) { action ->
-                    scope.launch { stateMachine.dispatch(action) }
-                  }
+              val testClass = component.testClass
+              val testClass2 = component.testClass2
+              val stateMachine = component.testStateMachine
+              val state = stateMachine.asComposeState()
+              val currentState = state.value
+              if (currentState != null) {
+                val scope = rememberCoroutineScope()
+                Test(testClass = testClass, test = testClass2, currentState) { action ->
+                  scope.launch { stateMachine.dispatch(action) }
                 }
               }
             }
@@ -440,8 +419,6 @@ internal class FileGeneratorTestCompose {
 
             import android.content.Context
             import androidx.compose.runtime.Composable
-            import androidx.compose.runtime.CompositionLocalProvider
-            import androidx.compose.runtime.ProvidedValue
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
@@ -501,8 +478,6 @@ internal class FileGeneratorTestCompose {
 
               public val testClass2: TestClass2
 
-              public val providedValues: Set<ProvidedValue<*>>
-
               @ContributesSubcomponent.Factory
               public interface Factory {
                 public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
@@ -553,18 +528,15 @@ internal class FileGeneratorTestCompose {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
-              val providedValues = component.providedValues
-              CompositionLocalProvider(*providedValues.toTypedArray()) {
-                val testClass = component.testClass
-                val testClass2 = component.testClass2
-                val stateMachine = component.testStateMachine
-                val state = stateMachine.asComposeState()
-                val currentState = state.value
-                if (currentState != null) {
-                  val scope = rememberCoroutineScope()
-                  Test(testClass = testClass, test = testClass2, currentState) { action ->
-                    scope.launch { stateMachine.dispatch(action) }
-                  }
+              val testClass = component.testClass
+              val testClass2 = component.testClass2
+              val stateMachine = component.testStateMachine
+              val state = stateMachine.asComposeState()
+              val currentState = state.value
+              if (currentState != null) {
+                val scope = rememberCoroutineScope()
+                Test(testClass = testClass, test = testClass2, currentState) { action ->
+                  scope.launch { stateMachine.dispatch(action) }
                 }
               }
             }

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
@@ -23,6 +23,10 @@ internal class FileGeneratorTestCompose {
         stateMachine = ClassName("com.test", "TestStateMachine"),
         navigation = null,
         navEntryData = null,
+        composableParameter = listOf(
+            ClassName("com.test", "TestClass"),
+            ClassName("com.test", "TestClass2"),
+        )
     )
 
     private val navEntryData = NavEntryData(
@@ -75,6 +79,10 @@ internal class FileGeneratorTestCompose {
     
               public val closeables: Set<Closeable>
 
+              public val testClass: TestClass
+
+              public val testClass2: TestClass2
+
               public val providedValues: Set<ProvidedValue<*>>
 
               @ContributesSubcomponent.Factory
@@ -126,12 +134,14 @@ internal class FileGeneratorTestCompose {
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
               val providedValues = component.providedValues
               CompositionLocalProvider(*providedValues.toTypedArray()) {
+                val testClass = component.testClass
+                val testClass2 = component.testClass2
                 val stateMachine = component.testStateMachine
                 val state = stateMachine.asComposeState()
                 val currentState = state.value
                 if (currentState != null) {
                   val scope = rememberCoroutineScope()
-                  Test(currentState) { action ->
+                  Test(testClass, testClass2, currentState) { action ->
                     scope.launch { stateMachine.dispatch(action) }
                   }
                 }
@@ -191,6 +201,10 @@ internal class FileGeneratorTestCompose {
     
               public val closeables: Set<Closeable>
 
+              public val testClass: TestClass
+
+              public val testClass2: TestClass2
+
               public val providedValues: Set<ProvidedValue<*>>
 
               @ContributesSubcomponent.Factory
@@ -245,12 +259,14 @@ internal class FileGeneratorTestCompose {
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
               val providedValues = component.providedValues
               CompositionLocalProvider(*providedValues.toTypedArray()) {
+                val testClass = component.testClass
+                val testClass2 = component.testClass2
                 val stateMachine = component.testStateMachine
                 val state = stateMachine.asComposeState()
                 val currentState = state.value
                 if (currentState != null) {
                   val scope = rememberCoroutineScope()
-                  Test(currentState) { action ->
+                  Test(testClass, testClass2, currentState) { action ->
                     scope.launch { stateMachine.dispatch(action) }
                   }
                 }
@@ -314,6 +330,10 @@ internal class FileGeneratorTestCompose {
     
               public val closeables: Set<Closeable>
 
+              public val testClass: TestClass
+
+              public val testClass2: TestClass2
+
               public val providedValues: Set<ProvidedValue<*>>
 
               @ContributesSubcomponent.Factory
@@ -368,12 +388,14 @@ internal class FileGeneratorTestCompose {
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
               val providedValues = component.providedValues
               CompositionLocalProvider(*providedValues.toTypedArray()) {
+                val testClass = component.testClass
+                val testClass2 = component.testClass2
                 val stateMachine = component.testStateMachine
                 val state = stateMachine.asComposeState()
                 val currentState = state.value
                 if (currentState != null) {
                   val scope = rememberCoroutineScope()
-                  Test(currentState) { action ->
+                  Test(testClass, testClass2, currentState) { action ->
                     scope.launch { stateMachine.dispatch(action) }
                   }
                 }
@@ -464,6 +486,10 @@ internal class FileGeneratorTestCompose {
 
               public val closeables: Set<Closeable>
 
+              public val testClass: TestClass
+
+              public val testClass2: TestClass2
+
               public val providedValues: Set<ProvidedValue<*>>
 
               @ContributesSubcomponent.Factory
@@ -518,12 +544,14 @@ internal class FileGeneratorTestCompose {
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
               val providedValues = component.providedValues
               CompositionLocalProvider(*providedValues.toTypedArray()) {
+                val testClass = component.testClass
+                val testClass2 = component.testClass2
                 val stateMachine = component.testStateMachine
                 val state = stateMachine.asComposeState()
                 val currentState = state.value
                 if (currentState != null) {
                   val scope = rememberCoroutineScope()
-                  Test(currentState) { action ->
+                  Test(testClass, testClass2, currentState) { action ->
                     scope.launch { stateMachine.dispatch(action) }
                   }
                 }

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
@@ -1,5 +1,6 @@
 package com.freeletics.mad.whetstone.codegen
 
+import com.freeletics.mad.whetstone.ComposableParameter
 import com.freeletics.mad.whetstone.ComposeScreenData
 import com.freeletics.mad.whetstone.NavEntryData
 import com.freeletics.mad.whetstone.Navigation
@@ -24,8 +25,14 @@ internal class FileGeneratorTestCompose {
         navigation = null,
         navEntryData = null,
         composableParameter = listOf(
-            ClassName("com.test", "TestClass"),
-            ClassName("com.other", "TestClass2"),
+            ComposableParameter(
+                name = "testClass",
+                className = ClassName("com.test", "TestClass"),
+            ),
+            ComposableParameter(
+                name = "test",
+                className = ClassName("com.other", "TestClass2"),
+            )
         )
     )
 
@@ -142,7 +149,7 @@ internal class FileGeneratorTestCompose {
                 val currentState = state.value
                 if (currentState != null) {
                   val scope = rememberCoroutineScope()
-                  Test(testClass, testClass2, currentState) { action ->
+                  Test(testClass = testClass, test = testClass2, currentState) { action ->
                     scope.launch { stateMachine.dispatch(action) }
                   }
                 }
@@ -268,7 +275,7 @@ internal class FileGeneratorTestCompose {
                 val currentState = state.value
                 if (currentState != null) {
                   val scope = rememberCoroutineScope()
-                  Test(testClass, testClass2, currentState) { action ->
+                  Test(testClass = testClass, test = testClass2, currentState) { action ->
                     scope.launch { stateMachine.dispatch(action) }
                   }
                 }
@@ -398,7 +405,7 @@ internal class FileGeneratorTestCompose {
                 val currentState = state.value
                 if (currentState != null) {
                   val scope = rememberCoroutineScope()
-                  Test(testClass, testClass2, currentState) { action ->
+                  Test(testClass = testClass, test = testClass2, currentState) { action ->
                     scope.launch { stateMachine.dispatch(action) }
                   }
                 }
@@ -555,7 +562,7 @@ internal class FileGeneratorTestCompose {
                 val currentState = state.value
                 if (currentState != null) {
                   val scope = rememberCoroutineScope()
-                  Test(testClass, testClass2, currentState) { action ->
+                  Test(testClass = testClass, test = testClass2, currentState) { action ->
                     scope.launch { stateMachine.dispatch(action) }
                   }
                 }

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
@@ -26,7 +26,10 @@ internal class FileGeneratorTestComposeFragment {
         fragmentBaseClass = fragment,
         navigation = null,
         navEntryData = null,
-        composableParameter = listOf(ClassName("com.test", "TestClass"))
+        composableParameter = listOf(
+            ClassName("com.test", "TestClass"),
+            ClassName("com.test", "TestClass2"),
+        )
     )
 
     private val navEntryData = NavEntryData(
@@ -84,6 +87,10 @@ internal class FileGeneratorTestComposeFragment {
               public val testStateMachine: TestStateMachine
 
               public val closeables: Set<Closeable>
+
+              public val testClass: TestClass
+
+              public val testClass2: TestClass2
 
               public val providedValues: Set<ProvidedValue<*>>
 
@@ -152,12 +159,14 @@ internal class FileGeneratorTestComposeFragment {
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
               val providedValues = component.providedValues
               CompositionLocalProvider(*providedValues.toTypedArray()) {
+                val testClass = component.testClass
+                val testClass2 = component.testClass2
                 val stateMachine = component.testStateMachine
                 val state = stateMachine.asComposeState()
                 val currentState = state.value
                 if (currentState != null) {
                   val scope = rememberCoroutineScope()
-                  Test(currentState) { action ->
+                  Test(testClass, testClass2, currentState) { action ->
                     scope.launch { stateMachine.dispatch(action) }
                   }
                 }
@@ -224,6 +233,10 @@ internal class FileGeneratorTestComposeFragment {
               public val navEventNavigator: NavEventNavigator
 
               public val closeables: Set<Closeable>
+
+              public val testClass: TestClass
+
+              public val testClass2: TestClass2
 
               public val providedValues: Set<ProvidedValue<*>>
 
@@ -295,12 +308,14 @@ internal class FileGeneratorTestComposeFragment {
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
               val providedValues = component.providedValues
               CompositionLocalProvider(*providedValues.toTypedArray()) {
+                val testClass = component.testClass
+                val testClass2 = component.testClass2
                 val stateMachine = component.testStateMachine
                 val state = stateMachine.asComposeState()
                 val currentState = state.value
                 if (currentState != null) {
                   val scope = rememberCoroutineScope()
-                  Test(currentState) { action ->
+                  Test(testClass, testClass2, currentState) { action ->
                     scope.launch { stateMachine.dispatch(action) }
                   }
                 }
@@ -372,6 +387,10 @@ internal class FileGeneratorTestComposeFragment {
 
               public val closeables: Set<Closeable>
 
+              public val testClass: TestClass
+
+              public val testClass2: TestClass2
+
               public val providedValues: Set<ProvidedValue<*>>
 
               @ContributesSubcomponent.Factory
@@ -442,12 +461,14 @@ internal class FileGeneratorTestComposeFragment {
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
               val providedValues = component.providedValues
               CompositionLocalProvider(*providedValues.toTypedArray()) {
+                val testClass = component.testClass
+                val testClass2 = component.testClass2
                 val stateMachine = component.testStateMachine
                 val state = stateMachine.asComposeState()
                 val currentState = state.value
                 if (currentState != null) {
                   val scope = rememberCoroutineScope()
-                  Test(currentState) { action ->
+                  Test(testClass, testClass2, currentState) { action ->
                     scope.launch { stateMachine.dispatch(action) }
                   }
                 }
@@ -545,6 +566,10 @@ internal class FileGeneratorTestComposeFragment {
 
               public val closeables: Set<Closeable>
 
+              public val testClass: TestClass
+
+              public val testClass2: TestClass2
+
               public val providedValues: Set<ProvidedValue<*>>
 
               @ContributesSubcomponent.Factory
@@ -615,12 +640,14 @@ internal class FileGeneratorTestComposeFragment {
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
               val providedValues = component.providedValues
               CompositionLocalProvider(*providedValues.toTypedArray()) {
+                val testClass = component.testClass
+                val testClass2 = component.testClass2
                 val stateMachine = component.testStateMachine
                 val state = stateMachine.asComposeState()
                 val currentState = state.value
                 if (currentState != null) {
                   val scope = rememberCoroutineScope()
-                  Test(currentState) { action ->
+                  Test(testClass, testClass2, currentState) { action ->
                     scope.launch { stateMachine.dispatch(action) }
                   }
                 }
@@ -760,6 +787,10 @@ internal class FileGeneratorTestComposeFragment {
 
               public val closeables: Set<Closeable>
 
+              public val testClass: TestClass
+
+              public val testClass2: TestClass2
+
               public val providedValues: Set<ProvidedValue<*>>
 
               @ContributesSubcomponent.Factory
@@ -827,12 +858,14 @@ internal class FileGeneratorTestComposeFragment {
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
               val providedValues = component.providedValues
               CompositionLocalProvider(*providedValues.toTypedArray()) {
+                val testClass = component.testClass
+                val testClass2 = component.testClass2
                 val stateMachine = component.testStateMachine
                 val state = stateMachine.asComposeState()
                 val currentState = state.value
                 if (currentState != null) {
                   val scope = rememberCoroutineScope()
-                  Test(currentState) { action ->
+                  Test(testClass, testClass2, currentState) { action ->
                     scope.launch { stateMachine.dispatch(action) }
                   }
                 }

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
@@ -1,5 +1,6 @@
 package com.freeletics.mad.whetstone.codegen
 
+import com.freeletics.mad.whetstone.ComposableParameter
 import com.freeletics.mad.whetstone.ComposeFragmentData
 import com.freeletics.mad.whetstone.NavEntryData
 import com.freeletics.mad.whetstone.Navigation
@@ -27,8 +28,14 @@ internal class FileGeneratorTestComposeFragment {
         navigation = null,
         navEntryData = null,
         composableParameter = listOf(
-            ClassName("com.test", "TestClass"),
-            ClassName("com.other", "TestClass2"),
+            ComposableParameter(
+                name = "testClass",
+                className = ClassName("com.test", "TestClass"),
+            ),
+            ComposableParameter(
+                name = "test",
+                className = ClassName("com.other", "TestClass2"),
+            )
         )
     )
 
@@ -167,7 +174,7 @@ internal class FileGeneratorTestComposeFragment {
                 val currentState = state.value
                 if (currentState != null) {
                   val scope = rememberCoroutineScope()
-                  Test(testClass, testClass2, currentState) { action ->
+                  Test(testClass = testClass, test = testClass2, currentState) { action ->
                     scope.launch { stateMachine.dispatch(action) }
                   }
                 }
@@ -317,7 +324,7 @@ internal class FileGeneratorTestComposeFragment {
                 val currentState = state.value
                 if (currentState != null) {
                   val scope = rememberCoroutineScope()
-                  Test(testClass, testClass2, currentState) { action ->
+                  Test(testClass = testClass, test = testClass2, currentState) { action ->
                     scope.launch { stateMachine.dispatch(action) }
                   }
                 }
@@ -471,7 +478,7 @@ internal class FileGeneratorTestComposeFragment {
                 val currentState = state.value
                 if (currentState != null) {
                   val scope = rememberCoroutineScope()
-                  Test(testClass, testClass2, currentState) { action ->
+                  Test(testClass = testClass, test = testClass2, currentState) { action ->
                     scope.launch { stateMachine.dispatch(action) }
                   }
                 }
@@ -651,7 +658,7 @@ internal class FileGeneratorTestComposeFragment {
                 val currentState = state.value
                 if (currentState != null) {
                   val scope = rememberCoroutineScope()
-                  Test(testClass, testClass2, currentState) { action ->
+                  Test(testClass = testClass, test = testClass2, currentState) { action ->
                     scope.launch { stateMachine.dispatch(action) }
                   }
                 }
@@ -870,7 +877,7 @@ internal class FileGeneratorTestComposeFragment {
                 val currentState = state.value
                 if (currentState != null) {
                   val scope = rememberCoroutineScope()
-                  Test(testClass, testClass2, currentState) { action ->
+                  Test(testClass = testClass, test = testClass2, currentState) { action ->
                     scope.launch { stateMachine.dispatch(action) }
                   }
                 }

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
@@ -27,16 +27,7 @@ internal class FileGeneratorTestComposeFragment {
         fragmentBaseClass = fragment,
         navigation = null,
         navEntryData = null,
-        composableParameter = listOf(
-            ComposableParameter(
-                name = "testClass",
-                className = ClassName("com.test", "TestClass"),
-            ),
-            ComposableParameter(
-                name = "test",
-                className = ClassName("com.other", "TestClass2"),
-            )
-        )
+        composableParameter = emptyList()
     )
 
     private val navEntryData = NavEntryData(
@@ -69,7 +60,6 @@ internal class FileGeneratorTestComposeFragment {
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
-            import com.other.TestClass2
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
             import com.test.parent.TestParentScope
@@ -93,10 +83,6 @@ internal class FileGeneratorTestComposeFragment {
               public val testStateMachine: TestStateMachine
 
               public val closeables: Set<Closeable>
-
-              public val testClass: TestClass
-
-              public val testClass2: TestClass2
 
               @ContributesSubcomponent.Factory
               public interface Factory {
@@ -161,16 +147,15 @@ internal class FileGeneratorTestComposeFragment {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
-              val testClass = component.testClass
-              val testClass2 = component.testClass2
               val stateMachine = component.testStateMachine
               val state = stateMachine.asComposeState()
               val currentState = state.value
               if (currentState != null) {
                 val scope = rememberCoroutineScope()
-                Test(testClass = testClass, test = testClass2, currentState) { action ->
-                  scope.launch { stateMachine.dispatch(action) }
-                }
+                Test(
+                  state = currentState,
+                  sendAction = { scope.launch { stateMachine.dispatch(action) } },
+                )
               }
             }
             
@@ -206,7 +191,6 @@ internal class FileGeneratorTestComposeFragment {
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
-            import com.other.TestClass2
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
             import com.test.destination.TestDestinationScope
@@ -233,10 +217,6 @@ internal class FileGeneratorTestComposeFragment {
               public val navEventNavigator: NavEventNavigator
 
               public val closeables: Set<Closeable>
-
-              public val testClass: TestClass
-
-              public val testClass2: TestClass2
 
               @ContributesSubcomponent.Factory
               public interface Factory {
@@ -304,16 +284,15 @@ internal class FileGeneratorTestComposeFragment {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
-              val testClass = component.testClass
-              val testClass2 = component.testClass2
               val stateMachine = component.testStateMachine
               val state = stateMachine.asComposeState()
               val currentState = state.value
               if (currentState != null) {
                 val scope = rememberCoroutineScope()
-                Test(testClass = testClass, test = testClass2, currentState) { action ->
-                  scope.launch { stateMachine.dispatch(action) }
-                }
+                Test(
+                  state = currentState,
+                  sendAction = { scope.launch { stateMachine.dispatch(action) } },
+                )
               }
             }
             
@@ -351,7 +330,6 @@ internal class FileGeneratorTestComposeFragment {
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
-            import com.other.TestClass2
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
             import com.test.destination.TestDestinationScope
@@ -380,10 +358,6 @@ internal class FileGeneratorTestComposeFragment {
               public val navEventNavigator: NavEventNavigator
 
               public val closeables: Set<Closeable>
-
-              public val testClass: TestClass
-
-              public val testClass2: TestClass2
 
               @ContributesSubcomponent.Factory
               public interface Factory {
@@ -451,16 +425,15 @@ internal class FileGeneratorTestComposeFragment {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
-              val testClass = component.testClass
-              val testClass2 = component.testClass2
               val stateMachine = component.testStateMachine
               val state = stateMachine.asComposeState()
               val currentState = state.value
               if (currentState != null) {
                 val scope = rememberCoroutineScope()
-                Test(testClass = testClass, test = testClass2, currentState) { action ->
-                  scope.launch { stateMachine.dispatch(action) }
-                }
+                Test(
+                  state = currentState,
+                  sendAction = { scope.launch { stateMachine.dispatch(action) } },
+                )
               }
             }
             
@@ -519,7 +492,6 @@ internal class FileGeneratorTestComposeFragment {
             import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetterKey
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
-            import com.other.TestClass2
             import com.squareup.anvil.annotations.ContributesMultibinding
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
@@ -553,10 +525,6 @@ internal class FileGeneratorTestComposeFragment {
               public val navEventNavigator: NavEventNavigator
 
               public val closeables: Set<Closeable>
-
-              public val testClass: TestClass
-
-              public val testClass2: TestClass2
 
               @ContributesSubcomponent.Factory
               public interface Factory {
@@ -624,16 +592,15 @@ internal class FileGeneratorTestComposeFragment {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
-              val testClass = component.testClass
-              val testClass2 = component.testClass2
               val stateMachine = component.testStateMachine
               val state = stateMachine.asComposeState()
               val currentState = state.value
               if (currentState != null) {
                 val scope = rememberCoroutineScope()
-                Test(testClass = testClass, test = testClass2, currentState) { action ->
-                  scope.launch { stateMachine.dispatch(action) }
-                }
+                Test(
+                  state = currentState,
+                  sendAction = { scope.launch { stateMachine.dispatch(action) } },
+                )
               }
             }
 
@@ -744,6 +711,148 @@ internal class FileGeneratorTestComposeFragment {
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
+            import com.squareup.anvil.annotations.ContributesSubcomponent
+            import com.squareup.anvil.annotations.ContributesTo
+            import com.test.parent.TestParentScope
+            import dagger.BindsInstance
+            import dagger.Module
+            import dagger.multibindings.Multibinds
+            import java.io.Closeable
+            import kotlin.OptIn
+            import kotlin.Unit
+            import kotlin.collections.Set
+            import kotlinx.coroutines.launch
+
+            @OptIn(InternalWhetstoneApi::class)
+            @ScopeTo(TestScreen::class)
+            @ContributesSubcomponent(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+              modules = [ComposeProviderValueModule::class],
+            )
+            public interface WhetstoneTestComponent {
+              public val testStateMachine: TestStateMachine
+
+              public val closeables: Set<Closeable>
+
+              @ContributesSubcomponent.Factory
+              public interface Factory {
+                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
+                    arguments: Bundle): WhetstoneTestComponent
+              }
+
+              @ContributesTo(TestParentScope::class)
+              public interface ParentComponent {
+                public fun whetstoneTestComponentFactory(): Factory
+              }
+            }
+
+            @Module
+            @ContributesTo(TestScreen::class)
+            public interface WhetstoneTestModule {
+              @Multibinds
+              public fun bindCloseables(): Set<Closeable>
+            }
+
+            @InternalWhetstoneApi
+            internal class WhetstoneTestViewModel(
+              parentComponent: WhetstoneTestComponent.ParentComponent,
+              savedStateHandle: SavedStateHandle,
+              arguments: Bundle,
+            ) : ViewModel() {
+              public val component: WhetstoneTestComponent =
+                  parentComponent.whetstoneTestComponentFactory().create(savedStateHandle, arguments)
+
+              public override fun onCleared(): Unit {
+                component.closeables.forEach {
+                  it.close()
+                }
+              }
+            }
+            
+            @OptIn(InternalWhetstoneApi::class)
+            public class WhetstoneTestFragment : DialogFragment() {
+              private lateinit var whetstoneTestComponent: WhetstoneTestComponent
+            
+              public override fun onCreateView(
+                inflater: LayoutInflater,
+                container: ViewGroup?,
+                savedInstanceState: Bundle?,
+              ): View {
+                if (!::whetstoneTestComponent.isInitialized) {
+                  val arguments = requireArguments()
+                  val viewModel = viewModel(TestParentScope::class, arguments, ::WhetstoneTestViewModel)
+                  whetstoneTestComponent = viewModel.component
+                }
+
+                return ComposeView(requireContext()).apply {
+                  setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnLifecycleDestroyed(viewLifecycleOwner))
+
+                  setContent {
+                    WhetstoneTest(whetstoneTestComponent)
+                  }
+                }
+              }
+            }
+
+            @Composable
+            @OptIn(InternalWhetstoneApi::class)
+            private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
+              val stateMachine = component.testStateMachine
+              val state = stateMachine.asComposeState()
+              val currentState = state.value
+              if (currentState != null) {
+                val scope = rememberCoroutineScope()
+                Test(
+                  state = currentState,
+                  sendAction = { scope.launch { stateMachine.dispatch(action) } },
+                )
+              }
+            }
+
+        """.trimIndent()
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `generates code for ComposeFragmentData with Composable Depedencies`() {
+        val actual = FileGenerator()
+            .generate(
+                data.copy(
+                    composableParameter = listOf(
+                        ComposableParameter(
+                            name = "testClass",
+                            className = ClassName("com.test", "TestClass"),
+                        ),
+                        ComposableParameter(
+                            name = "test",
+                            className = ClassName("com.other", "TestClass2"),
+                        )
+                    )
+                )
+            )
+            .toString()
+
+        val expected = """
+            package com.test
+
+            import android.os.Bundle
+            import android.view.LayoutInflater
+            import android.view.View
+            import android.view.ViewGroup
+            import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.rememberCoroutineScope
+            import androidx.compose.ui.platform.ComposeView
+            import androidx.compose.ui.platform.ViewCompositionStrategy
+            import androidx.fragment.app.Fragment
+            import androidx.lifecycle.SavedStateHandle
+            import androidx.lifecycle.ViewModel
+            import com.freeletics.mad.whetstone.ScopeTo
+            import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
+            import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
+            import com.freeletics.mad.whetstone.`internal`.asComposeState
+            import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
             import com.other.TestClass2
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
@@ -809,7 +918,7 @@ internal class FileGeneratorTestComposeFragment {
             }
             
             @OptIn(InternalWhetstoneApi::class)
-            public class WhetstoneTestFragment : DialogFragment() {
+            public class WhetstoneTestFragment : Fragment() {
               private lateinit var whetstoneTestComponent: WhetstoneTestComponent
             
               public override fun onCreateView(
@@ -843,12 +952,15 @@ internal class FileGeneratorTestComposeFragment {
               val currentState = state.value
               if (currentState != null) {
                 val scope = rememberCoroutineScope()
-                Test(testClass = testClass, test = testClass2, currentState) { action ->
-                  scope.launch { stateMachine.dispatch(action) }
-                }
+                Test(
+                  testClass = testClass,
+                  test = testClass2,
+                  state = currentState,
+                  sendAction = { scope.launch { stateMachine.dispatch(action) } },
+                )
               }
             }
-
+            
         """.trimIndent()
 
         assertThat(actual).isEqualTo(expected)

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
@@ -58,8 +58,6 @@ internal class FileGeneratorTestComposeFragment {
             import android.view.View
             import android.view.ViewGroup
             import androidx.compose.runtime.Composable
-            import androidx.compose.runtime.CompositionLocalProvider
-            import androidx.compose.runtime.ProvidedValue
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.compose.ui.platform.ComposeView
             import androidx.compose.ui.platform.ViewCompositionStrategy
@@ -99,8 +97,6 @@ internal class FileGeneratorTestComposeFragment {
               public val testClass: TestClass
 
               public val testClass2: TestClass2
-
-              public val providedValues: Set<ProvidedValue<*>>
 
               @ContributesSubcomponent.Factory
               public interface Factory {
@@ -165,18 +161,15 @@ internal class FileGeneratorTestComposeFragment {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
-              val providedValues = component.providedValues
-              CompositionLocalProvider(*providedValues.toTypedArray()) {
-                val testClass = component.testClass
-                val testClass2 = component.testClass2
-                val stateMachine = component.testStateMachine
-                val state = stateMachine.asComposeState()
-                val currentState = state.value
-                if (currentState != null) {
-                  val scope = rememberCoroutineScope()
-                  Test(testClass = testClass, test = testClass2, currentState) { action ->
-                    scope.launch { stateMachine.dispatch(action) }
-                  }
+              val testClass = component.testClass
+              val testClass2 = component.testClass2
+              val stateMachine = component.testStateMachine
+              val state = stateMachine.asComposeState()
+              val currentState = state.value
+              if (currentState != null) {
+                val scope = rememberCoroutineScope()
+                Test(testClass = testClass, test = testClass2, currentState) { action ->
+                  scope.launch { stateMachine.dispatch(action) }
                 }
               }
             }
@@ -199,8 +192,6 @@ internal class FileGeneratorTestComposeFragment {
             import android.view.View
             import android.view.ViewGroup
             import androidx.compose.runtime.Composable
-            import androidx.compose.runtime.CompositionLocalProvider
-            import androidx.compose.runtime.ProvidedValue
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.compose.ui.platform.ComposeView
             import androidx.compose.ui.platform.ViewCompositionStrategy
@@ -246,8 +237,6 @@ internal class FileGeneratorTestComposeFragment {
               public val testClass: TestClass
 
               public val testClass2: TestClass2
-
-              public val providedValues: Set<ProvidedValue<*>>
 
               @ContributesSubcomponent.Factory
               public interface Factory {
@@ -315,18 +304,15 @@ internal class FileGeneratorTestComposeFragment {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
-              val providedValues = component.providedValues
-              CompositionLocalProvider(*providedValues.toTypedArray()) {
-                val testClass = component.testClass
-                val testClass2 = component.testClass2
-                val stateMachine = component.testStateMachine
-                val state = stateMachine.asComposeState()
-                val currentState = state.value
-                if (currentState != null) {
-                  val scope = rememberCoroutineScope()
-                  Test(testClass = testClass, test = testClass2, currentState) { action ->
-                    scope.launch { stateMachine.dispatch(action) }
-                  }
+              val testClass = component.testClass
+              val testClass2 = component.testClass2
+              val stateMachine = component.testStateMachine
+              val state = stateMachine.asComposeState()
+              val currentState = state.value
+              if (currentState != null) {
+                val scope = rememberCoroutineScope()
+                Test(testClass = testClass, test = testClass2, currentState) { action ->
+                  scope.launch { stateMachine.dispatch(action) }
                 }
               }
             }
@@ -349,8 +335,6 @@ internal class FileGeneratorTestComposeFragment {
             import android.view.View
             import android.view.ViewGroup
             import androidx.compose.runtime.Composable
-            import androidx.compose.runtime.CompositionLocalProvider
-            import androidx.compose.runtime.ProvidedValue
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.compose.ui.platform.ComposeView
             import androidx.compose.ui.platform.ViewCompositionStrategy
@@ -401,8 +385,6 @@ internal class FileGeneratorTestComposeFragment {
 
               public val testClass2: TestClass2
 
-              public val providedValues: Set<ProvidedValue<*>>
-
               @ContributesSubcomponent.Factory
               public interface Factory {
                 public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
@@ -469,18 +451,15 @@ internal class FileGeneratorTestComposeFragment {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
-              val providedValues = component.providedValues
-              CompositionLocalProvider(*providedValues.toTypedArray()) {
-                val testClass = component.testClass
-                val testClass2 = component.testClass2
-                val stateMachine = component.testStateMachine
-                val state = stateMachine.asComposeState()
-                val currentState = state.value
-                if (currentState != null) {
-                  val scope = rememberCoroutineScope()
-                  Test(testClass = testClass, test = testClass2, currentState) { action ->
-                    scope.launch { stateMachine.dispatch(action) }
-                  }
+              val testClass = component.testClass
+              val testClass2 = component.testClass2
+              val stateMachine = component.testStateMachine
+              val state = stateMachine.asComposeState()
+              val currentState = state.value
+              if (currentState != null) {
+                val scope = rememberCoroutineScope()
+                Test(testClass = testClass, test = testClass2, currentState) { action ->
+                  scope.launch { stateMachine.dispatch(action) }
                 }
               }
             }
@@ -517,8 +496,6 @@ internal class FileGeneratorTestComposeFragment {
             import android.view.View
             import android.view.ViewGroup
             import androidx.compose.runtime.Composable
-            import androidx.compose.runtime.CompositionLocalProvider
-            import androidx.compose.runtime.ProvidedValue
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.compose.ui.platform.ComposeView
             import androidx.compose.ui.platform.ViewCompositionStrategy
@@ -581,8 +558,6 @@ internal class FileGeneratorTestComposeFragment {
 
               public val testClass2: TestClass2
 
-              public val providedValues: Set<ProvidedValue<*>>
-
               @ContributesSubcomponent.Factory
               public interface Factory {
                 public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
@@ -649,18 +624,15 @@ internal class FileGeneratorTestComposeFragment {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
-              val providedValues = component.providedValues
-              CompositionLocalProvider(*providedValues.toTypedArray()) {
-                val testClass = component.testClass
-                val testClass2 = component.testClass2
-                val stateMachine = component.testStateMachine
-                val state = stateMachine.asComposeState()
-                val currentState = state.value
-                if (currentState != null) {
-                  val scope = rememberCoroutineScope()
-                  Test(testClass = testClass, test = testClass2, currentState) { action ->
-                    scope.launch { stateMachine.dispatch(action) }
-                  }
+              val testClass = component.testClass
+              val testClass2 = component.testClass2
+              val stateMachine = component.testStateMachine
+              val state = stateMachine.asComposeState()
+              val currentState = state.value
+              if (currentState != null) {
+                val scope = rememberCoroutineScope()
+                Test(testClass = testClass, test = testClass2, currentState) { action ->
+                  scope.launch { stateMachine.dispatch(action) }
                 }
               }
             }
@@ -761,8 +733,6 @@ internal class FileGeneratorTestComposeFragment {
             import android.view.View
             import android.view.ViewGroup
             import androidx.compose.runtime.Composable
-            import androidx.compose.runtime.CompositionLocalProvider
-            import androidx.compose.runtime.ProvidedValue
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.compose.ui.platform.ComposeView
             import androidx.compose.ui.platform.ViewCompositionStrategy
@@ -802,8 +772,6 @@ internal class FileGeneratorTestComposeFragment {
               public val testClass: TestClass
 
               public val testClass2: TestClass2
-
-              public val providedValues: Set<ProvidedValue<*>>
 
               @ContributesSubcomponent.Factory
               public interface Factory {
@@ -868,18 +836,15 @@ internal class FileGeneratorTestComposeFragment {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
-              val providedValues = component.providedValues
-              CompositionLocalProvider(*providedValues.toTypedArray()) {
-                val testClass = component.testClass
-                val testClass2 = component.testClass2
-                val stateMachine = component.testStateMachine
-                val state = stateMachine.asComposeState()
-                val currentState = state.value
-                if (currentState != null) {
-                  val scope = rememberCoroutineScope()
-                  Test(testClass = testClass, test = testClass2, currentState) { action ->
-                    scope.launch { stateMachine.dispatch(action) }
-                  }
+              val testClass = component.testClass
+              val testClass2 = component.testClass2
+              val stateMachine = component.testStateMachine
+              val state = stateMachine.asComposeState()
+              val currentState = state.value
+              if (currentState != null) {
+                val scope = rememberCoroutineScope()
+                Test(testClass = testClass, test = testClass2, currentState) { action ->
+                  scope.launch { stateMachine.dispatch(action) }
                 }
               }
             }

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
@@ -26,6 +26,7 @@ internal class FileGeneratorTestComposeFragment {
         fragmentBaseClass = fragment,
         navigation = null,
         navEntryData = null,
+        composableParameter = listOf(ClassName("com.test", "TestClass"))
     )
 
     private val navEntryData = NavEntryData(

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
@@ -28,7 +28,7 @@ internal class FileGeneratorTestComposeFragment {
         navEntryData = null,
         composableParameter = listOf(
             ClassName("com.test", "TestClass"),
-            ClassName("com.test", "TestClass2"),
+            ClassName("com.other", "TestClass2"),
         )
     )
 
@@ -64,6 +64,7 @@ internal class FileGeneratorTestComposeFragment {
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
+            import com.other.TestClass2
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
             import com.test.parent.TestParentScope
@@ -207,6 +208,7 @@ internal class FileGeneratorTestComposeFragment {
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
+            import com.other.TestClass2
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
             import com.test.destination.TestDestinationScope
@@ -358,6 +360,7 @@ internal class FileGeneratorTestComposeFragment {
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
+            import com.other.TestClass2
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
             import com.test.destination.TestDestinationScope
@@ -532,6 +535,7 @@ internal class FileGeneratorTestComposeFragment {
             import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetterKey
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
+            import com.other.TestClass2
             import com.squareup.anvil.annotations.ContributesMultibinding
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
@@ -763,6 +767,7 @@ internal class FileGeneratorTestComposeFragment {
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
             import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
+            import com.other.TestClass2
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
             import com.test.parent.TestParentScope


### PR DESCRIPTION
This adds new functionality to inject classes into Composables, which have the `ComposeFragment` or `ComposeScreen` annotation applied.

Before this change users could provide UI specific dependencies via Composes' `LocalCompositionProvider`. This got removed in favour of injecting directly into the Composable.

Example:
We want to use an instance of `MyDependency` in the UI, which is provided through Dagger.
```
@ComposeFragment( //or @ComposeScreen
    scope = Example::class,
    parentScope = Singleton::class,
    stateMachine = ExampleStateMachine::class,
)
@Composable
internal fun ExampleUi(
    myDependency: MyDependency,
    state: ExampleState,
    sendAction: (ExampleAction) -> Unit,
) {
```
