### PR TITLE
use NavigationExecutor inside whetstone

### DIFF
--- a/navigator/androidx-nav/src/main/java/com/freeletics/mad/navigator/internal/CustomActivityNavigator.kt
+++ b/navigator/androidx-nav/src/main/java/com/freeletics/mad/navigator/internal/CustomActivityNavigator.kt
@@ -19,7 +19,6 @@ import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.os.Parcelable
 import androidx.navigation.NavController
@@ -27,7 +26,6 @@ import androidx.navigation.NavDestination
 import androidx.navigation.NavOptions
 import androidx.navigation.Navigator
 import androidx.navigation.NavigatorProvider
-import com.freeletics.mad.navigator.ActivityRoute
 
 /**
  * ActivityNavigator implements cross-activity navigation.

--- a/navigator/runtime-compose/build.gradle
+++ b/navigator/runtime-compose/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     api project(":navigator:navigator-runtime")
     api libs.androidx.compose.runtime
     api libs.androidx.compose.ui
-    api libs.androidx.navigation.runtime
+    implementation libs.androidx.navigation.runtime
 
     implementation project(":navigator:androidx-nav")
     implementation libs.coroutines.core

--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavHost.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavHost.kt
@@ -91,10 +91,7 @@ public fun NavHost(
         }
     }
 
-    CompositionLocalProvider(
-        LocalNavigationExecutor provides executor,
-        LocalNavController provides navController,
-    ) {
+    CompositionLocalProvider(LocalNavigationExecutor provides executor) {
         ModalBottomSheetLayout(
             bottomSheetNavigator = bottomSheetNavigator,
             sheetShape = bottomSheetShape,
@@ -178,10 +175,5 @@ private fun Activity.toDestination(
 
 @InternalNavigatorApi
 public val LocalNavigationExecutor: ProvidableCompositionLocal<NavigationExecutor> = staticCompositionLocalOf {
-    throw IllegalStateException("Can't use NavEventNavigationHandler outside of a navigator NavHost")
-}
-
-@InternalNavigatorApi
-public val LocalNavController: ProvidableCompositionLocal<NavController> = staticCompositionLocalOf {
     throw IllegalStateException("Can't use NavEventNavigationHandler outside of a navigator NavHost")
 }

--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavHostFragment.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/NavHostFragment.kt
@@ -1,6 +1,5 @@
 package com.freeletics.mad.navigator.fragment
 
-import androidx.navigation.ActivityNavigator
 import androidx.navigation.NavArgument
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
@@ -12,8 +11,8 @@ import androidx.navigation.get
 import com.freeletics.mad.navigator.BaseRoute
 import com.freeletics.mad.navigator.internal.CustomActivityNavigator
 import com.freeletics.mad.navigator.internal.activityDestinationId
-import com.freeletics.mad.navigator.internal.getArguments
 import com.freeletics.mad.navigator.internal.destinationId
+import com.freeletics.mad.navigator.internal.getArguments
 
 /**
  * Creates and sets a [androidx.navigation.NavGraph] containing all given [destinations].

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/ResultOwner.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/ResultOwner.kt
@@ -14,12 +14,9 @@ import com.freeletics.mad.navigator.PermissionsResultRequest.PermissionResult.GR
 import com.freeletics.mad.navigator.internal.InternalNavigatorApi
 import kotlin.reflect.KClass
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.receiveAsFlow
 
 /**
  * A base class for anything that exposes a [Flow] of [results]. Results will only be delivered

--- a/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
+++ b/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
@@ -389,11 +389,9 @@ internal class FileGeneratorTestCompose {
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
-            import androidx.navigation.NavBackStackEntry
             import com.freeletics.mad.navigator.NavEventNavigator
             import com.freeletics.mad.navigator.`internal`.InternalNavigatorApi
-            import com.freeletics.mad.navigator.`internal`.destinationId
-            import com.freeletics.mad.navigator.`internal`.requireRoute
+            import com.freeletics.mad.navigator.`internal`.NavigationExecutor
             import com.freeletics.mad.navigator.compose.NavDestination
             import com.freeletics.mad.navigator.compose.NavigationSetup
             import com.freeletics.mad.navigator.compose.ScreenDestination
@@ -405,7 +403,7 @@ internal class FileGeneratorTestCompose {
             import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetter
             import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetterKey
             import com.freeletics.mad.whetstone.`internal`.asComposeState
-            import com.freeletics.mad.whetstone.`internal`.viewModel
+            import com.freeletics.mad.whetstone.`internal`.navEntryViewModel
             import com.freeletics.mad.whetstone.compose.`internal`.rememberViewModel
             import com.squareup.anvil.annotations.ContributesMultibinding
             import com.squareup.anvil.annotations.ContributesSubcomponent
@@ -420,7 +418,6 @@ internal class FileGeneratorTestCompose {
             import java.io.Closeable
             import javax.inject.Inject
             import kotlin.Any
-            import kotlin.Int
             import kotlin.OptIn
             import kotlin.Unit
             import kotlin.collections.Set
@@ -568,11 +565,9 @@ internal class FileGeneratorTestCompose {
             )
             public class TestScreenNavEntryComponentGetter @Inject constructor() : NavEntryComponentGetter {
               @OptIn(InternalWhetstoneApi::class, InternalNavigatorApi::class)
-              public override fun retrieve(findEntry: (Int) -> NavBackStackEntry, context: Context): Any {
-                val entry = findEntry(TestRoute::class.destinationId())
-                val route: TestRoute = entry.arguments.requireRoute()
-                val viewModel = viewModel(entry, context, TestParentScope::class, TestDestinationScope::class,
-                    route, findEntry, ::WhetstoneTestScreenNavEntryViewModel)
+              public override fun retrieve(executor: NavigationExecutor, context: Context): Any {
+                val viewModel = navEntryViewModel(TestRoute::class, executor, context, TestParentScope::class,
+                    TestDestinationScope::class, ::WhetstoneTestScreenNavEntryViewModel)
                 return viewModel.component
               }
             }

--- a/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
+++ b/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
@@ -467,10 +467,9 @@ internal class FileGeneratorTestComposeFragment {
             import androidx.fragment.app.Fragment
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
-            import androidx.navigation.NavBackStackEntry
             import com.freeletics.mad.navigator.NavEventNavigator
             import com.freeletics.mad.navigator.`internal`.InternalNavigatorApi
-            import com.freeletics.mad.navigator.`internal`.destinationId
+            import com.freeletics.mad.navigator.`internal`.NavigationExecutor
             import com.freeletics.mad.navigator.fragment.NavDestination
             import com.freeletics.mad.navigator.fragment.ScreenDestination
             import com.freeletics.mad.navigator.fragment.handleNavigation
@@ -483,6 +482,7 @@ internal class FileGeneratorTestComposeFragment {
             import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetter
             import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetterKey
             import com.freeletics.mad.whetstone.`internal`.asComposeState
+            import com.freeletics.mad.whetstone.`internal`.navEntryViewModel
             import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
             import com.squareup.anvil.annotations.ContributesMultibinding
             import com.squareup.anvil.annotations.ContributesSubcomponent
@@ -497,12 +497,10 @@ internal class FileGeneratorTestComposeFragment {
             import java.io.Closeable
             import javax.inject.Inject
             import kotlin.Any
-            import kotlin.Int
             import kotlin.OptIn
             import kotlin.Unit
             import kotlin.collections.Set
             import kotlinx.coroutines.launch
-            import com.freeletics.mad.navigator.`internal`.requireRoute as bundleRequireRoute
 
             @OptIn(InternalWhetstoneApi::class)
             @ScopeTo(TestScreen::class)
@@ -661,12 +659,9 @@ internal class FileGeneratorTestComposeFragment {
             )
             public class TestScreenNavEntryComponentGetter @Inject constructor() : NavEntryComponentGetter {
               @OptIn(InternalWhetstoneApi::class, InternalNavigatorApi::class)
-              public override fun retrieve(findEntry: (Int) -> NavBackStackEntry, context: Context): Any {
-                val entry = findEntry(TestRoute::class.destinationId())
-                val route: TestRoute = entry.arguments.bundleRequireRoute()
-                val viewModel = com.freeletics.mad.whetstone.`internal`.viewModel(entry, context,
-                    TestParentScope::class, TestDestinationScope::class, route, findEntry,
-                    ::WhetstoneTestScreenNavEntryViewModel)
+              public override fun retrieve(executor: NavigationExecutor, context: Context): Any {
+                val viewModel = navEntryViewModel(TestRoute::class, executor, context, TestParentScope::class,
+                    TestDestinationScope::class, ::WhetstoneTestScreenNavEntryViewModel)
                 return viewModel.component
               }
             }

--- a/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestRendererFragment.kt
+++ b/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestRendererFragment.kt
@@ -389,10 +389,9 @@ internal class FileGeneratorTestRendererFragment {
             import androidx.fragment.app.Fragment
             import androidx.lifecycle.SavedStateHandle
             import androidx.lifecycle.ViewModel
-            import androidx.navigation.NavBackStackEntry
             import com.freeletics.mad.navigator.NavEventNavigator
             import com.freeletics.mad.navigator.`internal`.InternalNavigatorApi
-            import com.freeletics.mad.navigator.`internal`.destinationId
+            import com.freeletics.mad.navigator.`internal`.NavigationExecutor
             import com.freeletics.mad.navigator.fragment.NavDestination
             import com.freeletics.mad.navigator.fragment.ScreenDestination
             import com.freeletics.mad.navigator.fragment.handleNavigation
@@ -403,6 +402,7 @@ internal class FileGeneratorTestRendererFragment {
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
             import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetter
             import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetterKey
+            import com.freeletics.mad.whetstone.`internal`.navEntryViewModel
             import com.freeletics.mad.whetstone.fragment.`internal`.viewModel
             import com.gabrielittner.renderer.connect.connect
             import com.squareup.anvil.annotations.ContributesMultibinding
@@ -418,11 +418,9 @@ internal class FileGeneratorTestRendererFragment {
             import java.io.Closeable
             import javax.inject.Inject
             import kotlin.Any
-            import kotlin.Int
             import kotlin.OptIn
             import kotlin.Unit
             import kotlin.collections.Set
-            import com.freeletics.mad.navigator.`internal`.requireRoute as bundleRequireRoute
 
             @OptIn(InternalWhetstoneApi::class)
             @ScopeTo(TestScreen::class)
@@ -563,12 +561,9 @@ internal class FileGeneratorTestRendererFragment {
             )
             public class TestScreenNavEntryComponentGetter @Inject constructor() : NavEntryComponentGetter {
               @OptIn(InternalWhetstoneApi::class, InternalNavigatorApi::class)
-              public override fun retrieve(findEntry: (Int) -> NavBackStackEntry, context: Context): Any {
-                val entry = findEntry(TestRoute::class.destinationId())
-                val route: TestRoute = entry.arguments.bundleRequireRoute()
-                val viewModel = com.freeletics.mad.whetstone.`internal`.viewModel(entry, context,
-                    TestParentScope::class, TestDestinationScope::class, route, findEntry,
-                    ::WhetstoneTestScreenNavEntryViewModel)
+              public override fun retrieve(executor: NavigationExecutor, context: Context): Any {
+                val viewModel = navEntryViewModel(TestRoute::class, executor, context, TestParentScope::class,
+                    TestDestinationScope::class, ::WhetstoneTestScreenNavEntryViewModel)
                 return viewModel.component
               }
             }

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/WhetstoneCodeGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/WhetstoneCodeGenerator.kt
@@ -26,19 +26,14 @@ import com.squareup.anvil.compiler.api.createGeneratedFile
 import com.squareup.anvil.compiler.internal.asClassName
 import com.squareup.anvil.compiler.internal.fqNameOrNull
 import com.squareup.anvil.compiler.internal.reference.AnnotatedReference
-import com.squareup.anvil.compiler.internal.reference.AnvilCompilationExceptionAnnotationReference
-import com.squareup.anvil.compiler.internal.reference.AnvilCompilationExceptionParameterReference
 import com.squareup.anvil.compiler.internal.reference.ClassReference
 import com.squareup.anvil.compiler.internal.reference.classAndInnerClassReferences
-import com.squareup.anvil.compiler.internal.requireFqName
-import com.squareup.kotlinpoet.ClassName
 import java.io.File
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.descriptors.containingPackage
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNamedFunction
-import org.jetbrains.kotlin.resolve.calls.util.getType
 
 @OptIn(ExperimentalAnvilApi::class)
 @AutoService(CodeGenerator::class)

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/FileGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/FileGenerator.kt
@@ -4,7 +4,6 @@ import com.freeletics.mad.whetstone.BaseData
 import com.freeletics.mad.whetstone.ComposeFragmentData
 import com.freeletics.mad.whetstone.ComposeScreenData
 import com.freeletics.mad.whetstone.NavEntryData
-import com.freeletics.mad.whetstone.Navigation
 import com.freeletics.mad.whetstone.RendererFragmentData
 import com.freeletics.mad.whetstone.codegen.common.ComponentGenerator
 import com.freeletics.mad.whetstone.codegen.common.ComposeGenerator
@@ -16,7 +15,6 @@ import com.freeletics.mad.whetstone.codegen.fragment.RendererFragmentGenerator
 import com.freeletics.mad.whetstone.codegen.nav.DestinationComponentGenerator
 import com.freeletics.mad.whetstone.codegen.nav.NavDestinationModuleGenerator
 import com.freeletics.mad.whetstone.codegen.nav.NavEntryComponentGetterGenerator
-import com.freeletics.mad.whetstone.codegen.util.bundleRequireRoute
 import com.squareup.kotlinpoet.FileSpec
 
 public class FileGenerator{
@@ -85,13 +83,6 @@ public class FileGenerator{
             val componentGenerator = ComponentGenerator(data)
             val moduleGenerator = ModuleGenerator(data)
             val viewModelGenerator = ViewModelGenerator(data)
-
-            if (data.navigation is Navigation.Fragment) {
-                // Bundle.requireRoute clashes with Fragment.requireRoute
-                // This is fixed in unreleased version of kotlinpoet
-                // https://github.com/square/kotlinpoet/issues/1089
-                addAliasedImport(bundleRequireRoute, "bundleRequireRoute")
-            }
             val componentGetterGenerator = NavEntryComponentGetterGenerator(data)
             val destinationComponentGenerator = DestinationComponentGenerator(data)
 

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/FileGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/FileGenerator.kt
@@ -6,16 +6,16 @@ import com.freeletics.mad.whetstone.ComposeScreenData
 import com.freeletics.mad.whetstone.NavEntryData
 import com.freeletics.mad.whetstone.Navigation
 import com.freeletics.mad.whetstone.RendererFragmentData
-import com.freeletics.mad.whetstone.codegen.common.ComposeGenerator
-import com.freeletics.mad.whetstone.codegen.nav.DestinationComponentGenerator
-import com.freeletics.mad.whetstone.codegen.nav.NavDestinationModuleGenerator
 import com.freeletics.mad.whetstone.codegen.common.ComponentGenerator
+import com.freeletics.mad.whetstone.codegen.common.ComposeGenerator
 import com.freeletics.mad.whetstone.codegen.common.ModuleGenerator
 import com.freeletics.mad.whetstone.codegen.common.ViewModelGenerator
 import com.freeletics.mad.whetstone.codegen.compose.ComposeScreenGenerator
 import com.freeletics.mad.whetstone.codegen.fragment.ComposeFragmentGenerator
-import com.freeletics.mad.whetstone.codegen.nav.NavEntryComponentGetterGenerator
 import com.freeletics.mad.whetstone.codegen.fragment.RendererFragmentGenerator
+import com.freeletics.mad.whetstone.codegen.nav.DestinationComponentGenerator
+import com.freeletics.mad.whetstone.codegen.nav.NavDestinationModuleGenerator
+import com.freeletics.mad.whetstone.codegen.nav.NavEntryComponentGetterGenerator
 import com.freeletics.mad.whetstone.codegen.util.bundleRequireRoute
 import com.squareup.kotlinpoet.FileSpec
 

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/ComponentGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/ComponentGenerator.kt
@@ -13,7 +13,6 @@ import com.freeletics.mad.whetstone.codegen.util.contributesToAnnotation
 import com.freeletics.mad.whetstone.codegen.util.navEntryAnnotation
 import com.freeletics.mad.whetstone.codegen.util.navEventNavigator
 import com.freeletics.mad.whetstone.codegen.util.optInAnnotation
-import com.freeletics.mad.whetstone.codegen.util.providedValue
 import com.freeletics.mad.whetstone.codegen.util.savedStateHandle
 import com.freeletics.mad.whetstone.codegen.util.scopeToAnnotation
 import com.freeletics.mad.whetstone.codegen.util.simplePropertySpec
@@ -28,7 +27,6 @@ import com.squareup.kotlinpoet.KModifier.ABSTRACT
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.SET
-import com.squareup.kotlinpoet.STAR
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.asTypeName
 import java.io.Closeable

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/compose/ComposeScreenGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/compose/ComposeScreenGenerator.kt
@@ -1,10 +1,10 @@
 package com.freeletics.mad.whetstone.codegen.compose
 
 import com.freeletics.mad.whetstone.ComposeScreenData
-import com.freeletics.mad.whetstone.codegen.common.viewModelClassName
-import com.freeletics.mad.whetstone.codegen.common.viewModelComponentName
 import com.freeletics.mad.whetstone.codegen.Generator
 import com.freeletics.mad.whetstone.codegen.common.composableName
+import com.freeletics.mad.whetstone.codegen.common.viewModelClassName
+import com.freeletics.mad.whetstone.codegen.common.viewModelComponentName
 import com.freeletics.mad.whetstone.codegen.util.asParameter
 import com.freeletics.mad.whetstone.codegen.util.composable
 import com.freeletics.mad.whetstone.codegen.util.composeNavigationHandler

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/fragment/BaseFragmentGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/fragment/BaseFragmentGenerator.kt
@@ -8,7 +8,6 @@ import com.freeletics.mad.whetstone.codegen.common.viewModelClassName
 import com.freeletics.mad.whetstone.codegen.common.viewModelComponentName
 import com.freeletics.mad.whetstone.codegen.util.asParameter
 import com.freeletics.mad.whetstone.codegen.util.bundle
-import com.freeletics.mad.whetstone.codegen.util.requireArguments
 import com.freeletics.mad.whetstone.codegen.util.fragmentNavigationHandler
 import com.freeletics.mad.whetstone.codegen.util.fragmentViewModel
 import com.freeletics.mad.whetstone.codegen.util.lateinitPropertySpec
@@ -16,6 +15,7 @@ import com.freeletics.mad.whetstone.codegen.util.layoutInflater
 import com.freeletics.mad.whetstone.codegen.util.navEventNavigator
 import com.freeletics.mad.whetstone.codegen.util.optInAnnotation
 import com.freeletics.mad.whetstone.codegen.util.propertyName
+import com.freeletics.mad.whetstone.codegen.util.requireArguments
 import com.freeletics.mad.whetstone.codegen.util.view
 import com.freeletics.mad.whetstone.codegen.util.viewGroup
 import com.squareup.kotlinpoet.CodeBlock

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/nav/NavEntryComponentGetterGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/nav/NavEntryComponentGetterGenerator.kt
@@ -4,24 +4,20 @@ import com.freeletics.mad.whetstone.NavEntryData
 import com.freeletics.mad.whetstone.codegen.Generator
 import com.freeletics.mad.whetstone.codegen.common.viewModelClassName
 import com.freeletics.mad.whetstone.codegen.common.viewModelComponentName
-import com.freeletics.mad.whetstone.codegen.util.bundleRequireRoute
 import com.freeletics.mad.whetstone.codegen.util.context
-import com.freeletics.mad.whetstone.codegen.util.destinationId
 import com.freeletics.mad.whetstone.codegen.util.inject
 import com.freeletics.mad.whetstone.codegen.util.internalNavigatorApi
 import com.freeletics.mad.whetstone.codegen.util.internalWhetstoneApi
-import com.freeletics.mad.whetstone.codegen.util.navBackStackEntry
 import com.freeletics.mad.whetstone.codegen.util.navEntryComponentGetter
 import com.freeletics.mad.whetstone.codegen.util.navEntryComponentGetterKey
 import com.freeletics.mad.whetstone.codegen.util.navEntryViewModel
+import com.freeletics.mad.whetstone.codegen.util.navigationExecutor
 import com.freeletics.mad.whetstone.codegen.util.optInAnnotation
 import com.squareup.anvil.annotations.ContributesMultibinding
 import com.squareup.kotlinpoet.ANY
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.FunSpec
-import com.squareup.kotlinpoet.INT
 import com.squareup.kotlinpoet.KModifier.OVERRIDE
-import com.squareup.kotlinpoet.LambdaTypeName
 import com.squareup.kotlinpoet.TypeSpec
 
 internal val Generator<NavEntryData>.componentGetterClassName
@@ -66,13 +62,11 @@ internal class NavEntryComponentGetterGenerator(
         return FunSpec.builder("retrieve")
             .addModifiers(OVERRIDE)
             .addAnnotation(optInAnnotation(internalWhetstoneApi, internalNavigatorApi))
-            .addParameter("findEntry", LambdaTypeName.get(parameters = arrayOf(INT), returnType = navBackStackEntry))
+            .addParameter("executor", navigationExecutor)
             .addParameter("context", context)
             .returns(ANY)
-            .addStatement("val entry = findEntry(%T::class.%M())", data.navigation.route, destinationId)
-            .addStatement("val route: %T = entry.arguments.%M()", data.navigation.route, bundleRequireRoute)
-            .addStatement("val viewModel = %M(entry, context, %T::class, %T::class, route, findEntry, ::%T)",
-                navEntryViewModel, data.parentScope, data.navigation.destinationScope, viewModelClassName)
+            .addStatement("val viewModel = %M(%T::class, executor, context, %T::class, %T::class, ::%T)",
+                navEntryViewModel, data.navigation.route, data.parentScope, data.navigation.destinationScope, viewModelClassName)
             .addStatement("return viewModel.%L", viewModelComponentName)
             .build()
     }

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/nav/NavEntryComponentGetterGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/nav/NavEntryComponentGetterGenerator.kt
@@ -4,6 +4,7 @@ import com.freeletics.mad.whetstone.NavEntryData
 import com.freeletics.mad.whetstone.codegen.Generator
 import com.freeletics.mad.whetstone.codegen.common.viewModelClassName
 import com.freeletics.mad.whetstone.codegen.common.viewModelComponentName
+import com.freeletics.mad.whetstone.codegen.util.bundleRequireRoute
 import com.freeletics.mad.whetstone.codegen.util.context
 import com.freeletics.mad.whetstone.codegen.util.destinationId
 import com.freeletics.mad.whetstone.codegen.util.inject
@@ -14,7 +15,6 @@ import com.freeletics.mad.whetstone.codegen.util.navEntryComponentGetter
 import com.freeletics.mad.whetstone.codegen.util.navEntryComponentGetterKey
 import com.freeletics.mad.whetstone.codegen.util.navEntryViewModel
 import com.freeletics.mad.whetstone.codegen.util.optInAnnotation
-import com.freeletics.mad.whetstone.codegen.util.bundleRequireRoute
 import com.squareup.anvil.annotations.ContributesMultibinding
 import com.squareup.kotlinpoet.ANY
 import com.squareup.kotlinpoet.AnnotationSpec

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/Annotations.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/Annotations.kt
@@ -9,9 +9,7 @@ import com.squareup.anvil.compiler.internal.reference.ClassReference
 import com.squareup.anvil.compiler.internal.reference.argumentAt
 import com.squareup.anvil.compiler.internal.reference.asClassName
 import com.squareup.kotlinpoet.ClassName
-import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.name.FqName
-import org.jetbrains.kotlin.psi.KtConstantExpression
 
 internal fun AnnotatedReference.findAnnotation(fqName: FqName): AnnotationReference? {
     return annotations.find { it.fqName == fqName }

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
@@ -70,18 +70,14 @@ internal val module = ClassName("dagger", "Module")
 
 // AndroidX
 internal val fragment = ClassName("androidx.fragment.app", "Fragment")
-internal val dialogFragment = ClassName("androidx.fragment.app", "DialogFragment")
-
 internal val viewModel = ClassName("androidx.lifecycle", "ViewModel")
 internal val savedStateHandle = ClassName("androidx.lifecycle", "SavedStateHandle")
-
 internal val navBackStackEntry = ClassName("androidx.navigation", "NavBackStackEntry")
 
 // Compose
 internal val composable = ClassName("androidx.compose.runtime", "Composable")
 internal val getValue = MemberName("androidx.compose.runtime", "getValue")
 internal val rememberCoroutineScope = MemberName("androidx.compose.runtime", "rememberCoroutineScope")
-internal val providedValue = ClassName("androidx.compose.runtime", "ProvidedValue")
 internal val composeView = ClassName("androidx.compose.ui.platform", "ComposeView")
 internal val viewCompositionStrategy = ClassName("androidx.compose.ui.platform", "ViewCompositionStrategy")
 internal val disposeOnLifecycleDestroyed = viewCompositionStrategy.nestedClass("DisposeOnLifecycleDestroyed")

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
@@ -27,7 +27,7 @@ internal val navEntryComponentFqName = FqName(navEntryComponent.canonicalName)
 // Whetstone Internal API
 internal val asComposeState = MemberName("com.freeletics.mad.whetstone.internal", "asComposeState")
 internal val internalWhetstoneApi = ClassName("com.freeletics.mad.whetstone.internal", "InternalWhetstoneApi")
-internal val navEntryViewModel = MemberName("com.freeletics.mad.whetstone.internal", "viewModel")
+internal val navEntryViewModel = MemberName("com.freeletics.mad.whetstone.internal", "navEntryViewModel")
 internal val fragmentViewModel = MemberName("com.freeletics.mad.whetstone.fragment.internal", "viewModel")
 internal val rememberViewModel = MemberName("com.freeletics.mad.whetstone.compose.internal", "rememberViewModel")
 internal val navEntryComponentGetter = ClassName("com.freeletics.mad.whetstone.internal", "NavEntryComponentGetter")
@@ -37,6 +37,7 @@ internal val destinationComponent = ClassName("com.freeletics.mad.whetstone.inte
 
 // Navigator
 internal val navEventNavigator = ClassName("com.freeletics.mad.navigator", "NavEventNavigator")
+internal val navigationExecutor = ClassName("com.freeletics.mad.navigator.internal", "NavigationExecutor")
 internal val composeNavigationHandler = MemberName("com.freeletics.mad.navigator.compose", "NavigationSetup")
 internal val composeDestination = ClassName("com.freeletics.mad.navigator.compose", "NavDestination")
 internal val composeScreenDestination = MemberName("com.freeletics.mad.navigator.compose", "ScreenDestination")
@@ -47,8 +48,6 @@ internal val fragmentDestination = ClassName("com.freeletics.mad.navigator.fragm
 internal val fragmentScreenDestination = MemberName("com.freeletics.mad.navigator.fragment", "ScreenDestination")
 internal val fragmentDialogDestination = MemberName("com.freeletics.mad.navigator.fragment", "DialogDestination")
 internal val fragmentRequireRoute = MemberName("com.freeletics.mad.navigator.fragment", "requireRoute")
-internal val destinationId = MemberName("com.freeletics.mad.navigator.internal", "destinationId")
-internal val bundleRequireRoute = MemberName("com.freeletics.mad.navigator.internal", "requireRoute")
 internal val internalNavigatorApi = ClassName("com.freeletics.mad.navigator.internal", "InternalNavigatorApi")
 
 // Renderer
@@ -72,7 +71,6 @@ internal val module = ClassName("dagger", "Module")
 internal val fragment = ClassName("androidx.fragment.app", "Fragment")
 internal val viewModel = ClassName("androidx.lifecycle", "ViewModel")
 internal val savedStateHandle = ClassName("androidx.lifecycle", "SavedStateHandle")
-internal val navBackStackEntry = ClassName("androidx.navigation", "NavBackStackEntry")
 
 // Compose
 internal val composable = ClassName("androidx.compose.runtime", "Composable")

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/KotlinPoet.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/KotlinPoet.kt
@@ -1,7 +1,7 @@
 package com.freeletics.mad.whetstone.codegen.util
 
-import com.squareup.anvil.annotations.ContributesSubcomponent
 import com.freeletics.mad.whetstone.Navigation
+import com.squareup.anvil.annotations.ContributesSubcomponent
 import com.squareup.anvil.annotations.ContributesTo
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.AnnotationSpec.UseSiteTarget

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/TopLevelFunctionReference.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/TopLevelFunctionReference.kt
@@ -6,21 +6,16 @@ import com.squareup.anvil.compiler.internal.reference.AnnotatedReference
 import com.squareup.anvil.compiler.internal.reference.AnnotationReference
 import com.squareup.anvil.compiler.internal.reference.ClassReference
 import com.squareup.anvil.compiler.internal.reference.FunctionReference
-import com.squareup.anvil.compiler.internal.reference.ParameterReference
 import com.squareup.anvil.compiler.internal.reference.toAnnotationReference
-import com.squareup.anvil.compiler.internal.reference.toFunctionReference
 import com.squareup.anvil.compiler.internal.requireFqName
+import kotlin.LazyThreadSafetyMode.NONE
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtNamedFunction
-import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
-import kotlin.LazyThreadSafetyMode.NONE
-import org.jetbrains.kotlin.descriptors.ModuleDescriptor
-import org.jetbrains.kotlin.descriptors.ValueParameterDescriptor
-import org.jetbrains.kotlin.psi.KtCallableDeclaration
 import org.jetbrains.kotlin.psi.KtParameter
-import org.jetbrains.kotlin.psi.psiUtil.getValueParameters
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 
 /**
  * Simplified of [FunctionReference] from Anvil to support top level functions.

--- a/whetstone/navigation-compose/build.gradle
+++ b/whetstone/navigation-compose/build.gradle
@@ -41,6 +41,7 @@ kotlin {
 
     sourceSets.all {
         languageSettings {
+            optIn("com.freeletics.mad.navigator.internal.InternalNavigatorApi")
             optIn("com.freeletics.mad.whetstone.internal.InternalWhetstoneApi")
         }
     }
@@ -65,6 +66,4 @@ dependencies {
     implementation libs.androidx.viewmodel
     implementation libs.androidx.viewmodel.savedstate
     implementation libs.androidx.viewmodel.compose
-    implementation libs.androidx.navigation.common
-    implementation libs.androidx.navigation.runtime
 }

--- a/whetstone/navigation-compose/src/main/java/com/freeletics/mad/whetstone/compose/internal/NavComposeViewModelProvider.kt
+++ b/whetstone/navigation-compose/src/main/java/com/freeletics/mad/whetstone/compose/internal/NavComposeViewModelProvider.kt
@@ -12,7 +12,7 @@ import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.freeletics.mad.navigator.BaseRoute
-import com.freeletics.mad.navigator.compose.LocalNavController
+import com.freeletics.mad.navigator.compose.LocalNavigationExecutor
 import com.freeletics.mad.navigator.internal.InternalNavigatorApi
 import com.freeletics.mad.whetstone.internal.InternalWhetstoneApi
 import com.freeletics.mad.whetstone.internal.findComponentByScope
@@ -36,11 +36,11 @@ public inline fun <reified T : ViewModel, D : Any, R : BaseRoute> rememberViewMo
 ): T {
     val viewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current)
     val context = LocalContext.current
-    val navController = LocalNavController.current
-    return remember(viewModelStoreOwner, context, navController, route) {
+    val executor = LocalNavigationExecutor.current
+    return remember(viewModelStoreOwner, context, executor, route) {
         val viewModelFactory = viewModelFactory {
             initializer {
-                val dependencies = context.findComponentByScope<D>(scope, destinationScope, navController::getBackStackEntry)
+                val dependencies = context.findComponentByScope<D>(scope, destinationScope, executor)
                 val savedStateHandle = createSavedStateHandle()
                 factory(dependencies, savedStateHandle, route)
             }

--- a/whetstone/navigation-fragment/build.gradle
+++ b/whetstone/navigation-fragment/build.gradle
@@ -36,6 +36,7 @@ kotlin {
 
     sourceSets.all {
         languageSettings {
+            optIn("com.freeletics.mad.navigator.internal.InternalNavigatorApi")
             optIn("com.freeletics.mad.whetstone.internal.InternalWhetstoneApi")
         }
     }
@@ -54,11 +55,9 @@ dependencies {
     api project(":navigator:navigator-runtime")
 
     implementation project(":whetstone:runtime")
+    implementation project(":navigator:navigator-runtime-fragment")
     implementation libs.androidx.compose.runtime
     implementation libs.androidx.viewmodel
     implementation libs.androidx.viewmodel.savedstate
     implementation libs.androidx.fragment
-    implementation libs.androidx.navigation.common
-    implementation libs.androidx.navigation.runtime
-    implementation libs.androidx.navigation.fragment
 }

--- a/whetstone/navigation-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/internal/NavFragmentViewModelProvider.kt
+++ b/whetstone/navigation-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/internal/NavFragmentViewModelProvider.kt
@@ -8,8 +8,8 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
-import androidx.navigation.fragment.findNavController
 import com.freeletics.mad.navigator.BaseRoute
+import com.freeletics.mad.navigator.fragment.findNavigationExecutor
 import com.freeletics.mad.whetstone.internal.InternalWhetstoneApi
 import com.freeletics.mad.whetstone.internal.findComponentByScope
 import kotlin.reflect.KClass
@@ -30,8 +30,8 @@ public inline fun <reified T : ViewModel, D : Any, R : BaseRoute> Fragment.viewM
 ): T {
     val viewModelFactory = viewModelFactory {
         initializer {
-            val navController = findNavController()
-            val dependencies = requireContext().findComponentByScope<D>(scope, destinationScope, navController::getBackStackEntry)
+            val executor = findNavigationExecutor()
+            val dependencies = requireContext().findComponentByScope<D>(scope, destinationScope, executor)
             val savedStateHandle = createSavedStateHandle()
             factory(dependencies, savedStateHandle, route)
         }

--- a/whetstone/navigation/build.gradle
+++ b/whetstone/navigation/build.gradle
@@ -36,6 +36,7 @@ kotlin {
 
     sourceSets.all {
         languageSettings {
+            optIn("com.freeletics.mad.navigator.internal.InternalNavigatorApi")
             optIn("com.freeletics.mad.whetstone.internal.InternalWhetstoneApi")
         }
     }
@@ -50,11 +51,10 @@ tasks.withType(JavaCompile).configureEach {
 
 dependencies {
     api project(":whetstone:runtime")
+    api project(":navigator:navigator-runtime")
     api libs.inject
     api libs.dagger
-    api libs.androidx.navigation.common
 
-    implementation project(":navigator:navigator-runtime")
     implementation libs.androidx.viewmodel
     implementation libs.androidx.viewmodel.savedstate
 }

--- a/whetstone/navigation/src/main/java/com/freeletics/mad/whetstone/internal/NavEntryComponentGetter.kt
+++ b/whetstone/navigation/src/main/java/com/freeletics/mad/whetstone/internal/NavEntryComponentGetter.kt
@@ -1,7 +1,8 @@
 package com.freeletics.mad.whetstone.internal
 
 import android.content.Context
-import androidx.navigation.NavBackStackEntry
+import com.freeletics.mad.navigator.internal.InternalNavigatorApi
+import com.freeletics.mad.navigator.internal.NavigationExecutor
 import com.freeletics.mad.whetstone.NavEntryComponent
 import dagger.MapKey
 import kotlin.reflect.KClass
@@ -12,10 +13,10 @@ import kotlin.reflect.KClass
 @InternalWhetstoneApi
 public interface NavEntryComponentGetter {
     /**
-     * The given [findEntry] should look up a back strack entry for that id
-     * in the current `NavController`.
+     * The implementation should return an instance of the generated nav entry component.
      */
