### PR TITLE
move AndroidX navigation specific code more into androidx-nav module

### DIFF
--- a/navigator/androidx-nav/api/androidx-nav.api
+++ b/navigator/androidx-nav/api/androidx-nav.api
@@ -1,0 +1,3 @@
+public final class com/freeletics/mad/navigator/internal/DestinationIdKt {
+}
+

--- a/navigator/androidx-nav/build.gradle
+++ b/navigator/androidx-nav/build.gradle
@@ -52,5 +52,6 @@ dependencies {
     implementation project(":navigator:navigator-runtime")
     implementation libs.androidx.navigation.common
     implementation libs.androidx.navigation.runtime
+    implementation libs.androidx.viewmodel
     implementation libs.androidx.viewmodel.savedstate
 }

--- a/navigator/androidx-nav/src/main/java/com/freeletics/mad/navigator/internal/AndroidXNavigationExecutor.kt
+++ b/navigator/androidx-nav/src/main/java/com/freeletics/mad/navigator/internal/AndroidXNavigationExecutor.kt
@@ -1,6 +1,9 @@
 package com.freeletics.mad.navigator.internal
 
 import android.os.Parcelable
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModelStore
+import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
 import androidx.navigation.NavOptions
 import com.freeletics.mad.navigator.ActivityRoute
@@ -45,11 +48,26 @@ public class AndroidXNavigationExecutor(
     }
 
     override fun deliverResult(key: NavigationResultRequest.Key<*>, result: Parcelable) {
-        val entry = controller.getBackStackEntry(key.destinationId)
-        entry.savedStateHandle.set(key.requestKey, result)
+        savedStateHandleFor(key.route)[key.requestKey] = result
     }
 
     override fun navigateBackTo(route: KClass<out BaseRoute>, isInclusive: Boolean) {
         controller.popBackStack(route.destinationId(), isInclusive)
+    }
+
+    override fun savedStateHandleFor(route: KClass<out BaseRoute>): SavedStateHandle {
+        return entryFor(route).savedStateHandle
+    }
+
+    override fun <T : BaseRoute> routeFor(route: KClass<T>): T {
+        return entryFor(route).arguments.requireRoute()
+    }
+
+    override fun viewModelStoreFor(route: KClass<out BaseRoute>): ViewModelStore {
+        return entryFor(route).viewModelStore
+    }
+
+    private fun entryFor(route: KClass<out BaseRoute>): NavBackStackEntry {
+        return controller.getBackStackEntry(route.destinationId())
     }
 }

--- a/navigator/androidx-nav/src/main/java/com/freeletics/mad/navigator/internal/DestinationId.kt
+++ b/navigator/androidx-nav/src/main/java/com/freeletics/mad/navigator/internal/DestinationId.kt
@@ -1,0 +1,20 @@
+package com.freeletics.mad.navigator.internal
+
+import com.freeletics.mad.navigator.ActivityRoute
+import com.freeletics.mad.navigator.BaseRoute
+import kotlin.reflect.KClass
+
+
+@InternalNavigatorApi
+public fun BaseRoute.destinationId(): Int = this::class.destinationId()
+
+@InternalNavigatorApi
+public fun KClass<out BaseRoute>.destinationId(): Int = internalDestinationId()
+
+@InternalNavigatorApi
+public fun ActivityRoute.destinationId(): Int = this::class.activityDestinationId()
+
+@InternalNavigatorApi
+public fun KClass<out ActivityRoute>.activityDestinationId(): Int = internalDestinationId()
+
+private fun KClass<*>.internalDestinationId() = qualifiedName!!.hashCode()

--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavHost.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavHost.kt
@@ -29,8 +29,10 @@ import com.freeletics.mad.navigator.compose.NavDestination.Activity
 import com.freeletics.mad.navigator.compose.NavDestination.BottomSheet
 import com.freeletics.mad.navigator.compose.NavDestination.Dialog
 import com.freeletics.mad.navigator.compose.NavDestination.Screen
+import com.freeletics.mad.navigator.internal.AndroidXNavigationExecutor
 import com.freeletics.mad.navigator.internal.CustomActivityNavigator
 import com.freeletics.mad.navigator.internal.InternalNavigatorApi
