### PR TITLE
make ActivityRoute Parcelable

### DIFF
--- a/navigator/README.md
+++ b/navigator/README.md
@@ -209,36 +209,33 @@ is disabled. This can be used to for example show a confirmation dialog before n
 ### Activity destinations
 
 It is also possible navigate to an `Activity` both inside and outside of the app. In both cases
-it's required to define an `ActivityRoute` and an `ActivityDestination` like for any other screen.
-The route can then simply be passed to `navigateTo` to start the associated `Activity`. The
-`ActivityDestination` is just another `NavDestination` than can be added to the `Set` with all
-other destinations.
+it's required to define an `InternalActivtyRoute` or `ExternalActivityRoute` as well as an 
+`ActivityDestination` like for any other screen. The route can then simply be passed to `navigateTo` 
+to start the associated `Activity`. The `ActivityDestination` is just another `NavDestination` 
+than can be added to the `Set` with all other destinations.
 
-For an `Activity` in the same app it's recommended to extend `Parcelable` with will allow the
-started `Activity` to obtain the route and use it to easily access any parameter.
+`InternalActivtyRoute` is meant for `Activity` instances in the current app and can be obtained
+in the launched activity by calling `getRoute` or `requireRoute` to read parameters passed to it.
+
 
 This is example shows the route and destination for a `SettingsActivity`:
 ```kotlin
 @Parcelize
 data class SettingsActivityRoute(
     val id: String,
-) : ActivityRoute, Parcelable
+) : InternalActivityRoute
 
 val extraActivityDestination: NavDestination = ActivityDestination<SettingsRoute>(
     intent = Intent(context, SettingsActivity::class)
 )
 ```
 
-The `SettingsActivity` could then access `SettingsActivityRoute` by using the `Activity.requireRoute()`
-extension function.
-
-In the case of external activities `Parcelable` can't be used because it would crash the other app.
-It is possible to add static extras to the destination or to dynamically add extras to the route
-by implementing `intentExtras`:
+Activities in other apps can be targeted with `ExternalActivityRoute` which allows enriching the
+resulting `Intent` with it's `fillInIntent` method.
 
 ```kotlin
 // minimal route
-object PlayStoreRoute : ActivityRoute
+object PlayStoreRoute : ExternalActivityRoute
 
 val playStoreDestination: NavDestination = ActivityDestination<PlayStoreRoute>(
     // full intent is statically defined
@@ -249,7 +246,7 @@ val playStoreDestination: NavDestination = ActivityDestination<PlayStoreRoute>(
 class ShareRoute(
     private val title: String,
     private val message: String
-) : ActivityRoute {
+) : ExternalActivityRoute {
     // the returned Intent is filled into the Intent of the destination by calling
     // destinationIntent.fillIn(fillInIntent())
     override fun fillInIntent() = Intent()
@@ -259,7 +256,6 @@ class ShareRoute(
             type = "text/plain"
             putExtra(Intent.EXTRA_TEXT, message)
         })
-    }
 }
 
 val shareDestination: NavDestination = ActivityDestination<ShareRoute>(

--- a/navigator/README.md
+++ b/navigator/README.md
@@ -223,7 +223,7 @@ This is example shows the route and destination for a `SettingsActivity`:
 @Parcelize
 data class SettingsActivityRoute(
     val id: String,
-) : InternalActivityRoute
+) : InternalActivityRoute()
 
 val extraActivityDestination: NavDestination = ActivityDestination<SettingsRoute>(
     intent = Intent(context, SettingsActivity::class)
@@ -235,6 +235,7 @@ resulting `Intent` with it's `fillInIntent` method.
 
 ```kotlin
 // minimal route