-    public fun retrieve(findEntry: (Int) -> NavBackStackEntry, context: Context): Any
+    @OptIn(InternalNavigatorApi::class)
+    public fun retrieve(executor: NavigationExecutor, context: Context): Any
 }
 
 /**

--- a/whetstone/navigation/src/main/java/com/freeletics/mad/whetstone/internal/NavFind.kt
+++ b/whetstone/navigation/src/main/java/com/freeletics/mad/whetstone/internal/NavFind.kt
@@ -1,7 +1,7 @@
 package com.freeletics.mad.whetstone.internal
 
 import android.content.Context
-import androidx.navigation.NavBackStackEntry
+import com.freeletics.mad.navigator.internal.NavigationExecutor
 import kotlin.reflect.KClass
 
 /**
@@ -12,14 +12,14 @@ import kotlin.reflect.KClass
 public fun <T : Any> Context.findComponentByScope(
     scope: KClass<*>,
     destinationScope: KClass<*>,
-    findEntry: (Int) -> NavBackStackEntry
+    executor: NavigationExecutor,
 ): T {
     if (scope != destinationScope) {
         val destinationComponent = find(destinationScope) as? DestinationComponent
         val getter = destinationComponent?.navEntryComponentGetters?.get(scope.java)
         if (getter != null) {
             @Suppress("UNCHECKED_CAST")
-            return getter.retrieve(findEntry, this) as T
+            return getter.retrieve(executor, this) as T
         }
     }
     val dependency = find(scope)


### PR DESCRIPTION
Whetstone now has 0 direct dependencies on AndroidX Navigation, all it uses are our own navigation APIs, mainly through NavigationExecutor. This also means `LocalNavController` is being removed now.

Nice side effects
- we don't need the import alias workaround anymore
- the generated code got a bit simpler