### PR TITLE
replace PermissionResult enum with a sealed class

### DIFF
--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavigationSetup.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavigationSetup.kt
@@ -1,8 +1,5 @@
 package com.freeletics.mad.navigator.compose
 
-import android.app.Activity
-import android.content.Context
-import android.content.ContextWrapper
 import android.os.Parcelable
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -74,17 +71,8 @@ private fun rememberResultLaunchers(
 ): ActivityResultLauncher<List<String>> {
     val context = LocalContext.current
     return rememberLauncherForActivityResult(RequestPermissionsContract()) { resultMap ->
-        request.handleResult(resultMap, context.findActivity())
+        request.handleResult(resultMap, context)
     }
-}
-
-private fun Context.findActivity(): Activity {
-    var context = this
-    while (context is ContextWrapper) {
-        if (context is Activity) return context
-        context = context.baseContext
-    }
-    throw IllegalStateException("Permissions should be called in the context of an Activity")
 }
 
 @Composable

--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/HandleNavigation.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/HandleNavigation.kt
@@ -1,6 +1,6 @@
 package com.freeletics.mad.navigator.fragment
 
-import android.app.Activity
+import android.content.Context
 import android.os.Parcelable
 import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
@@ -29,7 +29,7 @@ public fun handleNavigation(fragment: Fragment, navigator: NavEventNavigator) {
         it.registerIn(fragment)
     }
     val permissionLaunchers = navigator.permissionsResultRequests.associateWith {
-        it.registerIn(fragment, fragment.requireActivity())
+        it.registerIn(fragment, fragment.requireContext())
     }
 
     val lifecycle = fragment.lifecycle