+@Parcelize
 object PlayStoreRoute : ExternalActivityRoute
 
 val playStoreDestination: NavDestination = ActivityDestination<PlayStoreRoute>(
@@ -243,6 +244,7 @@ val playStoreDestination: NavDestination = ActivityDestination<PlayStoreRoute>(
 )
 
 // route with extra values
+@Parcelize
 class ShareRoute(
     private val title: String,
     private val message: String
@@ -264,9 +266,10 @@ val shareDestination: NavDestination = ActivityDestination<ShareRoute>(
 )
 
 // route with a data uri extra
+@Parcelize
 class BrowserRoute(
     uri: Uri,
-) : ActivityRoute {
+) : ExternalActivityRoute {
     // the returned Intent is filled into the Intent of the destination by calling
     // destinationIntent.fillIn(fillInIntent())
     override fun fillInIntent() = Intent().setData(uri)

--- a/navigator/androidx-nav/src/main/java/com/freeletics/mad/navigator/internal/Bundle.kt
+++ b/navigator/androidx-nav/src/main/java/com/freeletics/mad/navigator/internal/Bundle.kt
@@ -25,9 +25,6 @@ public fun BaseRoute.getArguments(): Bundle = Bundle().also {
 @InternalNavigatorApi
 public fun ActivityRoute.getArguments(): Bundle = Bundle().also {
     it.putParcelable(EXTRA_FILL_IN_INTENT, fillInIntent())
-    if (this is Parcelable) {
-        it.putParcelable(EXTRA_ROUTE, this)
-    }
 }
 
 internal const val EXTRA_FILL_IN_INTENT: String = "com.freeletics.mad.navigation.FILL_IN_INTENT"

--- a/navigator/androidx-nav/src/main/java/com/freeletics/mad/navigator/internal/Bundle.kt
+++ b/navigator/androidx-nav/src/main/java/com/freeletics/mad/navigator/internal/Bundle.kt
@@ -1,7 +1,6 @@
 package com.freeletics.mad.navigator.internal
 
 import android.os.Bundle
-import android.os.Parcelable
 import com.freeletics.mad.navigator.ActivityRoute
 import com.freeletics.mad.navigator.BaseRoute
 import com.freeletics.mad.navigator.EXTRA_ROUTE

--- a/navigator/androidx-nav/src/main/java/com/freeletics/mad/navigator/internal/CustomActivityNavigator.kt
+++ b/navigator/androidx-nav/src/main/java/com/freeletics/mad/navigator/internal/CustomActivityNavigator.kt
@@ -91,12 +91,6 @@ public open class CustomActivityNavigator(
             if (fillInIntent != null) {
                 intent.fillIn(fillInIntent, 0)
             }
-
-            @Suppress("DEPRECATION")
-            val route = args.getParcelable<Parcelable>(EXTRA_ROUTE)
-            if (route != null) {
-                intent.putExtra(EXTRA_ROUTE, route)
-            }
         }
         if (hostActivity == null) {
             // If we're not launching from an Activity context we have to launch in a new task.

--- a/navigator/runtime/api/navigator-runtime.api
+++ b/navigator/runtime/api/navigator-runtime.api
@@ -5,11 +5,15 @@ public abstract interface class com/freeletics/mad/navigator/ActivityRoute : and
 	public abstract fun fillInIntent ()Landroid/content/Intent;
 }
 
-public final class com/freeletics/mad/navigator/ActivityRoute$DefaultImpls {
-	public static fun fillInIntent (Lcom/freeletics/mad/navigator/ActivityRoute;)Landroid/content/Intent;
+public abstract interface class com/freeletics/mad/navigator/BaseRoute : android/os/Parcelable {
 }
 
-public abstract interface class com/freeletics/mad/navigator/BaseRoute : android/os/Parcelable {
+public abstract interface class com/freeletics/mad/navigator/ExternalActivityRoute : com/freeletics/mad/navigator/ActivityRoute {
+}
+
+public abstract class com/freeletics/mad/navigator/InternalActivityRoute : com/freeletics/mad/navigator/ActivityRoute {
+	public fun <init> ()V
+	public fun fillInIntent ()Landroid/content/Intent;
 }
 
 public class com/freeletics/mad/navigator/NavEventNavigator {

--- a/navigator/runtime/api/navigator-runtime.api
+++ b/navigator/runtime/api/navigator-runtime.api
@@ -9,11 +9,16 @@ public abstract interface class com/freeletics/mad/navigator/BaseRoute : android
 }
 
 public abstract interface class com/freeletics/mad/navigator/ExternalActivityRoute : com/freeletics/mad/navigator/ActivityRoute {
+	public abstract fun fillInIntent ()Landroid/content/Intent;
+}
+
+public final class com/freeletics/mad/navigator/ExternalActivityRoute$DefaultImpls {
+	public static fun fillInIntent (Lcom/freeletics/mad/navigator/ExternalActivityRoute;)Landroid/content/Intent;
 }
 
 public abstract class com/freeletics/mad/navigator/InternalActivityRoute : com/freeletics/mad/navigator/ActivityRoute {
 	public fun <init> ()V
-	public fun fillInIntent ()Landroid/content/Intent;
+	public final fun fillInIntent ()Landroid/content/Intent;
 }
 
 public class com/freeletics/mad/navigator/NavEventNavigator {

--- a/navigator/runtime/api/navigator-runtime.api
+++ b/navigator/runtime/api/navigator-runtime.api
@@ -1,12 +1,8 @@
 public final class com/freeletics/mad/navigator/ActivityResultRequest : com/freeletics/mad/navigator/ResultOwner {
 }
 
-public abstract interface class com/freeletics/mad/navigator/ActivityRoute {
-	public static final field Companion Lcom/freeletics/mad/navigator/ActivityRoute$Companion;
+public abstract interface class com/freeletics/mad/navigator/ActivityRoute : android/os/Parcelable {
 	public abstract fun fillInIntent ()Landroid/content/Intent;
-}
-
-public final class com/freeletics/mad/navigator/ActivityRoute$Companion {
 }
 
 public final class com/freeletics/mad/navigator/ActivityRoute$DefaultImpls {

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavRoute.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavRoute.kt
@@ -28,15 +28,15 @@ public interface NavRoot : BaseRoute
 /**
  * Represents the route to a destination.
  *
- * When the implementing class is [Parcelable], the instance of route will be put into the
- * navigation arguments and is then available to the target screens. Do not do this in case this
- * route leads to a different app.
+ * By default the instance of this class will be added to th resulting `Intent` and can be accessed
+ * in the launched `Activity` by calling [getRoute] or [requireRoute].
+ *
+ * If this route leads to another app it is required to override [fillInIntent] and at least return
+ * an empty [Intent] from it.
  */
-public interface ActivityRoute {
-    public fun fillInIntent(): Intent = EMPTY_INTENT
-
-    public companion object {
-        private val EMPTY_INTENT = Intent()
+public interface ActivityRoute : Parcelable{
+    public fun fillInIntent(): Intent {
+        return Intent().putExtra(EXTRA_ROUTE, this)
     }
 }
 

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavRoute.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavRoute.kt
@@ -26,19 +26,30 @@ public interface NavRoute : BaseRoute
 public interface NavRoot : BaseRoute
 
 /**
- * Represents the route to a destination.
- *
- * By default the instance of this class will be added to th resulting `Intent` and can be accessed
- * in the launched `Activity` by calling [getRoute] or [requireRoute].
- *
- * If this route leads to another app it is required to override [fillInIntent] and at least return
- * an empty [Intent] from it.
+ * Represents the route to an `Activity`. Should be used through []
  */
-public interface ActivityRoute : Parcelable{
-    public fun fillInIntent(): Intent {
+public sealed interface ActivityRoute : Parcelable{
+    public fun fillInIntent(): Intent
+}
+
+
+
+/**
+ * Represents the route to an `Activity` within the current app. The instance of this route
+ * will be added to th resulting `Intent` and can be accessed in the launched `Activity` by calling
+ * [getRoute] or [requireRoute].
+ */
+public abstract class InternalActivityRoute : ActivityRoute {
+    override fun fillInIntent(): Intent {
         return Intent().putExtra(EXTRA_ROUTE, this)
     }
 }
+
+/**
+ * Represents the route to an `Activity` in another app. [fillInIntent] can be used to dynamically
+ * add extras to the resulting `Intent`.
+ */
+public interface ExternalActivityRoute : ActivityRoute
 
 /**
  * Returns the [ActivityRoute] that was used to navigate to this [Activity].

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavRoute.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavRoute.kt
@@ -32,8 +32,6 @@ public sealed interface ActivityRoute : Parcelable{
     public fun fillInIntent(): Intent
 }
 
-
-
 /**
  * Represents the route to an `Activity` within the current app. The instance of this route
  * will be added to the resulting `Intent` and can be accessed in the launched `Activity` by calling

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavRoute.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavRoute.kt
@@ -36,7 +36,7 @@ public sealed interface ActivityRoute : Parcelable{
 
 /**
  * Represents the route to an `Activity` within the current app. The instance of this route
- * will be added to th resulting `Intent` and can be accessed in the launched `Activity` by calling
+ * will be added to the resulting `Intent` and can be accessed in the launched `Activity` by calling
  * [getRoute] or [requireRoute].
  */
 public abstract class InternalActivityRoute : ActivityRoute {

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavRoute.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavRoute.kt
@@ -40,7 +40,7 @@ public sealed interface ActivityRoute : Parcelable{
  * [getRoute] or [requireRoute].
  */
 public abstract class InternalActivityRoute : ActivityRoute {
-    override fun fillInIntent(): Intent {
+    final override fun fillInIntent(): Intent {
         return Intent().putExtra(EXTRA_ROUTE, this)
     }
 }
@@ -49,7 +49,11 @@ public abstract class InternalActivityRoute : ActivityRoute {
  * Represents the route to an `Activity` in another app. [fillInIntent] can be used to dynamically
  * add extras to the resulting `Intent`.
  */
-public interface ExternalActivityRoute : ActivityRoute
+public interface ExternalActivityRoute : ActivityRoute {
+    override fun fillInIntent(): Intent {
+        return Intent()
+    }
+}
 
 /**
  * Returns the [ActivityRoute] that was used to navigate to this [Activity].

--- a/navigator/runtime/src/test/java/com/freeletics/mad/navigator/NavEventNavigatorTest.kt
+++ b/navigator/runtime/src/test/java/com/freeletics/mad/navigator/NavEventNavigatorTest.kt
@@ -42,7 +42,7 @@ public class NavEventNavigatorTest {
     private class SimpleRoot(val number: Int) : NavRoot
     @Poko
     @Parcelize
-    private class SimpleActivity(val number: Int) : ActivityRoute
+    private class SimpleActivity(val number: Int) : InternalActivityRoute()
     @Poko
     @Parcelize
     private class TestParcelable(val value: Int) : Parcelable

--- a/navigator/runtime/src/test/java/com/freeletics/mad/navigator/NavEventNavigatorTest.kt
+++ b/navigator/runtime/src/test/java/com/freeletics/mad/navigator/NavEventNavigatorTest.kt
@@ -42,7 +42,7 @@ public class NavEventNavigatorTest {
     private class SimpleRoot(val number: Int) : NavRoot
     @Poko
     @Parcelize
-    private class SimpleActivity(val number: Int) : ActivityRoute, Parcelable
+    private class SimpleActivity(val number: Int) : ActivityRoute
     @Poko
     @Parcelize
     private class TestParcelable(val value: Int) : Parcelable


### PR DESCRIPTION
Currently it is not `Parcelable` because putting it into the `Intent` would crash any third party app launched by it. So consumers can make it Parcelable for internal use and then we will add it to the extras. The issue is that this makes deep links a lot more complex because we can't pass through the route and then handle it. With this `ActivityRoute` becomes `Parcelable` and the default implementation of `fillInIntent` will add it to the extras. Other places like the activity navigator don't need to deal with it anymore. When implementing route for external destinations users can override `fillInIntent` to prevent the route from being added and therefor avoid the crash.