+import com.freeletics.mad.navigator.internal.NavigationExecutor
 import com.freeletics.mad.navigator.internal.activityDestinationId
 import com.freeletics.mad.navigator.internal.destinationId
 import com.freeletics.mad.navigator.internal.getArguments
@@ -62,6 +64,7 @@ public fun NavHost(
 ) {
     val bottomSheetNavigator = rememberBottomSheetNavigator()
     val navController = rememberNavController(bottomSheetNavigator)
+    val executor = remember(navController) { AndroidXNavigationExecutor(navController) }
     val context = LocalContext.current
 
     if (destinationChangedCallback != null) {
@@ -88,7 +91,10 @@ public fun NavHost(
         }
     }
 
-    CompositionLocalProvider(LocalNavController provides navController) {
+    CompositionLocalProvider(
+        LocalNavigationExecutor provides executor,
+        LocalNavController provides navController,
+    ) {
         ModalBottomSheetLayout(
             bottomSheetNavigator = bottomSheetNavigator,
             sheetShape = bottomSheetShape,
@@ -168,6 +174,11 @@ private fun Activity.toDestination(
         it.id = route.activityDestinationId()
         it.intent = intent
     }
+}
+
+@InternalNavigatorApi
+public val LocalNavigationExecutor: ProvidableCompositionLocal<NavigationExecutor> = staticCompositionLocalOf {
+    throw IllegalStateException("Can't use NavEventNavigationHandler outside of a navigator NavHost")
 }
 
 @InternalNavigatorApi

--- a/navigator/runtime-fragment/api/navigator-runtime-fragment.api
+++ b/navigator/runtime-fragment/api/navigator-runtime-fragment.api
@@ -1,4 +1,4 @@
-public final class com/freeletics/mad/navigator/fragment/FragmentRouteKt {
+public final class com/freeletics/mad/navigator/fragment/FragmentExtensionsKt {
 	public static final fun requireRoute (Landroidx/fragment/app/Fragment;)Lcom/freeletics/mad/navigator/BaseRoute;
 }
 

--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/FragmentExtensions.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/FragmentExtensions.kt
@@ -1,0 +1,16 @@
+package com.freeletics.mad.navigator.fragment
+
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import com.freeletics.mad.navigator.BaseRoute
+import com.freeletics.mad.navigator.internal.AndroidXNavigationExecutor
+import com.freeletics.mad.navigator.internal.InternalNavigatorApi
+import com.freeletics.mad.navigator.internal.NavigationExecutor
+import com.freeletics.mad.navigator.internal.requireRoute
+
+public fun <T : BaseRoute> Fragment.requireRoute(): T = requireArguments().requireRoute()
+
+@InternalNavigatorApi
+public fun Fragment.findNavigationExectuor(): NavigationExecutor {
+    return AndroidXNavigationExecutor(findNavController())
+}

--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/FragmentExtensions.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/FragmentExtensions.kt
@@ -11,6 +11,6 @@ import com.freeletics.mad.navigator.internal.requireRoute
 public fun <T : BaseRoute> Fragment.requireRoute(): T = requireArguments().requireRoute()
 
 @InternalNavigatorApi
-public fun Fragment.findNavigationExectuor(): NavigationExecutor {
+public fun Fragment.findNavigationExecutor(): NavigationExecutor {
     return AndroidXNavigationExecutor(findNavController())
 }

--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/FragmentRoute.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/FragmentRoute.kt
@@ -1,7 +1,0 @@
-package com.freeletics.mad.navigator.fragment
-
-import androidx.fragment.app.Fragment
-import com.freeletics.mad.navigator.BaseRoute
-import com.freeletics.mad.navigator.internal.requireRoute
-
-public fun <T : BaseRoute> Fragment.requireRoute(): T = requireArguments().requireRoute()

--- a/navigator/runtime/api/navigator-runtime.api
+++ b/navigator/runtime/api/navigator-runtime.api
@@ -53,10 +53,10 @@ public final class com/freeletics/mad/navigator/NavigationResultRequest : com/fr
 public final class com/freeletics/mad/navigator/NavigationResultRequest$Key : android/os/Parcelable {
 	public static final field CREATOR Lcom/freeletics/mad/navigator/NavigationResultRequest$Key$CREATOR;
 	public fun <init> (Landroid/os/Parcel;)V
-	public final fun component1 ()I
+	public final fun component1 ()Lkotlin/reflect/KClass;
 	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (ILjava/lang/String;)Lcom/freeletics/mad/navigator/NavigationResultRequest$Key;
-	public static synthetic fun copy$default (Lcom/freeletics/mad/navigator/NavigationResultRequest$Key;ILjava/lang/String;ILjava/lang/Object;)Lcom/freeletics/mad/navigator/NavigationResultRequest$Key;
+	public final fun copy (Lkotlin/reflect/KClass;Ljava/lang/String;)Lcom/freeletics/mad/navigator/NavigationResultRequest$Key;
+	public static synthetic fun copy$default (Lcom/freeletics/mad/navigator/NavigationResultRequest$Key;Lkotlin/reflect/KClass;Ljava/lang/String;ILjava/lang/Object;)Lcom/freeletics/mad/navigator/NavigationResultRequest$Key;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I

--- a/navigator/runtime/build.gradle
+++ b/navigator/runtime/build.gradle
@@ -53,6 +53,8 @@ dependencies {
     api libs.coroutines.core
 
     implementation libs.androidx.core
+    implementation libs.androidx.viewmodel
+    implementation libs.androidx.viewmodel.savedstate
 
     testImplementation libs.junit
     testImplementation libs.truth

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
@@ -14,7 +14,6 @@ import com.freeletics.mad.navigator.NavEvent.PermissionsResultEvent
 import com.freeletics.mad.navigator.NavEvent.UpEvent
 import com.freeletics.mad.navigator.internal.DelegatingOnBackPressedCallback
 import com.freeletics.mad.navigator.internal.InternalNavigatorApi
-import com.freeletics.mad.navigator.internal.destinationId
 import kotlin.reflect.KClass
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.awaitClose
@@ -119,7 +118,7 @@ public open class NavEventNavigator {
     ): NavigationResultRequest<O> {
         checkAllowedToAddRequests()
         val requestKey = "${route.qualifiedName!!}-${result.qualifiedName!!}"
-        val key = NavigationResultRequest.Key<O>(route.destinationId(), requestKey)
+        val key = NavigationResultRequest.Key<O>(route, requestKey)
         val request = NavigationResultRequest(key)
         _navigationResultRequests.add(request)
         return request

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavRoute.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavRoute.kt
@@ -3,7 +3,7 @@ package com.freeletics.mad.navigator
 import android.app.Activity
 import android.content.Intent
 import android.os.Parcelable
-import com.freeletics.mad.navigator.internal.toActivityRoute
+import com.freeletics.mad.navigator.internal.EXTRA_ROUTE
 
 public sealed interface BaseRoute : Parcelable
 
@@ -54,5 +54,5 @@ public fun <T : ActivityRoute> Activity.requireRoute(): T {
  * Activity's Intent.
  */
 public fun <T : ActivityRoute> Activity.getRoute(): T? {
-    return intent.extras?.toActivityRoute()
+    return intent.extras?.getParcelable(EXTRA_ROUTE)
 }

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/ResultOwner.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/ResultOwner.kt
@@ -12,6 +12,7 @@ import com.freeletics.mad.navigator.PermissionsResultRequest.PermissionResult.DE
 import com.freeletics.mad.navigator.PermissionsResultRequest.PermissionResult.DENIED_PERMANENTLY
 import com.freeletics.mad.navigator.PermissionsResultRequest.PermissionResult.GRANTED
 import com.freeletics.mad.navigator.internal.InternalNavigatorApi
+import kotlin.reflect.KClass
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.channels.trySendBlocking
@@ -123,19 +124,20 @@ public class NavigationResultRequest<O : Parcelable> internal constructor(
     /**
      * Use to identify where the result should be delivered to.
      */
-    public data class Key<@Suppress("unused") O : Parcelable> @InternalNavigatorApi constructor(
+    public data class Key<@Suppress("unused") O : Parcelable> internal constructor(
         @property:InternalNavigatorApi
-        public val destinationId: Int,
+        public val route: KClass<out BaseRoute>,
         @property:InternalNavigatorApi
         public val requestKey: String
     ) : Parcelable {
+        @Suppress("UNCHECKED_CAST", "DEPRECATION")
         public constructor(parcel: Parcel) : this(
-            parcel.readInt(),
+            (parcel.readSerializable() as Class<out BaseRoute>).kotlin,
             parcel.readString()!!
         )
 
         override fun writeToParcel(parcel: Parcel, flags: Int) {
-            parcel.writeInt(destinationId)
+            parcel.writeSerializable(route.java)
             parcel.writeString(requestKey)
         }
 

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/Navigate.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/Navigate.kt
@@ -8,7 +8,6 @@ import com.freeletics.mad.navigator.ActivityRoute
 import com.freeletics.mad.navigator.BaseRoute
 import com.freeletics.mad.navigator.NavEvent
 import com.freeletics.mad.navigator.PermissionsResultRequest
-import kotlin.reflect.KClass
 
 @InternalNavigatorApi
 public fun navigate(
@@ -60,19 +59,6 @@ public fun navigate(
     }
 }
 
-@InternalNavigatorApi
-public fun BaseRoute.destinationId(): Int = this::class.destinationId()
-
-@InternalNavigatorApi
-public fun KClass<out BaseRoute>.destinationId(): Int = internalDestinationId()
-
-@InternalNavigatorApi
-public fun ActivityRoute.destinationId(): Int = this::class.activityDestinationId()
-
-@InternalNavigatorApi
-public fun KClass<out ActivityRoute>.activityDestinationId(): Int = internalDestinationId()
-
-private fun KClass<*>.internalDestinationId() = qualifiedName!!.hashCode()
 
 @InternalNavigatorApi
 public fun <T : BaseRoute> Bundle?.requireRoute(): T = requireNotNull(this) {
@@ -83,9 +69,6 @@ public fun <T : BaseRoute> Bundle?.requireRoute(): T = requireNotNull(this) {
             "Bundle doesn't contain Route data in \"$EXTRA_ROUTE\""
         }
     }
-
-@InternalNavigatorApi
-public fun <T : ActivityRoute> Bundle.toActivityRoute(): T? = getParcelable(EXTRA_ROUTE)
 
 @InternalNavigatorApi
 public fun BaseRoute.getArguments(): Bundle = Bundle().also {

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/NavigationExecutor.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/NavigationExecutor.kt
@@ -1,6 +1,8 @@
 package com.freeletics.mad.navigator.internal
 
 import android.os.Parcelable
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModelStore
 import com.freeletics.mad.navigator.ActivityRoute
 import com.freeletics.mad.navigator.BaseRoute
 import com.freeletics.mad.navigator.NavRoot
@@ -18,4 +20,7 @@ public interface NavigationExecutor {
     public fun navigateBack()
     public fun navigateBackTo(route: KClass<out BaseRoute>, isInclusive: Boolean)
     public fun deliverResult(key: NavigationResultRequest.Key<*>, result: Parcelable)
+    public fun <T : BaseRoute> routeFor(route: KClass<T>): T
+    public fun savedStateHandleFor(route: KClass<out BaseRoute>): SavedStateHandle
+    public fun viewModelStoreFor(route: KClass<out BaseRoute>): ViewModelStore
 }


### PR DESCRIPTION
#222 removed AndroidX navigation fror navigator-runtime. This is a follow up that moves some more AndroidX specific elements out of the runtime and prepares for making whetstone independent of AndroidX navigation.

Note: none of these changes affect the public API

- move methods that create destination ids from routes to the `androidx-nav` module
- to make the above change work the `NavigationResultRequest.Key` will now hold the route class instead of the id, the `AndroidXNavigationExecutor` will turn it into an id internally
-  added methods to whetstone to obtain a `SavedStateHandle`, `ViewModelStore` and `BaseRoute` for a given destination to hide AndroidX back stack related APIs
- generally replace `NavController` usages with `NavigationExecutor`
- add a composition local to obtain the `NavigationExecutor` (the NavController composition local will be removed when whetstone starts using the new APIs) and a find method for fragments

Whetstone changes will be an extra PR but can be seen here 575f956