@@ -59,10 +59,10 @@ private fun <I, O> ActivityResultRequest<I, O>.registerIn(
 
 private fun PermissionsResultRequest.registerIn(
     caller: ActivityResultCaller,
-    activity: Activity
+    context: Context
 ): ActivityResultLauncher<List<String>> {
     return caller.registerForActivityResult(RequestPermissionsContract()) { resultMap ->
-        handleResult(resultMap, activity)
+        handleResult(resultMap, context)
     }
 }
 

--- a/navigator/runtime/api/navigator-runtime.api
+++ b/navigator/runtime/api/navigator-runtime.api
@@ -74,12 +74,16 @@ public final class com/freeletics/mad/navigator/NavigationResultRequest$Key$CREA
 public final class com/freeletics/mad/navigator/PermissionsResultRequest : com/freeletics/mad/navigator/ResultOwner {
 }
 
-public final class com/freeletics/mad/navigator/PermissionsResultRequest$PermissionResult : java/lang/Enum {
-	public static final field DENIED Lcom/freeletics/mad/navigator/PermissionsResultRequest$PermissionResult;
-	public static final field DENIED_PERMANENTLY Lcom/freeletics/mad/navigator/PermissionsResultRequest$PermissionResult;
-	public static final field GRANTED Lcom/freeletics/mad/navigator/PermissionsResultRequest$PermissionResult;
-	public static fun valueOf (Ljava/lang/String;)Lcom/freeletics/mad/navigator/PermissionsResultRequest$PermissionResult;
-	public static fun values ()[Lcom/freeletics/mad/navigator/PermissionsResultRequest$PermissionResult;
+public abstract interface class com/freeletics/mad/navigator/PermissionsResultRequest$PermissionResult {
+}
+
+public final class com/freeletics/mad/navigator/PermissionsResultRequest$PermissionResult$Denied : com/freeletics/mad/navigator/PermissionsResultRequest$PermissionResult {
+	public fun <init> (Z)V
+	public final fun getShouldShowRationale ()Z
+}
+
+public final class com/freeletics/mad/navigator/PermissionsResultRequest$PermissionResult$Granted : com/freeletics/mad/navigator/PermissionsResultRequest$PermissionResult {
+	public static final field INSTANCE Lcom/freeletics/mad/navigator/PermissionsResultRequest$PermissionResult$Granted;
 }
 
 public abstract class com/freeletics/mad/navigator/ResultOwner {

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
@@ -82,9 +82,9 @@ public open class NavEventNavigator {
      * [NavEventNavigator.requestPermissions].
      *
      * Compared to using [registerForActivityResult] with
-     * [androidx.activity.result.contract.ActivityResultContracts.RequestPermission] this also
-     * gives you the information whether a permission was
-     * [permanently denied][PermissionsResultRequest.PermissionResult.DENIED_PERMANENTLY].
+     * [androidx.activity.result.contract.ActivityResultContracts.RequestPermission] this provides
+     * a `PermissionResult` instead of a `boolean. See `[PermissionsResultRequest.PermissionResult]`
+     * for more information.
      *
      * Note: This has to be called *before* this [NavEventNavigator] gets attached to a fragment.
      *   In practice, this means it should usually be called during initialisation of your subclass.
@@ -205,10 +205,10 @@ public open class NavEventNavigator {
     /**
      * Triggers a new [NavEvent] that requests the given [permissions].
      *
-     * Compared to using [navigateForResult] with
-     * [androidx.activity.result.contract.ActivityResultContracts.RequestPermission] this also
-     * gives you the information whether a permission was
-     * [permanently denied][PermissionsResultRequest.PermissionResult.DENIED_PERMANENTLY].
+     * Compared to using [registerForActivityResult] with
+     * [androidx.activity.result.contract.ActivityResultContracts.RequestPermission] this provides
+     * a `PermissionResult` instead of a `boolean. See `[PermissionsResultRequest.PermissionResult]`
+     * for more information.
      *
      * The [request] can be obtained by calling [registerForPermissionsResult].
      */
@@ -219,10 +219,10 @@ public open class NavEventNavigator {
     /**
      * Triggers a new [NavEvent] that requests the given [permissions].
      *
-     * Compared to using [navigateForResult] with
-     * [androidx.activity.result.contract.ActivityResultContracts.RequestPermission] this also
-     * gives you the information whether a permission was
-     * [permanently denied][PermissionsResultRequest.PermissionResult.DENIED_PERMANENTLY].
+     * Compared to using [registerForActivityResult] with
+     * [androidx.activity.result.contract.ActivityResultContracts.RequestPermission] this provides
+     * a `PermissionResult` instead of a `boolean. See `[PermissionsResultRequest.PermissionResult]`
+     * for more information.
      *
      * The [request] can be obtained by calling [registerForPermissionsResult].
      */

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/ResultOwner.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/ResultOwner.kt
@@ -106,7 +106,7 @@ public class PermissionsResultRequest internal constructor() :
          * - Android 11+: the user denied the request twice already and the system won't ask again
          *     - `shouldShowRationale` is `false`
          * - Android 11+: the user dismissed the notification request without making a choice
-         *     - `shouldShowRationale` is `false` if the user dit not deny the permission before
+         *     - `shouldShowRationale` is `false` if the user did not deny the permission before
          *     - `shouldShowRationale` is `true` if the user denied the permission before
          *
          * Until Android 11 `shouldShowRationale` being `false` can be interpreted as the permission

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/RequestPermissionsContract.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/RequestPermissionsContract.kt
@@ -1,9 +1,13 @@
 package com.freeletics.mad.navigator.internal
 
+import android.app.Activity
 import android.content.Context
+import android.content.ContextWrapper
 import android.content.Intent
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.app.ActivityCompat.shouldShowRequestPermissionRationale as shouldShowRationale
+import com.freeletics.mad.navigator.PermissionsResultRequest.PermissionResult
 
 /**
  * Wrapper for [ActivityResultContracts.RequestMultiplePermissions] so that a [List] is used
@@ -30,5 +34,30 @@ public class RequestPermissionsContract :
 
     override fun parseResult(resultCode: Int, intent: Intent?): Map<String, Boolean> {
         return contract.parseResult(resultCode, intent)
+    }
+
+    internal companion object {
+        internal fun enrichResult(
+            context: Context,
+            resultMap: Map<String, Boolean>
+        ): Map<String, PermissionResult> {
+            val activity = context.findActivity()
+            return resultMap.mapValues { (permission, granted) ->
+                if (granted) {
+                    PermissionResult.Granted
+                } else {
+                    PermissionResult.Denied(shouldShowRationale(activity, permission))
+                }
+            }
+        }
+
+        private fun Context.findActivity(): Activity {
+            var context = this
+            while (context is ContextWrapper) {
+                if (context is Activity) return context
+                context = context.baseContext
+            }
+            throw IllegalStateException("Permissions should be requested in the context of an Activity")
+        }
     }
 }


### PR DESCRIPTION
With this the result matches what the platform provides and does not try to interpret the values (in a wrong way).