### PR TITLE
Fix action lambda in compose code generation

### DIFF
--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/ComposeGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/ComposeGenerator.kt
@@ -50,7 +50,7 @@ internal class ComposeGenerator(
             }
             .addStatement("  state = currentState,")
             // dispatch: external method
-            .addStatement("  sendAction = { scope.%M { stateMachine.dispatch(action) } },", launch)
+            .addStatement("  sendAction = { scope.%M { stateMachine.dispatch(it) } },", launch)
             .addStatement(")")
             .endControlFlow()
             .build()

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
@@ -129,7 +129,7 @@ internal class FileGeneratorTestCompose {
                 val scope = rememberCoroutineScope()
                 Test(
                   state = currentState,
-                  sendAction = { scope.launch { stateMachine.dispatch(action) } },
+                  sendAction = { scope.launch { stateMachine.dispatch(it) } },
                 )
               }
             }
@@ -242,7 +242,7 @@ internal class FileGeneratorTestCompose {
                 val scope = rememberCoroutineScope()
                 Test(
                   state = currentState,
-                  sendAction = { scope.launch { stateMachine.dispatch(action) } },
+                  sendAction = { scope.launch { stateMachine.dispatch(it) } },
                 )
               }
             }
@@ -359,7 +359,7 @@ internal class FileGeneratorTestCompose {
                 val scope = rememberCoroutineScope()
                 Test(
                   state = currentState,
-                  sendAction = { scope.launch { stateMachine.dispatch(action) } },
+                  sendAction = { scope.launch { stateMachine.dispatch(it) } },
                 )
               }
             }
@@ -503,7 +503,7 @@ internal class FileGeneratorTestCompose {
                 val scope = rememberCoroutineScope()
                 Test(
                   state = currentState,
-                  sendAction = { scope.launch { stateMachine.dispatch(action) } },
+                  sendAction = { scope.launch { stateMachine.dispatch(it) } },
                 )
               }
             }
@@ -711,7 +711,7 @@ internal class FileGeneratorTestCompose {
                   testClass = testClass,
                   test = testClass2,
                   state = currentState,
-                  sendAction = { scope.launch { stateMachine.dispatch(action) } },
+                  sendAction = { scope.launch { stateMachine.dispatch(it) } },
                 )
               }
             }

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
@@ -154,7 +154,7 @@ internal class FileGeneratorTestComposeFragment {
                 val scope = rememberCoroutineScope()
                 Test(
                   state = currentState,
-                  sendAction = { scope.launch { stateMachine.dispatch(action) } },
+                  sendAction = { scope.launch { stateMachine.dispatch(it) } },
                 )
               }
             }
@@ -291,7 +291,7 @@ internal class FileGeneratorTestComposeFragment {
                 val scope = rememberCoroutineScope()
                 Test(
                   state = currentState,
-                  sendAction = { scope.launch { stateMachine.dispatch(action) } },
+                  sendAction = { scope.launch { stateMachine.dispatch(it) } },
                 )
               }
             }
@@ -432,7 +432,7 @@ internal class FileGeneratorTestComposeFragment {
                 val scope = rememberCoroutineScope()
                 Test(
                   state = currentState,
-                  sendAction = { scope.launch { stateMachine.dispatch(action) } },
+                  sendAction = { scope.launch { stateMachine.dispatch(it) } },
                 )
               }
             }
@@ -599,7 +599,7 @@ internal class FileGeneratorTestComposeFragment {
                 val scope = rememberCoroutineScope()
                 Test(
                   state = currentState,
-                  sendAction = { scope.launch { stateMachine.dispatch(action) } },
+                  sendAction = { scope.launch { stateMachine.dispatch(it) } },
                 )
               }
             }
@@ -805,7 +805,7 @@ internal class FileGeneratorTestComposeFragment {
                 val scope = rememberCoroutineScope()
                 Test(
                   state = currentState,
-                  sendAction = { scope.launch { stateMachine.dispatch(action) } },
+                  sendAction = { scope.launch { stateMachine.dispatch(it) } },
                 )
               }
             }
@@ -956,7 +956,7 @@ internal class FileGeneratorTestComposeFragment {
                   testClass = testClass,
                   test = testClass2,
                   state = currentState,
-                  sendAction = { scope.launch { stateMachine.dispatch(action) } },
+                  sendAction = { scope.launch { stateMachine.dispatch(it) } },
                 )
               }
             }


### PR DESCRIPTION
Fixes the lambda to use `it`. This was a mistake during refactoring