### PR TITLE
don't allow passing NavRoot to navigateBackTo, instead add clear option to navigateToRoot

### DIFF
--- a/navigator/androidx-nav/src/main/java/com/freeletics/mad/navigator/internal/AndroidXNavigationExecutor.kt
+++ b/navigator/androidx-nav/src/main/java/com/freeletics/mad/navigator/internal/AndroidXNavigationExecutor.kt
@@ -25,10 +25,14 @@ public class AndroidXNavigationExecutor(
         controller.navigate(route.destinationId(), route.getArguments())
     }
 
-    override fun navigate(root: NavRoot, restoreRootState: Boolean) {
+    override fun navigate(root: NavRoot, restoreRootState: Boolean, saveCurrentRootState: Boolean) {
         val options = NavOptions.Builder()
             // save the state of the current root before leaving it
-            .setPopUpTo(controller.graph.startDestinationId, inclusive = false, saveState = true)
+            .setPopUpTo(
+                controller.graph.startDestinationId,
+                inclusive = false,
+                saveState = saveCurrentRootState
+            )
             // restoring the state of the target root
             .setRestoreState(restoreRootState)
             // makes sure that if the destination is already on the backstack, it and

--- a/navigator/runtime/api/navigator-runtime.api
+++ b/navigator/runtime/api/navigator-runtime.api
@@ -28,8 +28,8 @@ public class com/freeletics/mad/navigator/NavEventNavigator {
 	public final fun navigateForResult (Lcom/freeletics/mad/navigator/ActivityResultRequest;Ljava/lang/Object;)V
 	public final fun navigateTo (Lcom/freeletics/mad/navigator/ActivityRoute;)V
 	public final fun navigateTo (Lcom/freeletics/mad/navigator/NavRoute;)V
-	public final fun navigateToRoot (Lcom/freeletics/mad/navigator/NavRoot;Z)V
-	public static synthetic fun navigateToRoot$default (Lcom/freeletics/mad/navigator/NavEventNavigator;Lcom/freeletics/mad/navigator/NavRoot;ZILjava/lang/Object;)V
+	public final fun navigateToRoot (Lcom/freeletics/mad/navigator/NavRoot;ZZ)V
+	public static synthetic fun navigateToRoot$default (Lcom/freeletics/mad/navigator/NavEventNavigator;Lcom/freeletics/mad/navigator/NavRoot;ZZILjava/lang/Object;)V
 	public final fun navigateUp ()V
 	protected final fun registerForActivityResult (Landroidx/activity/result/contract/ActivityResultContract;)Lcom/freeletics/mad/navigator/ActivityResultRequest;
 	public final fun registerForNavigationResult-Enyiqp0 (Lkotlin/reflect/KClass;Ljava/lang/String;)Lcom/freeletics/mad/navigator/NavigationResultRequest;

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEvent.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEvent.kt
@@ -35,6 +35,7 @@ public sealed interface NavEvent {
     public class NavigateToRootEvent(
         internal val root: NavRoot,
         internal val restoreRootState: Boolean,
+        internal val saveCurrentRootState: Boolean,
     ) : NavEvent
 
     /**

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
@@ -134,14 +134,15 @@ public open class NavEventNavigator {
 
     /**
      * Triggers a new [NavEvent] to navigate to the given [root]. The current back stack will
-     * be popped and saved. Whether the backstack of the given root is restored depends
-     * on [restoreRootState].
+     * be popped and saved it [saveCurrentRootState] is `true`, otherwise it will be discarded.
+     * Whether the backstack of the given `root` is restored depends on [restoreRootState].
      */
     public fun navigateToRoot(
         root: NavRoot,
         restoreRootState: Boolean = false,
+        saveCurrentRootState: Boolean = true,
     ) {
-        val event = NavEvent.NavigateToRootEvent(root, restoreRootState)
+        val event = NavEvent.NavigateToRootEvent(root, restoreRootState, saveCurrentRootState)
         sendNavEvent(event)
     }
 
@@ -173,7 +174,7 @@ public open class NavEventNavigator {
      * Triggers a new [NavEvent] that pops the back stack to [T]. If [inclusive] is
      * `true` [T] itself will also be popped.
      */
-    public inline fun <reified T: BaseRoute> navigateBackTo(inclusive: Boolean = false) {
+    public inline fun <reified T: NavRoute> navigateBackTo(inclusive: Boolean = false) {
         navigateBackTo(DestinationId(T::class), inclusive)
     }
 

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/Navigate.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/Navigate.kt
@@ -33,7 +33,7 @@ private fun NavigationExecutor.navigate(
             navigate(event.route)
         }
         is NavEvent.NavigateToRootEvent -> {
-            navigate(event.root, event.restoreRootState)
+            navigate(event.root, event.restoreRootState, event.saveCurrentRootState)
         }
         is NavEvent.NavigateToActivityEvent -> {
             navigate(event.route)

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/NavigationExecutor.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/NavigationExecutor.kt
@@ -12,7 +12,7 @@ import com.freeletics.mad.navigator.NavigationResultRequest
 @InternalNavigatorApi
 public interface NavigationExecutor {
     public fun navigate(route: NavRoute)
-    public fun navigate(root: NavRoot, restoreRootState: Boolean)
+    public fun navigate(root: NavRoot, restoreRootState: Boolean, saveCurrentRootState: Boolean)
     public fun navigate(route: ActivityRoute)
     public fun navigateUp()
     public fun navigateBack()

--- a/navigator/runtime/src/test/java/com/freeletics/mad/navigator/NavEventNavigatorTest.kt
+++ b/navigator/runtime/src/test/java/com/freeletics/mad/navigator/NavEventNavigatorTest.kt
@@ -82,9 +82,17 @@ public class NavEventNavigatorTest {
         val navigator = TestNavigator()
 
         navigator.navEvents.test {
-            navigator.navigateToRoot(SimpleRoot(1), true)
+            navigator.navigateToRoot(
+                root = SimpleRoot(1),
+                restoreRootState = true,
+                saveCurrentRootState = false
+            )
 
-            assertThat(awaitItem()).isEqualTo(NavigateToRootEvent(SimpleRoot(1), true))
+            assertThat(awaitItem()).isEqualTo(NavigateToRootEvent(
+                root = SimpleRoot(1),
+                restoreRootState = true,
+                saveCurrentRootState = false
+            ))
 
             cancel()
         }


### PR DESCRIPTION
This will make implementing custom back stacks easier, because it ensures that the pop up to stays within the current back stack which starts with a `NavRoot`. In practice this means that if you want to go to the root of your stack or even the default back stack you need to use `navigateToRoot`. That method is now exposing `saveCurrentRootState` which previously was always true internally and allows dropping the state of the current stack.

With this the usages of navigateToRoot are
- bottom nav selected: `navigateToRoot(root, restoreRootState = true, saveCurrentRootState  = true)`
- current bottom nav re-selected: `navigateToRoot(root, restoreRootState = false, saveCurrentRootState  = false)` (we have true here right now but I guess it doesn't do anything because we are going to the same root and not restoring anything)
- navigating to another tab in code:  `navigateToRoot(root, restoreRootState = false, saveCurrentRootState  = true)`
- going back to start:  `navigateToRoot(root, restoreRootState = false, saveCurrentRootState  = false)`