### PR TITLE
add compile testing for whetstone

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,8 +76,8 @@ dependencyAnalysis {
                 // needed for compile testing
                 exclude(
                     "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                    "com.gabrielittner.renderer:connect:0.12.0",
-                    "org.jetbrains.kotlin:kotlin-compiler-embeddable:1.7.20",
+                    "com.gabrielittner.renderer:connect",
+                    "org.jetbrains.kotlin:kotlin-compiler-embeddable",
                     ":navigator:navigator-runtime-compose",
                     ":navigator:navigator-runtime-fragment",
                     ":whetstone:navigation",

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,25 @@ dependencyAnalysis {
                 exclude(":whetstone:navigation", ":whetstone:runtime-fragment")
             }
         }
+
+        project(":whetstone:compiler-test") {
+            onUnusedDependencies {
+                // needed for compile testing
+                exclude(
+                    "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
+                    "com.gabrielittner.renderer:connect:0.12.0",
+                    "org.jetbrains.kotlin:kotlin-compiler-embeddable:1.7.20",
+                    ":navigator:navigator-runtime-compose",
+                    ":navigator:navigator-runtime-fragment",
+                    ":whetstone:navigation",
+                    ":whetstone:navigation-compose",
+                    ":whetstone:navigation-fragment",
+                    ":whetstone:runtime",
+                    ":whetstone:runtime-compose",
+                    ":whetstone:runtime-fragment",
+                )
+            }
+        }
     }
 
     abi {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ auto-service = "1.0.1"
 junit = "4.13.2"
 truth = "1.1.3"
 turbine = "0.12.1"
+kotlin-compile-testing = "0.1.0"
 
 publish = "0.22.0"
 dokka = "1.7.20"
@@ -63,6 +64,7 @@ androidx-navigation-compose = { module = "androidx.navigation:navigation-compose
 androidx-navigation-fragment = { module = "androidx.navigation:navigation-fragment", version.ref = "androidx-navigation" }
 androidx-fragment = { module = "androidx.fragment:fragment", version.ref = "androidx-fragment" }
 androidx-savedstate = { module = "androidx.savedstate:savedstate", version.ref = "androidx-savedstate" }
+androidx-viewbinding = { module = "androidx.databinding:viewbinding", version.ref = "android-gradle" }
 
 
 accompanist-navigation = { module = "com.google.accompanist:accompanist-navigation-material", version.ref = "accompanist" }
@@ -72,13 +74,15 @@ anvil-compiler = { module = "com.squareup.anvil:compiler-api", version.ref = "an
 anvil-annotations = { module = "com.squareup.anvil:annotations", version.ref = "anvil" }
 anvil-utils = { module = "com.squareup.anvil:compiler-utils", version.ref = "anvil" }
 renderer = { module = "com.gabrielittner.renderer:renderer", version.ref = "renderer" }
+renderer-connect = { module = "com.gabrielittner.renderer:connect", version.ref = "renderer" }
 kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinpoet" }
 auto-service-annotations = { module = "com.google.auto.service:auto-service-annotations", version.ref = "auto-service" }
 auto-service-compiler = { module = "com.google.auto.service:auto-service", version.ref = "auto-service" }
 
-junit = { module = "junit:junit", version.ref = "junit" } 
+junit = { module = "junit:junit", version.ref = "junit" }
 truth = { module = "com.google.truth:truth", version.ref = "truth" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
+kotlin-compile-testing = { module = "dev.zacsweers.kctfork:core", version.ref = "kotlin-compile-testing" }
 
 [plugins]
 android-library = { id = "com.android.library", version.ref = "android-gradle" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,7 +21,7 @@ include ":navigator:androidx-nav"
 include ":navigator:runtime", ":navigator:runtime-compose", ":navigator:runtime-fragment"
 include ":state-machine"
 include ":text-resource"
-include ":whetstone:compiler"
+include ":whetstone:compiler", ":whetstone:compiler-test"
 include ":whetstone:runtime", ":whetstone:runtime-compose", ":whetstone:runtime-fragment"
 include ":whetstone:navigation", ":whetstone:navigation-compose", ":whetstone:navigation-fragment"
 

--- a/whetstone/compiler-test/build.gradle
+++ b/whetstone/compiler-test/build.gradle
@@ -1,0 +1,67 @@
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.android)
+}
+
+android {
+    namespace = "com.freeletics.mad.whetstone.test"
+    compileSdkVersion libs.versions.android.compile.get().toInteger()
+
+    defaultConfig {
+        minSdkVersion libs.versions.android.min.get().toInteger()
+    }
+
+    buildFeatures {
+        buildConfig = false
+    }
+
+    // still needed for Android projects despite toolchain
+    compileOptions {
+        sourceCompatibility(JavaVersion.toVersion(libs.versions.java.get()))
+        targetCompatibility(JavaVersion.toVersion(libs.versions.java.get()))
+    }
+}
+
+// workaround for https://youtrack.jetbrains.com/issue/KT-37652
+android.kotlinOptions.freeCompilerArgs += "-Xexplicit-api=strict"
+
+kotlin {
+    explicitApi()
+
+    jvmToolchain {
+        languageVersion.set(JavaLanguageVersion.of(libs.versions.java.get().toInteger()))
+    }
+}
+
+// workaround for https://issuetracker.google.com/issues/194113162
+tasks.withType(JavaCompile).configureEach {
+    javaCompiler = javaToolchains.compilerFor {
+        languageVersion = JavaLanguageVersion.of(libs.versions.java.get().toInteger())
+    }
+}
+
+dependencies {
+    testImplementation project(":whetstone:compiler")
+    testImplementation project(":whetstone:runtime")
+    testImplementation project(":whetstone:runtime-compose")
+    testImplementation project(":whetstone:runtime-fragment")
+    testImplementation project(":whetstone:navigation")
+    testImplementation project(":whetstone:navigation-compose")
+    testImplementation project(":whetstone:navigation-fragment")
+    testImplementation project(":navigator:navigator-runtime")
+    testImplementation project(":navigator:navigator-runtime-fragment")
+    testImplementation project(":navigator:navigator-runtime-compose")
+    testImplementation project(":state-machine")
+    testImplementation libs.androidx.compose.runtime
+    testImplementation libs.androidx.viewbinding
+    testImplementation libs.renderer
+    testImplementation libs.renderer.connect
+    testImplementation libs.coroutines.core
+
+    testImplementation libs.kotlinpoet
+    testImplementation libs.junit
+    testImplementation libs.truth
+    testImplementation libs.kotlin.compile.testing
+    testImplementation libs.androidx.compose.compiler
+    testImplementation(libs.kotlin.compiler) { force = true }
+}

--- a/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
+++ b/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
@@ -1,30 +1,26 @@
 package com.freeletics.mad.whetstone.codegen
 
 import com.freeletics.mad.whetstone.ComposableParameter
-import com.freeletics.mad.whetstone.ComposeFragmentData
+import com.freeletics.mad.whetstone.ComposeScreenData
 import com.freeletics.mad.whetstone.NavEntryData
 import com.freeletics.mad.whetstone.Navigation
-import com.freeletics.mad.whetstone.codegen.util.dialogFragment
-import com.freeletics.mad.whetstone.codegen.util.fragment
 import com.squareup.kotlinpoet.ClassName
-import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
-internal class FileGeneratorTestComposeFragment {
+internal class FileGeneratorTestCompose {
 
-    private val navigation = Navigation.Fragment(
+    private val navigation = Navigation.Compose(
         route = ClassName("com.test", "TestRoute"),
         destinationType = "NONE",
         destinationScope = ClassName("com.test.destination", "TestDestinationScope"),
     )
 
-    private val data = ComposeFragmentData(
+    private val data = ComposeScreenData(
         baseName = "Test",
         packageName = "com.test",
         scope = ClassName("com.test", "TestScreen"),
         parentScope = ClassName("com.test.parent", "TestParentScope"),
         stateMachine = ClassName("com.test", "TestStateMachine"),
-        fragmentBaseClass = fragment,
         navigation = null,
         navEntryData = null,
         composableParameter = emptyList()
@@ -38,28 +34,20 @@ internal class FileGeneratorTestComposeFragment {
     )
 
     @Test
-    fun `generates code for ComposeFragmentData`() {
-        val actual = FileGenerator().generate(data).toString()
-
+    fun `generates code for ComposeScreenData`() {
         val expected = """
             package com.test
 
             import android.os.Bundle
-            import android.view.LayoutInflater
-            import android.view.View
-            import android.view.ViewGroup
             import androidx.compose.runtime.Composable
             import androidx.compose.runtime.rememberCoroutineScope
-            import androidx.compose.ui.platform.ComposeView
-            import androidx.compose.ui.platform.ViewCompositionStrategy
-            import androidx.fragment.app.Fragment
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
-            import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
+            import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
             import com.test.parent.TestParentScope
@@ -81,7 +69,7 @@ internal class FileGeneratorTestComposeFragment {
             )
             public interface WhetstoneTestComponent {
               public val testStateMachine: TestStateMachine
-
+    
               public val closeables: Set<Closeable>
 
               @ContributesSubcomponent.Factory
@@ -118,32 +106,16 @@ internal class FileGeneratorTestComposeFragment {
                 }
               }
             }
-            
+
+            @Composable
             @OptIn(InternalWhetstoneApi::class)
-            public class WhetstoneTestFragment : Fragment() {
-              private lateinit var whetstoneTestComponent: WhetstoneTestComponent
-            
-              public override fun onCreateView(
-                inflater: LayoutInflater,
-                container: ViewGroup?,
-                savedInstanceState: Bundle?,
-              ): View {
-                if (!::whetstoneTestComponent.isInitialized) {
-                  val arguments = requireArguments()
-                  val viewModel = viewModel(TestParentScope::class, arguments, ::WhetstoneTestViewModel)
-                  whetstoneTestComponent = viewModel.component
-                }
+            public fun WhetstoneTest(arguments: Bundle): Unit {
+              val viewModel = rememberViewModel(TestParentScope::class, arguments, ::WhetstoneTestViewModel)
+              val component = viewModel.component
 
-                return ComposeView(requireContext()).apply {
-                  setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnLifecycleDestroyed(viewLifecycleOwner))
-
-                  setContent {
-                    WhetstoneTest(whetstoneTestComponent)
-                  }
-                }
-              }
+              WhetstoneTest(component)
             }
-
+            
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
@@ -161,36 +133,27 @@ internal class FileGeneratorTestComposeFragment {
             
         """.trimIndent()
 
-        assertThat(actual).isEqualTo(expected)
+        test(data, expected)
     }
 
     @Test
-    fun `generates code for ComposeFragmentData with navigation`() {
+    fun `generates code for ComposeScreenData with navigation`() {
         val withNavigation = data.copy(navigation = navigation)
-        val actual = FileGenerator().generate(withNavigation).toString()
 
         val expected = """
             package com.test
 
-            import android.os.Bundle
-            import android.view.LayoutInflater
-            import android.view.View
-            import android.view.ViewGroup
             import androidx.compose.runtime.Composable
             import androidx.compose.runtime.rememberCoroutineScope
-            import androidx.compose.ui.platform.ComposeView
-            import androidx.compose.ui.platform.ViewCompositionStrategy
-            import androidx.fragment.app.Fragment
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
             import com.freeletics.mad.navigator.NavEventNavigator
-            import com.freeletics.mad.navigator.fragment.handleNavigation
-            import com.freeletics.mad.navigator.fragment.requireRoute
+            import com.freeletics.mad.navigator.compose.NavigationSetup
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
-            import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
+            import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
             import com.test.destination.TestDestinationScope
@@ -215,7 +178,7 @@ internal class FileGeneratorTestComposeFragment {
               public val testStateMachine: TestStateMachine
 
               public val navEventNavigator: NavEventNavigator
-
+    
               public val closeables: Set<Closeable>
 
               @ContributesSubcomponent.Factory
@@ -252,35 +215,19 @@ internal class FileGeneratorTestComposeFragment {
                 }
               }
             }
-            
+
+            @Composable
             @OptIn(InternalWhetstoneApi::class)
-            public class WhetstoneTestFragment : Fragment() {
-              private lateinit var whetstoneTestComponent: WhetstoneTestComponent
-            
-              public override fun onCreateView(
-                inflater: LayoutInflater,
-                container: ViewGroup?,
-                savedInstanceState: Bundle?,
-              ): View {
-                if (!::whetstoneTestComponent.isInitialized) {
-                  val testRoute = requireRoute<TestRoute>()
-                  val viewModel = viewModel(TestParentScope::class, TestDestinationScope::class, testRoute,
-                      ::WhetstoneTestViewModel)
-                  whetstoneTestComponent = viewModel.component
-            
-                  handleNavigation(this, whetstoneTestComponent.navEventNavigator)
-                }
+            public fun WhetstoneTest(testRoute: TestRoute): Unit {
+              val viewModel = rememberViewModel(TestParentScope::class, TestDestinationScope::class, testRoute,
+                  ::WhetstoneTestViewModel)
+              val component = viewModel.component
 
-                return ComposeView(requireContext()).apply {
-                  setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnLifecycleDestroyed(viewLifecycleOwner))
+              NavigationSetup(component.navEventNavigator)
 
-                  setContent {
-                    WhetstoneTest(whetstoneTestComponent)
-                  }
-                }
-              }
+              WhetstoneTest(component)
             }
-
+            
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
@@ -298,38 +245,29 @@ internal class FileGeneratorTestComposeFragment {
             
         """.trimIndent()
 
-        assertThat(actual).isEqualTo(expected)
+        test(withNavigation, expected)
     }
 
     @Test
-    fun `generates code for ComposeFragmentData with navigation and destination`() {
+    fun `generates code for ComposeScreenData with navigation and destination`() {
         val withDestination = data.copy(navigation = navigation.copy(destinationType = "SCREEN"))
-        val actual = FileGenerator().generate(withDestination).toString()
 
         val expected = """
             package com.test
 
-            import android.os.Bundle
-            import android.view.LayoutInflater
-            import android.view.View
-            import android.view.ViewGroup
             import androidx.compose.runtime.Composable
             import androidx.compose.runtime.rememberCoroutineScope
-            import androidx.compose.ui.platform.ComposeView
-            import androidx.compose.ui.platform.ViewCompositionStrategy
-            import androidx.fragment.app.Fragment
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
             import com.freeletics.mad.navigator.NavEventNavigator
-            import com.freeletics.mad.navigator.fragment.NavDestination
-            import com.freeletics.mad.navigator.fragment.ScreenDestination
-            import com.freeletics.mad.navigator.fragment.handleNavigation
-            import com.freeletics.mad.navigator.fragment.requireRoute
+            import com.freeletics.mad.navigator.compose.NavDestination
+            import com.freeletics.mad.navigator.compose.NavigationSetup
+            import com.freeletics.mad.navigator.compose.ScreenDestination
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
-            import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
+            import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
             import com.test.destination.TestDestinationScope
@@ -356,7 +294,7 @@ internal class FileGeneratorTestComposeFragment {
               public val testStateMachine: TestStateMachine
 
               public val navEventNavigator: NavEventNavigator
-
+    
               public val closeables: Set<Closeable>
 
               @ContributesSubcomponent.Factory
@@ -393,35 +331,19 @@ internal class FileGeneratorTestComposeFragment {
                 }
               }
             }
-            
+
+            @Composable
             @OptIn(InternalWhetstoneApi::class)
-            public class WhetstoneTestFragment : Fragment() {
-              private lateinit var whetstoneTestComponent: WhetstoneTestComponent
-            
-              public override fun onCreateView(
-                inflater: LayoutInflater,
-                container: ViewGroup?,
-                savedInstanceState: Bundle?,
-              ): View {
-                if (!::whetstoneTestComponent.isInitialized) {
-                  val testRoute = requireRoute<TestRoute>()
-                  val viewModel = viewModel(TestParentScope::class, TestDestinationScope::class, testRoute,
-                      ::WhetstoneTestViewModel)
-                  whetstoneTestComponent = viewModel.component
-            
-                  handleNavigation(this, whetstoneTestComponent.navEventNavigator)
-                }
-            
-                return ComposeView(requireContext()).apply {
-                  setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnLifecycleDestroyed(viewLifecycleOwner))
+            public fun WhetstoneTest(testRoute: TestRoute): Unit {
+              val viewModel = rememberViewModel(TestParentScope::class, TestDestinationScope::class, testRoute,
+                  ::WhetstoneTestViewModel)
+              val component = viewModel.component
 
-                  setContent {
-                    WhetstoneTest(whetstoneTestComponent)
-                  }
-                }
-              }
+              NavigationSetup(component.navEventNavigator)
+
+              WhetstoneTest(component)
             }
-
+            
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
@@ -442,47 +364,39 @@ internal class FileGeneratorTestComposeFragment {
             public object WhetstoneTestNavDestinationModule {
               @Provides
               @IntoSet
-              public fun provideNavDestination(): NavDestination = ScreenDestination<TestRoute,
-                  WhetstoneTestFragment>()
+              public fun provideNavDestination(): NavDestination = ScreenDestination<TestRoute> {
+                WhetstoneTest(it)
+              }
             }
             
         """.trimIndent()
 
-        assertThat(actual).isEqualTo(expected)
+        test(withDestination, expected)
     }
 
     @Test
-    fun `generates code for ComposeFragmentData, with navigation, destination and navEntry`() {
-
-        val withDestinationAndNavEntry = data.copy(
+    fun `generates code for ComposeScreenData with navigation, destination and navEntry`() {
+        val withDestination = data.copy(
             navigation = navigation.copy(destinationType = "SCREEN"),
             navEntryData = navEntryData
         )
-        val actual = FileGenerator().generate(withDestinationAndNavEntry).toString()
 
         val expected = """
             package com.test
 
             import android.content.Context
-            import android.os.Bundle
-            import android.view.LayoutInflater
-            import android.view.View
-            import android.view.ViewGroup
             import androidx.compose.runtime.Composable
             import androidx.compose.runtime.rememberCoroutineScope
-            import androidx.compose.ui.platform.ComposeView
-            import androidx.compose.ui.platform.ViewCompositionStrategy
-            import androidx.fragment.app.Fragment
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
             import androidx.navigation.NavBackStackEntry
             import com.freeletics.mad.navigator.NavEventNavigator
             import com.freeletics.mad.navigator.`internal`.InternalNavigatorApi
             import com.freeletics.mad.navigator.`internal`.destinationId
-            import com.freeletics.mad.navigator.fragment.NavDestination
-            import com.freeletics.mad.navigator.fragment.ScreenDestination
-            import com.freeletics.mad.navigator.fragment.handleNavigation
-            import com.freeletics.mad.navigator.fragment.requireRoute
+            import com.freeletics.mad.navigator.`internal`.requireRoute
+            import com.freeletics.mad.navigator.compose.NavDestination
+            import com.freeletics.mad.navigator.compose.NavigationSetup
+            import com.freeletics.mad.navigator.compose.ScreenDestination
             import com.freeletics.mad.whetstone.NavEntry
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
@@ -491,7 +405,8 @@ internal class FileGeneratorTestComposeFragment {
             import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetter
             import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetterKey
             import com.freeletics.mad.whetstone.`internal`.asComposeState
-            import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
+            import com.freeletics.mad.whetstone.`internal`.viewModel
+            import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
             import com.squareup.anvil.annotations.ContributesMultibinding
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
@@ -510,7 +425,6 @@ internal class FileGeneratorTestComposeFragment {
             import kotlin.Unit
             import kotlin.collections.Set
             import kotlinx.coroutines.launch
-            import com.freeletics.mad.navigator.`internal`.requireRoute as bundleRequireRoute
 
             @OptIn(InternalWhetstoneApi::class)
             @ScopeTo(TestScreen::class)
@@ -561,32 +475,16 @@ internal class FileGeneratorTestComposeFragment {
               }
             }
 
+            @Composable
             @OptIn(InternalWhetstoneApi::class)
-            public class WhetstoneTestFragment : Fragment() {
-              private lateinit var whetstoneTestComponent: WhetstoneTestComponent
+            public fun WhetstoneTest(testRoute: TestRoute): Unit {
+              val viewModel = rememberViewModel(TestParentScope::class, TestDestinationScope::class, testRoute,
+                  ::WhetstoneTestViewModel)
+              val component = viewModel.component
 
-              public override fun onCreateView(
-                inflater: LayoutInflater,
-                container: ViewGroup?,
-                savedInstanceState: Bundle?,
-              ): View {
-                if (!::whetstoneTestComponent.isInitialized) {
-                  val testRoute = requireRoute<TestRoute>()
-                  val viewModel = viewModel(TestParentScope::class, TestDestinationScope::class, testRoute,
-                      ::WhetstoneTestViewModel)
-                  whetstoneTestComponent = viewModel.component
+              NavigationSetup(component.navEventNavigator)
 
-                  handleNavigation(this, whetstoneTestComponent.navEventNavigator)
-                }
-
-                return ComposeView(requireContext()).apply {
-                  setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnLifecycleDestroyed(viewLifecycleOwner))
-
-                  setContent {
-                    WhetstoneTest(whetstoneTestComponent)
-                  }
-                }
-              }
+              WhetstoneTest(component)
             }
 
             @Composable
@@ -609,8 +507,9 @@ internal class FileGeneratorTestComposeFragment {
             public object WhetstoneTestNavDestinationModule {
               @Provides
               @IntoSet
-              public fun provideNavDestination(): NavDestination = ScreenDestination<TestRoute,
-                  WhetstoneTestFragment>()
+              public fun provideNavDestination(): NavDestination = ScreenDestination<TestRoute> {
+                WhetstoneTest(it)
+              }
             }
 
             @OptIn(InternalWhetstoneApi::class)
@@ -671,10 +570,9 @@ internal class FileGeneratorTestComposeFragment {
               @OptIn(InternalWhetstoneApi::class, InternalNavigatorApi::class)
               public override fun retrieve(findEntry: (Int) -> NavBackStackEntry, context: Context): Any {
                 val entry = findEntry(TestRoute::class.destinationId())
-                val route: TestRoute = entry.arguments.bundleRequireRoute()
-                val viewModel = com.freeletics.mad.whetstone.`internal`.viewModel(entry, context,
-                    TestParentScope::class, TestDestinationScope::class, route, findEntry,
-                    ::WhetstoneTestScreenNavEntryViewModel)
+                val route: TestRoute = entry.arguments.requireRoute()
+                val viewModel = viewModel(entry, context, TestParentScope::class, TestDestinationScope::class,
+                    route, findEntry, ::WhetstoneTestScreenNavEntryViewModel)
                 return viewModel.component
               }
             }
@@ -684,35 +582,42 @@ internal class FileGeneratorTestComposeFragment {
             public interface WhetstoneTestScreenNavEntryDestinationComponent : DestinationComponent
 
         """.trimIndent()
-        assertThat(actual).isEqualTo(expected)
+
+        test(withDestination, expected)
     }
 
     @Test
-    fun `generates code for ComposeFragmentData, dialog fragment`() {
-        val dialogFragment = data.copy(fragmentBaseClass = dialogFragment)
-        val actual = FileGenerator().generate(dialogFragment).toString()
+    fun `generates code for ComposeScreenData with Composable Dependencies`() {
+        val withInjectedParameters = data.copy(
+            baseName = "Test2",
+            composableParameter = listOf(
+                ComposableParameter(
+                    name = "testClass",
+                    className = ClassName("com.test", "TestClass"),
+                ),
+                ComposableParameter(
+                    name = "test",
+                    className = ClassName("com.test.other", "TestClass2"),
+                )
+            )
+        )
 
         val expected = """
             package com.test
 
             import android.os.Bundle
-            import android.view.LayoutInflater
-            import android.view.View
-            import android.view.ViewGroup
             import androidx.compose.runtime.Composable
             import androidx.compose.runtime.rememberCoroutineScope
-            import androidx.compose.ui.platform.ComposeView
-            import androidx.compose.ui.platform.ViewCompositionStrategy
-            import androidx.fragment.app.DialogFragment
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.asComposeState
-            import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
+            import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
+            import com.test.other.TestClass2
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
             import dagger.Module
@@ -730,152 +635,9 @@ internal class FileGeneratorTestComposeFragment {
               parentScope = TestParentScope::class,
               modules = [ComposeProviderValueModule::class],
             )
-            public interface WhetstoneTestComponent {
+            public interface WhetstoneTest2Component {
               public val testStateMachine: TestStateMachine
-
-              public val closeables: Set<Closeable>
-
-              @ContributesSubcomponent.Factory
-              public interface Factory {
-                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
-                    arguments: Bundle): WhetstoneTestComponent
-              }
-
-              @ContributesTo(TestParentScope::class)
-              public interface ParentComponent {
-                public fun whetstoneTestComponentFactory(): Factory
-              }
-            }
-
-            @Module
-            @ContributesTo(TestScreen::class)
-            public interface WhetstoneTestModule {
-              @Multibinds
-              public fun bindCloseables(): Set<Closeable>
-            }
-
-            @InternalWhetstoneApi
-            internal class WhetstoneTestViewModel(
-              parentComponent: WhetstoneTestComponent.ParentComponent,
-              savedStateHandle: SavedStateHandle,
-              arguments: Bundle,
-            ) : ViewModel() {
-              public val component: WhetstoneTestComponent =
-                  parentComponent.whetstoneTestComponentFactory().create(savedStateHandle, arguments)
-
-              public override fun onCleared(): Unit {
-                component.closeables.forEach {
-                  it.close()
-                }
-              }
-            }
-            
-            @OptIn(InternalWhetstoneApi::class)
-            public class WhetstoneTestFragment : DialogFragment() {
-              private lateinit var whetstoneTestComponent: WhetstoneTestComponent
-            
-              public override fun onCreateView(
-                inflater: LayoutInflater,
-                container: ViewGroup?,
-                savedInstanceState: Bundle?,
-              ): View {
-                if (!::whetstoneTestComponent.isInitialized) {
-                  val arguments = requireArguments()
-                  val viewModel = viewModel(TestParentScope::class, arguments, ::WhetstoneTestViewModel)
-                  whetstoneTestComponent = viewModel.component
-                }
-
-                return ComposeView(requireContext()).apply {
-                  setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnLifecycleDestroyed(viewLifecycleOwner))
-
-                  setContent {
-                    WhetstoneTest(whetstoneTestComponent)
-                  }
-                }
-              }
-            }
-
-            @Composable
-            @OptIn(InternalWhetstoneApi::class)
-            private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
-              val stateMachine = component.testStateMachine
-              val state = stateMachine.asComposeState()
-              val currentState = state.value
-              if (currentState != null) {
-                val scope = rememberCoroutineScope()
-                Test(
-                  state = currentState,
-                  sendAction = { scope.launch { stateMachine.dispatch(it) } },
-                )
-              }
-            }
-
-        """.trimIndent()
-
-        assertThat(actual).isEqualTo(expected)
-    }
-
-    @Test
-    fun `generates code for ComposeFragmentData with Composable Depedencies`() {
-        val actual = FileGenerator()
-            .generate(
-                data.copy(
-                    composableParameter = listOf(
-                        ComposableParameter(
-                            name = "testClass",
-                            className = ClassName("com.test", "TestClass"),
-                        ),
-                        ComposableParameter(
-                            name = "test",
-                            className = ClassName("com.other", "TestClass2"),
-                        )
-                    )
-                )
-            )
-            .toString()
-
-        val expected = """
-            package com.test
-
-            import android.os.Bundle
-            import android.view.LayoutInflater
-            import android.view.View
-            import android.view.ViewGroup
-            import androidx.compose.runtime.Composable
-            import androidx.compose.runtime.rememberCoroutineScope
-            import androidx.compose.ui.platform.ComposeView
-            import androidx.compose.ui.platform.ViewCompositionStrategy
-            import androidx.fragment.app.Fragment
-            import androidx.lifecycle.SavedStateHandle
-            import androidx.lifecycle.ViewModel
-            import com.freeletics.mad.whetstone.ScopeTo
-            import com.freeletics.mad.whetstone.`internal`.ComposeProviderValueModule
-            import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
-            import com.freeletics.mad.whetstone.`internal`.asComposeState
-            import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
-            import com.other.TestClass2
-            import com.squareup.anvil.annotations.ContributesSubcomponent
-            import com.squareup.anvil.annotations.ContributesTo
-            import com.test.parent.TestParentScope
-            import dagger.BindsInstance
-            import dagger.Module
-            import dagger.multibindings.Multibinds
-            import java.io.Closeable
-            import kotlin.OptIn
-            import kotlin.Unit
-            import kotlin.collections.Set
-            import kotlinx.coroutines.launch
-
-            @OptIn(InternalWhetstoneApi::class)
-            @ScopeTo(TestScreen::class)
-            @ContributesSubcomponent(
-              scope = TestScreen::class,
-              parentScope = TestParentScope::class,
-              modules = [ComposeProviderValueModule::class],
-            )
-            public interface WhetstoneTestComponent {
-              public val testStateMachine: TestStateMachine
-
+    
               public val closeables: Set<Closeable>
 
               public val testClass: TestClass
@@ -885,30 +647,30 @@ internal class FileGeneratorTestComposeFragment {
               @ContributesSubcomponent.Factory
               public interface Factory {
                 public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
-                    arguments: Bundle): WhetstoneTestComponent
+                    arguments: Bundle): WhetstoneTest2Component
               }
 
               @ContributesTo(TestParentScope::class)
               public interface ParentComponent {
-                public fun whetstoneTestComponentFactory(): Factory
+                public fun whetstoneTest2ComponentFactory(): Factory
               }
             }
 
             @Module
             @ContributesTo(TestScreen::class)
-            public interface WhetstoneTestModule {
+            public interface WhetstoneTest2Module {
               @Multibinds
               public fun bindCloseables(): Set<Closeable>
             }
 
             @InternalWhetstoneApi
-            internal class WhetstoneTestViewModel(
-              parentComponent: WhetstoneTestComponent.ParentComponent,
+            internal class WhetstoneTest2ViewModel(
+              parentComponent: WhetstoneTest2Component.ParentComponent,
               savedStateHandle: SavedStateHandle,
               arguments: Bundle,
             ) : ViewModel() {
-              public val component: WhetstoneTestComponent =
-                  parentComponent.whetstoneTestComponentFactory().create(savedStateHandle, arguments)
+              public val component: WhetstoneTest2Component =
+                  parentComponent.whetstoneTest2ComponentFactory().create(savedStateHandle, arguments)
 
               public override fun onCleared(): Unit {
                 component.closeables.forEach {
@@ -916,35 +678,19 @@ internal class FileGeneratorTestComposeFragment {
                 }
               }
             }
-            
-            @OptIn(InternalWhetstoneApi::class)
-            public class WhetstoneTestFragment : Fragment() {
-              private lateinit var whetstoneTestComponent: WhetstoneTestComponent
-            
-              public override fun onCreateView(
-                inflater: LayoutInflater,
-                container: ViewGroup?,
-                savedInstanceState: Bundle?,
-              ): View {
-                if (!::whetstoneTestComponent.isInitialized) {
-                  val arguments = requireArguments()
-                  val viewModel = viewModel(TestParentScope::class, arguments, ::WhetstoneTestViewModel)
-                  whetstoneTestComponent = viewModel.component
-                }
-
-                return ComposeView(requireContext()).apply {
-                  setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnLifecycleDestroyed(viewLifecycleOwner))
-
-                  setContent {
-                    WhetstoneTest(whetstoneTestComponent)
-                  }
-                }
-              }
-            }
 
             @Composable
             @OptIn(InternalWhetstoneApi::class)
-            private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
+            public fun WhetstoneTest2(arguments: Bundle): Unit {
+              val viewModel = rememberViewModel(TestParentScope::class, arguments, ::WhetstoneTest2ViewModel)
+              val component = viewModel.component
+
+              WhetstoneTest2(component)
+            }
+            
+            @Composable
+            @OptIn(InternalWhetstoneApi::class)
+            private fun WhetstoneTest2(component: WhetstoneTest2Component): Unit {
               val testClass = component.testClass
               val testClass2 = component.testClass2
               val stateMachine = component.testStateMachine
@@ -952,7 +698,7 @@ internal class FileGeneratorTestComposeFragment {
               val currentState = state.value
               if (currentState != null) {
                 val scope = rememberCoroutineScope()
-                Test(
+                Test2(
                   testClass = testClass,
                   test = testClass2,
                   state = currentState,
@@ -963,6 +709,6 @@ internal class FileGeneratorTestComposeFragment {
             
         """.trimIndent()
 
-        assertThat(actual).isEqualTo(expected)
+        test(withInjectedParameters, expected)
     }
 }

--- a/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestRendererFragment.kt
+++ b/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestRendererFragment.kt
@@ -4,7 +4,6 @@ import com.freeletics.mad.whetstone.NavEntryData
 import com.freeletics.mad.whetstone.Navigation
 import com.freeletics.mad.whetstone.RendererFragmentData
 import com.squareup.kotlinpoet.ClassName
-import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 internal class FileGeneratorTestRendererFragment {
@@ -21,7 +20,7 @@ internal class FileGeneratorTestRendererFragment {
         scope = ClassName("com.test", "TestScreen"),
         parentScope = ClassName("com.test.parent", "TestParentScope"),
         stateMachine = ClassName("com.test", "TestStateMachine"),
-        factory = ClassName("com.test", "RendererFactory"),
+        factory = ClassName("com.test", "TestRenderer").nestedClass("Factory"),
         fragmentBaseClass = ClassName("androidx.fragment.app", "Fragment"),
         navigation = null,
         navEntryData = null,
@@ -36,8 +35,6 @@ internal class FileGeneratorTestRendererFragment {
 
     @Test
     fun `generates code for RendererFragmentData`() {
-        val actual = FileGenerator().generate(data).toString()
-
         val expected = """
             package com.test
 
@@ -74,7 +71,7 @@ internal class FileGeneratorTestRendererFragment {
             
               public val closeables: Set<Closeable>
 
-              public val rendererFactory: RendererFactory
+              public val testRendererFactory: TestRenderer.Factory
 
               @ContributesSubcomponent.Factory
               public interface Factory {
@@ -126,7 +123,7 @@ internal class FileGeneratorTestRendererFragment {
                   whetstoneTestComponent = viewModel.component
                 }
             
-                val renderer = whetstoneTestComponent.rendererFactory.inflate(inflater, container)
+                val renderer = whetstoneTestComponent.testRendererFactory.inflate(inflater, container)
                 connect(renderer, whetstoneTestComponent.testStateMachine)
                 return renderer.rootView
               }
@@ -134,13 +131,12 @@ internal class FileGeneratorTestRendererFragment {
             
         """.trimIndent()
 
-        assertThat(actual).isEqualTo(expected)
+        test(data, expected)
     }
 
     @Test
     fun `generates code for RendererFragmentData with navigation`() {
         val withNavigation = data.copy(navigation = navigation)
-        val actual = FileGenerator().generate(withNavigation).toString()
 
         val expected = """
             package com.test
@@ -184,7 +180,7 @@ internal class FileGeneratorTestRendererFragment {
             
               public val closeables: Set<Closeable>
 
-              public val rendererFactory: RendererFactory
+              public val testRendererFactory: TestRenderer.Factory
 
               @ContributesSubcomponent.Factory
               public interface Factory {
@@ -239,7 +235,7 @@ internal class FileGeneratorTestRendererFragment {
                   handleNavigation(this, whetstoneTestComponent.navEventNavigator)
                 }
             
-                val renderer = whetstoneTestComponent.rendererFactory.inflate(inflater, container)
+                val renderer = whetstoneTestComponent.testRendererFactory.inflate(inflater, container)
                 connect(renderer, whetstoneTestComponent.testStateMachine)
                 return renderer.rootView
               }
@@ -247,13 +243,12 @@ internal class FileGeneratorTestRendererFragment {
             
         """.trimIndent()
 
-        assertThat(actual).isEqualTo(expected)
+        test(withNavigation, expected)
     }
 
     @Test
     fun `generates code for RendererFragmentData with navigation and destination`() {
         val withDestination = data.copy(navigation = navigation.copy(destinationType = "SCREEN"))
-        val actual = FileGenerator().generate(withDestination).toString()
 
         val expected = """
             package com.test
@@ -301,7 +296,7 @@ internal class FileGeneratorTestRendererFragment {
             
               public val closeables: Set<Closeable>
 
-              public val rendererFactory: RendererFactory
+              public val testRendererFactory: TestRenderer.Factory
 
               @ContributesSubcomponent.Factory
               public interface Factory {
@@ -356,7 +351,7 @@ internal class FileGeneratorTestRendererFragment {
                   handleNavigation(this, whetstoneTestComponent.navEventNavigator)
                 }
             
-                val renderer = whetstoneTestComponent.rendererFactory.inflate(inflater, container)
+                val renderer = whetstoneTestComponent.testRendererFactory.inflate(inflater, container)
                 connect(renderer, whetstoneTestComponent.testStateMachine)
                 return renderer.rootView
               }
@@ -373,7 +368,7 @@ internal class FileGeneratorTestRendererFragment {
             
         """.trimIndent()
 
-        assertThat(actual).isEqualTo(expected)
+        test(withDestination, expected)
     }
 
     @Test
@@ -382,7 +377,6 @@ internal class FileGeneratorTestRendererFragment {
             navigation = navigation.copy(destinationType = "SCREEN"),
             navEntryData = navEntryData
         )
-        val actual = FileGenerator().generate(withDestination).toString()
 
         val expected = """
             package com.test
@@ -443,7 +437,7 @@ internal class FileGeneratorTestRendererFragment {
 
               public val closeables: Set<Closeable>
 
-              public val rendererFactory: RendererFactory
+              public val testRendererFactory: TestRenderer.Factory
 
               @ContributesSubcomponent.Factory
               public interface Factory {
@@ -498,7 +492,7 @@ internal class FileGeneratorTestRendererFragment {
                   handleNavigation(this, whetstoneTestComponent.navEventNavigator)
                 }
 
-                val renderer = whetstoneTestComponent.rendererFactory.inflate(inflater, container)
+                val renderer = whetstoneTestComponent.testRendererFactory.inflate(inflater, container)
                 connect(renderer, whetstoneTestComponent.testStateMachine)
                 return renderer.rootView
               }
@@ -584,7 +578,8 @@ internal class FileGeneratorTestRendererFragment {
             public interface WhetstoneTestScreenNavEntryDestinationComponent : DestinationComponent
             
         """.trimIndent()
-        assertThat(actual).isEqualTo(expected)
+
+        test(withDestination, expected)
     }
 
     @Test
@@ -592,7 +587,6 @@ internal class FileGeneratorTestRendererFragment {
         val dialogFragment = data.copy(
             fragmentBaseClass = ClassName("androidx.fragment.app", "DialogFragment")
         )
-        val actual = FileGenerator().generate(dialogFragment).toString()
 
         val expected = """
             package com.test
@@ -630,7 +624,7 @@ internal class FileGeneratorTestRendererFragment {
             
               public val closeables: Set<Closeable>
 
-              public val rendererFactory: RendererFactory
+              public val testRendererFactory: TestRenderer.Factory
 
               @ContributesSubcomponent.Factory
               public interface Factory {
@@ -682,7 +676,7 @@ internal class FileGeneratorTestRendererFragment {
                   whetstoneTestComponent = viewModel.component
                 }
             
-                val renderer = whetstoneTestComponent.rendererFactory.inflate(inflater, container)
+                val renderer = whetstoneTestComponent.testRendererFactory.inflate(inflater, container)
                 connect(renderer, whetstoneTestComponent.testStateMachine)
                 return renderer.rootView
               }
@@ -690,6 +684,6 @@ internal class FileGeneratorTestRendererFragment {
 
         """.trimIndent()
 
-        assertThat(actual).isEqualTo(expected)
+        test(dialogFragment, expected)
     }
 }

--- a/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/TestHelper.kt
+++ b/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/TestHelper.kt
@@ -1,0 +1,43 @@
+package com.freeletics.mad.whetstone.codegen
+
+import androidx.compose.compiler.plugins.kotlin.ComposeComponentRegistrar
+import com.freeletics.mad.whetstone.ComposeFragmentData
+import com.freeletics.mad.whetstone.ComposeScreenData
+import com.freeletics.mad.whetstone.RendererFragmentData
+import com.google.common.truth.Truth.assertThat
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
+import com.tschuchort.compiletesting.SourceFile
+
+public fun test(data: ComposeScreenData, expected: String) {
+    val actual = FileGenerator().generate(data).toString()
+    assertThat(actual).isEqualTo(expected)
+    compile(actual)
+}
+
+public fun test(data: ComposeFragmentData, expected: String) {
+    val actual = FileGenerator().generate(data).toString()
+    assertThat(actual).isEqualTo(expected)
+    compile(actual)
+}
+
+public fun test(data: RendererFragmentData, expected: String) {
+    val actual = FileGenerator().generate(data).toString()
+    assertThat(actual).isEqualTo(expected)
+    compile(actual)
+}
+
+private fun compile(source: String) {
+    val result = KotlinCompilation().apply {
+        sources = listOf(SourceFile.kotlin("WhetstoneTest.kt", source))
+        compilerPlugins = listOf(ComposeComponentRegistrar())
+        kotlincArguments = listOf(
+            "-P",
+            "plugin:androidx.compose.compiler.plugins.kotlin:suppressKotlinVersionCompatibilityCheck=1.7.22"
+        )
+        jvmTarget = "11"
+        inheritClassPath = true
+        messageOutputStream = System.out // see diagnostics in real time
+    }.compile()
+    assertThat(result.exitCode).isEqualTo(ExitCode.OK)
+}

--- a/whetstone/compiler-test/src/test/kotlin/com/test/TestFixtures.kt
+++ b/whetstone/compiler-test/src/test/kotlin/com/test/TestFixtures.kt
@@ -1,0 +1,57 @@
+package com.test
+
+import android.os.Parcel
+import android.view.View
+import androidx.compose.runtime.Composable
+import androidx.viewbinding.ViewBinding
+import com.freeletics.mad.navigator.NavRoute
+import com.freeletics.mad.statemachine.StateMachine
+import com.gabrielittner.renderer.ViewRenderer
+import com.test.other.TestClass2
+import kotlinx.coroutines.flow.Flow
+
+public class TestScreen
+public class TestClass
+
+public class TestRoute : NavRoute {
+    override fun describeContents(): Int = 0
+    override fun writeToParcel(p0: Parcel, p1: Int) {}
+}
+
+@Suppress("UNUSED_PARAMETER")
+@Composable
+public fun Test(
+    state: TestState,
+    sendAction: (TestAction) -> Unit
+) {}
+
+@Suppress("UNUSED_PARAMETER")
+@Composable
+public fun Test2(
+    testClass: TestClass,
+    test: TestClass2,
+    state: TestState,
+    sendAction: (TestAction) -> Unit
+) {}
+
+public class TestBinding : ViewBinding {
+    override fun getRoot(): View = throw UnsupportedOperationException("Not implemented")
+}
+
+public class TestRenderer(view: View) : ViewRenderer<TestState, TestAction>(view) {
+    override fun renderToView(state: TestState) {}
+
+    public abstract class Factory : ViewRenderer.Factory<TestBinding, TestRenderer>({ _, _, _ -> TestBinding() })
+}
+
+public class TestStateMachine : StateMachine<TestState, TestAction> {
+    override val state: Flow<TestState>
+        get() = throw UnsupportedOperationException("Not implemented")
+
+    override suspend fun dispatch(action: TestAction) {
+        throw UnsupportedOperationException("Not implemented")
+    }
+}
+
+public object TestAction
+public object TestState

--- a/whetstone/compiler-test/src/test/kotlin/com/test/destination/TestDestinationScope.kt
+++ b/whetstone/compiler-test/src/test/kotlin/com/test/destination/TestDestinationScope.kt
@@ -1,0 +1,3 @@
+package com.test.destination
+
+public class TestDestinationScope

--- a/whetstone/compiler-test/src/test/kotlin/com/test/other/TestClass2.kt
+++ b/whetstone/compiler-test/src/test/kotlin/com/test/other/TestClass2.kt
@@ -1,0 +1,3 @@
+package com.test.other
+
+public class TestClass2

--- a/whetstone/compiler-test/src/test/kotlin/com/test/parent/TestParentScope.kt
+++ b/whetstone/compiler-test/src/test/kotlin/com/test/parent/TestParentScope.kt
@@ -1,0 +1,3 @@
+package com.test.parent
+
+public class TestParentScope

--- a/whetstone/compiler/build.gradle
+++ b/whetstone/compiler/build.gradle
@@ -15,13 +15,10 @@ kotlin {
 dependencies {
     api libs.kotlin.compiler
     api libs.anvil.compiler
+    api libs.kotlinpoet
     implementation libs.anvil.annotations
     implementation libs.anvil.utils
-    implementation libs.kotlinpoet
 
     compileOnly libs.auto.service.annotations
     kapt libs.auto.service.compiler
-
-    testImplementation libs.junit
-    testImplementation libs.truth
 }

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/Data.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/Data.kt
@@ -10,29 +10,29 @@ import com.freeletics.mad.whetstone.codegen.util.fragmentScreenDestination
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.MemberName
 
-internal sealed interface BaseData {
-    val baseName: String
-    val packageName: String
+public sealed interface BaseData {
+    public val baseName: String
+    public val packageName: String
 
-    val scope: ClassName
-    val parentScope: ClassName
+    public val scope: ClassName
+    public val parentScope: ClassName
 
-    val stateMachine: ClassName?
-    val navigation: Navigation?
+    public val stateMachine: ClassName?
+    public val navigation: Navigation?
 }
 
-internal sealed interface ComposeData : BaseData {
+public sealed interface ComposeData : BaseData {
     override val stateMachine: ClassName
-    val navEntryData: NavEntryData?
-    val composableParameter: List<ComposableParameter>
+    public val navEntryData: NavEntryData?
+    public val composableParameter: List<ComposableParameter>
 }
 
-internal data class ComposableParameter(
-    val name: String,
-    val className: ClassName
+public data class ComposableParameter(
+    public val name: String,
+    public val className: ClassName
 )
 
-internal data class ComposeScreenData(
+public data class ComposeScreenData(
     override val baseName: String,
     override val packageName: String,
 
@@ -46,13 +46,13 @@ internal data class ComposeScreenData(
     override val composableParameter: List<ComposableParameter>,
 ) :  ComposeData
 
-internal sealed interface FragmentData : BaseData {
-    val fragmentBaseClass: ClassName
+public sealed interface FragmentData : BaseData {
+    public val fragmentBaseClass: ClassName
     override val navigation: Navigation.Fragment?
-    val navEntryData: NavEntryData?
+    public val navEntryData: NavEntryData?
 }
 
-internal data class ComposeFragmentData(
+public data class ComposeFragmentData(
     override val baseName: String,
     override val packageName: String,
 
@@ -67,7 +67,7 @@ internal data class ComposeFragmentData(
     override val composableParameter: List<ComposableParameter>,
 ) : ComposeData, FragmentData
 
-internal data class RendererFragmentData(
+public data class RendererFragmentData(
     override val baseName: String,
     override val packageName: String,
 
@@ -75,14 +75,14 @@ internal data class RendererFragmentData(
     override val parentScope: ClassName,
 
     override val stateMachine: ClassName,
-    val factory: ClassName,
+    public val factory: ClassName,
     override val fragmentBaseClass: ClassName,
 
     override val navigation: Navigation.Fragment?,
     override val navEntryData: NavEntryData?,
 ) : FragmentData
 
-internal data class NavEntryData(
+public data class NavEntryData(
     override val packageName: String,
 
     override val scope: ClassName,
@@ -95,20 +95,20 @@ internal data class NavEntryData(
     override val stateMachine: ClassName? = null
 }
 
-internal sealed interface Navigation {
-    val route: ClassName
-    val destinationClass: ClassName
-    val destinationScope: ClassName
-    val destinationMethod: MemberName?
+public sealed interface Navigation {
+    public val route: ClassName
+    public val destinationClass: ClassName
+    public val destinationScope: ClassName
+    public val destinationMethod: MemberName?
 
-    data class Compose(
+    public data class Compose(
         override val route: ClassName,
         private val destinationType: String,
         override val destinationScope: ClassName,
     ) : Navigation {
         override val destinationClass: ClassName = composeDestination
 
-        override val destinationMethod = when(destinationType) {
+        override val destinationMethod: MemberName? = when(destinationType) {
             "NONE" -> null
             "SCREEN" -> composeScreenDestination
             "DIALOG" -> composeDialogDestination
@@ -117,14 +117,14 @@ internal sealed interface Navigation {
         }
     }
 
-    data class Fragment(
+    public data class Fragment(
         override val route: ClassName,
         private val destinationType: String,
         override val destinationScope: ClassName,
     ) : Navigation {
         override val destinationClass: ClassName = fragmentDestination
 
-        override val destinationMethod = when(destinationType) {
+        override val destinationMethod: MemberName? = when(destinationType) {
             "NONE" -> null
             "SCREEN" -> fragmentScreenDestination
             "DIALOG" -> fragmentDialogDestination

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/FileGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/FileGenerator.kt
@@ -19,9 +19,9 @@ import com.freeletics.mad.whetstone.codegen.fragment.RendererFragmentGenerator
 import com.freeletics.mad.whetstone.codegen.util.bundleRequireRoute
 import com.squareup.kotlinpoet.FileSpec
 
-internal class FileGenerator{
+public class FileGenerator{
 
-    fun generate(data: ComposeScreenData): FileSpec {
+    public fun generate(data: ComposeScreenData): FileSpec {
         val componentGenerator = ComponentGenerator(data)
         val moduleGenerator = ModuleGenerator(data)
         val viewModelGenerator = ViewModelGenerator(data)
@@ -39,7 +39,7 @@ internal class FileGenerator{
             .build()
     }
 
-    fun generate(data: ComposeFragmentData): FileSpec {
+    public fun generate(data: ComposeFragmentData): FileSpec {
         val componentGenerator = ComponentGenerator(data)
         val moduleGenerator = ModuleGenerator(data)
         val viewModelGenerator = ViewModelGenerator(data)
@@ -57,7 +57,7 @@ internal class FileGenerator{
             .build()
     }
 
-    fun generate(data: RendererFragmentData): FileSpec {
+    public fun generate(data: RendererFragmentData): FileSpec {
         val componentGenerator = ComponentGenerator(data)
         val moduleGenerator = ModuleGenerator(data)
         val viewModelGenerator = ViewModelGenerator(data)


### PR DESCRIPTION
Closes #13 

With this each test will not just check that the output matches what we expect but also that the code actually compiles. For this to work I've needed to move the tests to their own module which use com.android.library which allows us to depend on other Android libraries which we need at compilation time. The existing calls to `FileGenerator` and `assertThat` have been moved to `test` helper functions that will then use kotlin-compile-testing to invoke the Kotlin compiler.

In a future iteration of this we could remove the `Test` and `Test2` composables as well as the `TestRenderer` and replace them with string based inputs to `test` that alos include the whetstone annotations. With that we could run Anvil as part of the compilation and also check that the creation of our data models works correctly.