### PR TITLE
move Bundle related methods

### DIFF
--- a/navigator/androidx-nav/api/androidx-nav.api
+++ b/navigator/androidx-nav/api/androidx-nav.api
@@ -1,3 +1,6 @@
+public final class com/freeletics/mad/navigator/internal/BundleKt {
+}
+
 public final class com/freeletics/mad/navigator/internal/DestinationIdKt {
 }
 

--- a/navigator/androidx-nav/src/main/java/com/freeletics/mad/navigator/internal/Bundle.kt
+++ b/navigator/androidx-nav/src/main/java/com/freeletics/mad/navigator/internal/Bundle.kt
@@ -1,0 +1,33 @@
+package com.freeletics.mad.navigator.internal
+
+import android.os.Bundle
+import android.os.Parcelable
+import com.freeletics.mad.navigator.ActivityRoute
+import com.freeletics.mad.navigator.BaseRoute
+import com.freeletics.mad.navigator.EXTRA_ROUTE
+
+@InternalNavigatorApi
+public fun <T : BaseRoute> Bundle?.requireRoute(): T {
+    requireNotNull(this) {
+        "Bundle is null. Can't extract Route data."
+    }
+    @Suppress("DEPRECATION")
+    return requireNotNull(getParcelable(EXTRA_ROUTE)) {
+        "Bundle doesn't contain Route data in \"$EXTRA_ROUTE\""
+    }
+}
+
+@InternalNavigatorApi
+public fun BaseRoute.getArguments(): Bundle = Bundle().also {
+    it.putParcelable(EXTRA_ROUTE, this)
+}
+
+@InternalNavigatorApi
+public fun ActivityRoute.getArguments(): Bundle = Bundle().also {
+    it.putParcelable(EXTRA_FILL_IN_INTENT, fillInIntent())
+    if (this is Parcelable) {
+        it.putParcelable(EXTRA_ROUTE, this)
+    }
+}
+
+internal const val EXTRA_FILL_IN_INTENT: String = "com.freeletics.mad.navigation.FILL_IN_INTENT"

--- a/navigator/androidx-nav/src/main/java/com/freeletics/mad/navigator/internal/CustomActivityNavigator.kt
+++ b/navigator/androidx-nav/src/main/java/com/freeletics/mad/navigator/internal/CustomActivityNavigator.kt
@@ -26,6 +26,7 @@ import androidx.navigation.NavDestination
 import androidx.navigation.NavOptions
 import androidx.navigation.Navigator
 import androidx.navigation.NavigatorProvider
+import com.freeletics.mad.navigator.EXTRA_ROUTE
 
 /**
  * ActivityNavigator implements cross-activity navigation.
@@ -85,11 +86,13 @@ public open class CustomActivityNavigator(
         }
         val intent = Intent(destination.intent)
         if (args != null) {
+            @Suppress("DEPRECATION")
             val fillInIntent = args.getParcelable<Intent>(EXTRA_FILL_IN_INTENT)
             if (fillInIntent != null) {
                 intent.fillIn(fillInIntent, 0)
             }
 
+            @Suppress("DEPRECATION")
             val route = args.getParcelable<Parcelable>(EXTRA_ROUTE)
             if (route != null) {
                 intent.putExtra(EXTRA_ROUTE, route)

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavRoute.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavRoute.kt
@@ -3,7 +3,7 @@ package com.freeletics.mad.navigator
 import android.app.Activity
 import android.content.Intent
 import android.os.Parcelable
-import com.freeletics.mad.navigator.internal.EXTRA_ROUTE
+import com.freeletics.mad.navigator.internal.InternalNavigatorApi
 
 public sealed interface BaseRoute : Parcelable
 
@@ -54,5 +54,9 @@ public fun <T : ActivityRoute> Activity.requireRoute(): T {
  * Activity's Intent.
  */
 public fun <T : ActivityRoute> Activity.getRoute(): T? {
+    @Suppress("DEPRECATION")
     return intent.extras?.getParcelable(EXTRA_ROUTE)
 }
+
+@InternalNavigatorApi
+public const val EXTRA_ROUTE: String = "com.freeletics.mad.navigation.ROUTE"

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/Navigate.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/Navigate.kt
@@ -1,11 +1,7 @@
 package com.freeletics.mad.navigator.internal
 
-import android.os.Bundle
-import android.os.Parcelable
 import androidx.activity.result.ActivityResultLauncher
 import com.freeletics.mad.navigator.ActivityResultRequest
-import com.freeletics.mad.navigator.ActivityRoute
-import com.freeletics.mad.navigator.BaseRoute
 import com.freeletics.mad.navigator.NavEvent
 import com.freeletics.mad.navigator.PermissionsResultRequest
 
@@ -58,33 +54,3 @@ public fun navigate(
         }
     }
 }
-
-
-@InternalNavigatorApi
-public fun <T : BaseRoute> Bundle?.requireRoute(): T = requireNotNull(this) {
-        "Bundle is null. Can't extract Route data."
-    }
-    .run {
-        requireNotNull(getParcelable(EXTRA_ROUTE)) {
-            "Bundle doesn't contain Route data in \"$EXTRA_ROUTE\""
-        }
-    }
-
-@InternalNavigatorApi
-public fun BaseRoute.getArguments(): Bundle = Bundle().also {
-    it.putParcelable(EXTRA_ROUTE, this)
-}
-
-@InternalNavigatorApi
-public fun ActivityRoute.getArguments(): Bundle = Bundle().also {
-    it.putParcelable(EXTRA_FILL_IN_INTENT, fillInIntent())
-    if (this is Parcelable) {
-        it.putParcelable(EXTRA_ROUTE, this)
-    }
-}
-
-@InternalNavigatorApi
-public const val EXTRA_ROUTE: String = "com.freeletics.mad.navigation.ROUTE"
-
-@InternalNavigatorApi
-public const val EXTRA_FILL_IN_INTENT: String = "com.freeletics.mad.navigation.FILL_IN_INTENT"


### PR DESCRIPTION
Moves all methods that turn routes to bundles and the other way around to the androidx base module. This is part of the changes to make `:navigator:runtime` AndroidX navigation free. Only `EXTRA_ROUTE` stays because that is used for the public `Activity.getRoute` API which will stay regardless of how the navigation implementation looks like. 

This does not affect the public API of the library, all moved methods/properties are marked as internal.