### PR TITLE
share collecting navigation results, make more of NavigationResultRequest.Key internal

### DIFF
--- a/navigator/androidx-nav/src/main/java/com/freeletics/mad/navigator/internal/AndroidXNavigationExecutor.kt
+++ b/navigator/androidx-nav/src/main/java/com/freeletics/mad/navigator/internal/AndroidXNavigationExecutor.kt
@@ -1,6 +1,5 @@
 package com.freeletics.mad.navigator.internal
 
-import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModelStore
 import androidx.navigation.NavBackStackEntry
@@ -10,7 +9,6 @@ import com.freeletics.mad.navigator.ActivityRoute
 import com.freeletics.mad.navigator.BaseRoute
 import com.freeletics.mad.navigator.NavRoot
 import com.freeletics.mad.navigator.NavRoute
-import com.freeletics.mad.navigator.NavigationResultRequest
 
 @InternalNavigatorApi
 public class AndroidXNavigationExecutor(
@@ -44,10 +42,6 @@ public class AndroidXNavigationExecutor(
 
     override fun navigateUp() {
         controller.navigateUp()
-    }
-
-    override fun deliverResult(key: NavigationResultRequest.Key<*>, result: Parcelable) {
-        savedStateHandleFor(key.destinationId)[key.requestKey] = result
     }
 
     override fun navigateBackTo(destinationId: DestinationId<*>, isInclusive: Boolean) {

--- a/navigator/runtime-compose/api/navigator-runtime-compose.api
+++ b/navigator/runtime-compose/api/navigator-runtime-compose.api
@@ -10,14 +10,6 @@ public final class com/freeletics/mad/navigator/compose/DialogDestination : com/
 	public synthetic fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
-public final class com/freeletics/mad/navigator/compose/InitialValue$Creator : android/os/Parcelable$Creator {
-	public fun <init> ()V
-	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/freeletics/mad/navigator/compose/InitialValue;
-	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
-	public final fun newArray (I)[Lcom/freeletics/mad/navigator/compose/InitialValue;
-	public synthetic fun newArray (I)[Ljava/lang/Object;
-}
-
 public abstract interface class com/freeletics/mad/navigator/compose/NavDestination {
 }
 

--- a/navigator/runtime-compose/build.gradle
+++ b/navigator/runtime-compose/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.dokka)
     alias(libs.plugins.publish)
 }
@@ -67,9 +66,7 @@ dependencies {
     implementation libs.androidx.compose.foundation
     implementation libs.androidx.compose.material
     implementation libs.androidx.lifecycle.common
-    implementation libs.androidx.viewmodel.savedstate
     implementation libs.androidx.navigation.common
     implementation libs.androidx.navigation.compose
     implementation libs.accompanist.navigation
-    implementation libs.kotlin.parcelize
 }

--- a/navigator/runtime-fragment/api/navigator-runtime-fragment.api
+++ b/navigator/runtime-fragment/api/navigator-runtime-fragment.api
@@ -14,14 +14,6 @@ public final class com/freeletics/mad/navigator/fragment/HandleNavigationKt {
 	public static final fun handleNavigation (Landroidx/fragment/app/Fragment;Lcom/freeletics/mad/navigator/NavEventNavigator;)V
 }
 
-public final class com/freeletics/mad/navigator/fragment/InitialValue$Creator : android/os/Parcelable$Creator {
-	public fun <init> ()V
-	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/freeletics/mad/navigator/fragment/InitialValue;
-	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
-	public final fun newArray (I)[Lcom/freeletics/mad/navigator/fragment/InitialValue;
-	public synthetic fun newArray (I)[Ljava/lang/Object;
-}
-
 public abstract interface class com/freeletics/mad/navigator/fragment/NavDestination {
 }
 

--- a/navigator/runtime-fragment/build.gradle
+++ b/navigator/runtime-fragment/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.dokka)
     alias(libs.plugins.publish)
 }
@@ -59,8 +58,6 @@ dependencies {
     implementation libs.androidx.activity
     implementation libs.androidx.lifecycle.common
     implementation libs.androidx.lifecycle.runtime
-    implementation libs.androidx.viewmodel.savedstate
     implementation libs.androidx.navigation.common
     implementation libs.androidx.navigation.runtime
-    implementation libs.kotlin.parcelize
 }

--- a/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/HandleNavigation.kt
+++ b/navigator/runtime-fragment/src/main/java/com/freeletics/mad/navigator/fragment/HandleNavigation.kt
@@ -1,24 +1,19 @@
 package com.freeletics.mad.navigator.fragment
 
 import android.content.Context
-import android.os.Parcelable
 import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.coroutineScope
 import androidx.navigation.fragment.findNavController
 import com.freeletics.mad.navigator.ActivityResultRequest
 import com.freeletics.mad.navigator.NavEventNavigator
-import com.freeletics.mad.navigator.NavigationResultRequest
 import com.freeletics.mad.navigator.PermissionsResultRequest
 import com.freeletics.mad.navigator.internal.AndroidXNavigationExecutor
-import com.freeletics.mad.navigator.internal.DestinationId
-import com.freeletics.mad.navigator.internal.NavigationExecutor
 import com.freeletics.mad.navigator.internal.RequestPermissionsContract
 import com.freeletics.mad.navigator.internal.collectAndHandleNavEvents
+import com.freeletics.mad.navigator.internal.collectAndHandleNavigationResults
 import kotlinx.coroutines.launch
-import kotlinx.parcelize.Parcelize
 
 /**
  * Handles the [NavEventNavigator] events while the Fragment's lifecycle is at least
@@ -36,7 +31,9 @@ public fun handleNavigation(fragment: Fragment, navigator: NavEventNavigator) {
 
     val executor = AndroidXNavigationExecutor(fragment.findNavController())
     navigator.navigationResultRequests.forEach {
-        it.registerIn(executor, lifecycle)
+        lifecycle.coroutineScope.launch {
+            executor.collectAndHandleNavigationResults(it)
+        }
     }
 
     val dispatcher = fragment.requireActivity().onBackPressedDispatcher
@@ -62,23 +59,3 @@ private fun PermissionsResultRequest.registerIn(
         handleResult(resultMap, context)
     }
 }
-
-private fun <O : Parcelable> NavigationResultRequest<O>.registerIn(
-    executor: NavigationExecutor,
-    lifecycle: Lifecycle,
-) {
-    lifecycle.coroutineScope.launch {
-        val savedStateHandle = executor.savedStateHandleFor(key.destinationId)
-        savedStateHandle.getStateFlow<Parcelable>(key.requestKey, InitialValue)
-            .collect { result ->
-                if (result != InitialValue) {
-                    @Suppress("UNCHECKED_CAST")
-                    handleResult(result as O)
-                    savedStateHandle[key.requestKey] = InitialValue
-                }
-            }
-    }
-}
-
-@Parcelize
-private object InitialValue : Parcelable

--- a/navigator/runtime/api/navigator-runtime.api
+++ b/navigator/runtime/api/navigator-runtime.api
@@ -94,9 +94,17 @@ public abstract class com/freeletics/mad/navigator/ResultOwner {
 public final class com/freeletics/mad/navigator/internal/DestinationIdKt {
 }
 
+public final class com/freeletics/mad/navigator/internal/InitialValue$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/freeletics/mad/navigator/internal/InitialValue;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/freeletics/mad/navigator/internal/InitialValue;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public abstract interface annotation class com/freeletics/mad/navigator/internal/InternalNavigatorApi : java/lang/annotation/Annotation {
 }
 
-public final class com/freeletics/mad/navigator/internal/NavigateKt {
+public final class com/freeletics/mad/navigator/internal/NavigationSetupKt {
 }
 

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/ResultOwner.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/ResultOwner.kt
@@ -133,21 +133,14 @@ public class NavigationResultRequest<R : Parcelable> internal constructor(
     public val key: Key<R>,
 ) : ResultOwner<R>() {
 
-    @InternalNavigatorApi
-    public fun handleResult(result: R) {
-        onResult(result)
-    }
-
     /**
      * Use to identify where the result should be delivered to.
      */
     @Poko
     @Parcelize
     public class Key<R : Parcelable> internal constructor(
-        @property:InternalNavigatorApi
-        public val destinationId: DestinationId<*>,
-        @property:InternalNavigatorApi
-        public val requestKey: String
+        internal val destinationId: DestinationId<*>,
+        internal val requestKey: String
     ) : Parcelable {
         private companion object : Parceler<Key<*>> {
             override fun Key<*>.write(parcel: Parcel, flags: Int) {

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/NavigationExecutor.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/NavigationExecutor.kt
@@ -1,13 +1,11 @@
 package com.freeletics.mad.navigator.internal
 
-import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModelStore
 import com.freeletics.mad.navigator.ActivityRoute
 import com.freeletics.mad.navigator.BaseRoute
 import com.freeletics.mad.navigator.NavRoot
 import com.freeletics.mad.navigator.NavRoute
-import com.freeletics.mad.navigator.NavigationResultRequest
 
 @InternalNavigatorApi
 public interface NavigationExecutor {
@@ -17,7 +15,6 @@ public interface NavigationExecutor {
     public fun navigateUp()
     public fun navigateBack()
     public fun navigateBackTo(destinationId: DestinationId<*>, isInclusive: Boolean)
-    public fun deliverResult(key: NavigationResultRequest.Key<*>, result: Parcelable)
     public fun <T : BaseRoute> routeFor(destinationId: DestinationId<T>): T
     public fun savedStateHandleFor(destinationId: DestinationId<*>): SavedStateHandle
     public fun viewModelStoreFor(destinationId: DestinationId<*>): ViewModelStore

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/NavigationSetup.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/NavigationSetup.kt
@@ -1,13 +1,16 @@
 package com.freeletics.mad.navigator.internal
 
 import android.annotation.SuppressLint
+import android.os.Parcelable
 import androidx.activity.result.ActivityResultLauncher
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import com.freeletics.mad.navigator.ActivityResultRequest
 import com.freeletics.mad.navigator.NavEvent
 import com.freeletics.mad.navigator.NavEventNavigator
+import com.freeletics.mad.navigator.NavigationResultRequest
 import com.freeletics.mad.navigator.PermissionsResultRequest
+import kotlinx.parcelize.Parcelize
 
 @SuppressLint("VisibleForTests") // VisibleForTests(otherwise = INTERNAL) does not exist
 @InternalNavigatorApi
@@ -66,7 +69,26 @@ private fun NavigationExecutor.navigate(
             (launcher as ActivityResultLauncher<Any?>).launch(event.permissions)
         }
         is NavEvent.DestinationResultEvent<*> -> {
-            deliverResult(event.key, event.result)
+            savedStateHandleFor(event.key.destinationId)[event.key.requestKey] = event.result
         }
     }
 }
+
+@SuppressLint("VisibleForTests") // VisibleForTests(otherwise = INTERNAL) does not exist
+@InternalNavigatorApi
+public suspend fun <R : Parcelable> NavigationExecutor.collectAndHandleNavigationResults(
+    request: NavigationResultRequest<R>,
+) {
+    val savedStateHandle = savedStateHandleFor(request.key.destinationId)
+    savedStateHandle.getStateFlow<Parcelable>(request.key.requestKey, InitialValue)
+        .collect {
+            if (it != InitialValue) {
+                @Suppress("UNCHECKED_CAST")
+                request.onResult(it as R)
+                savedStateHandle[request.key.requestKey] = InitialValue
+            }
+        }
+}
+
+@Parcelize
+private object InitialValue : Parcelable


### PR DESCRIPTION
Similar to the shared `collectAndHandleNavEvents`, the main runtime now has `collectAndHandleNavigationResults` which will take care of collecting and forwarding navigation results. `deliverResult` was also removed from the executor and instead is done in the nav event code since we are exposing the saved state handle anyways. The latter allows us to make the contents of the Key completely internal.