### PR TITLE
share handling activity results, merge activity and permission handling

### DIFF
--- a/navigator/runtime/api/navigator-runtime.api
+++ b/navigator/runtime/api/navigator-runtime.api
@@ -1,4 +1,4 @@
-public final class com/freeletics/mad/navigator/ActivityResultRequest : com/freeletics/mad/navigator/ResultOwner {
+public final class com/freeletics/mad/navigator/ActivityResultRequest : com/freeletics/mad/navigator/ContractResultOwner {
 }
 
 public abstract interface class com/freeletics/mad/navigator/ActivityRoute {
@@ -14,6 +14,9 @@ public final class com/freeletics/mad/navigator/ActivityRoute$DefaultImpls {
 }
 
 public abstract interface class com/freeletics/mad/navigator/BaseRoute : android/os/Parcelable {
+}
+
+public abstract class com/freeletics/mad/navigator/ContractResultOwner : com/freeletics/mad/navigator/ResultOwner {
 }
 
 public class com/freeletics/mad/navigator/NavEventNavigator {
@@ -70,7 +73,8 @@ public final class com/freeletics/mad/navigator/NavigationResultRequest$Key$Crea
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/freeletics/mad/navigator/PermissionsResultRequest : com/freeletics/mad/navigator/ResultOwner {
+public final class com/freeletics/mad/navigator/PermissionsResultRequest : com/freeletics/mad/navigator/ContractResultOwner {
+	public synthetic fun getContract ()Landroidx/activity/result/contract/ActivityResultContract;
 }
 
 public abstract interface class com/freeletics/mad/navigator/PermissionsResultRequest$PermissionResult {

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEvent.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEvent.kt
@@ -76,18 +76,8 @@ public sealed interface NavEvent {
     @VisibleForTesting(otherwise = PACKAGE_PRIVATE)
     @Poko
     public class ActivityResultEvent<I>(
-        internal val request: ActivityResultRequest<I, *>,
+        internal val request: ContractResultOwner<I, *, *>,
         internal val input: I,
-    ) : NavEvent
-
-    /**
-     * Launches the [request] to retrieve an event.
-     */
-    @VisibleForTesting(otherwise = PACKAGE_PRIVATE)
-    @Poko
-    public class PermissionsResultEvent(
-        internal val request: PermissionsResultRequest,
-        internal val permissions: List<String>,
     ) : NavEvent
 
     /**

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
@@ -10,7 +10,6 @@ import com.freeletics.mad.navigator.NavEvent.BackEvent
 import com.freeletics.mad.navigator.NavEvent.BackToEvent
 import com.freeletics.mad.navigator.NavEvent.NavigateToActivityEvent
 import com.freeletics.mad.navigator.NavEvent.NavigateToEvent
-import com.freeletics.mad.navigator.NavEvent.PermissionsResultEvent
 import com.freeletics.mad.navigator.NavEvent.UpEvent
 import com.freeletics.mad.navigator.internal.DelegatingOnBackPressedCallback
 import com.freeletics.mad.navigator.internal.DestinationId
@@ -48,8 +47,7 @@ public open class NavEventNavigator {
         }
     }
 
-    private val _activityResultRequests = mutableListOf<ActivityResultRequest<*, *>>()
-    private val _permissionsResultRequests = mutableListOf<PermissionsResultRequest>()
+    private val _activityResultRequests = mutableListOf<ContractResultOwner<*, *, *>>()
     private val _navigationResultRequests = mutableListOf<NavigationResultRequest<*>>()
     private val _onBackPressedCallback = DelegatingOnBackPressedCallback()
 
@@ -92,7 +90,7 @@ public open class NavEventNavigator {
     protected fun registerForPermissionsResult(): PermissionsResultRequest {
         checkAllowedToAddRequests()
         val request = PermissionsResultRequest()
-        _permissionsResultRequests.add(request)
+        _activityResultRequests.add(request)
         return request
     }
 
@@ -228,7 +226,7 @@ public open class NavEventNavigator {
      * The [request] can be obtained by calling [registerForPermissionsResult].
      */
     public fun requestPermissions(request: PermissionsResultRequest, permissions: List<String>) {
-        val event = PermissionsResultEvent(request, permissions)
+        val event = ActivityResultEvent(request, permissions)
         sendNavEvent(event)
     }
 
@@ -285,17 +283,10 @@ public open class NavEventNavigator {
     }
 
     @InternalNavigatorApi
-    public val activityResultRequests: List<ActivityResultRequest<*, *>>
+    public val activityResultRequests: List<ContractResultOwner<*, *, *>>
         get() {
             allowedToAddRequests = false
             return _activityResultRequests.toList()
-        }
-
-    @InternalNavigatorApi
-    public val permissionsResultRequests: List<PermissionsResultRequest>
-        get() {
-            allowedToAddRequests = false
-            return _permissionsResultRequests.toList()
         }
 
     @InternalNavigatorApi

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/ResultOwner.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/ResultOwner.kt
@@ -1,6 +1,5 @@
 package com.freeletics.mad.navigator
 
-import android.content.Context
 import android.os.Parcel
 import android.os.Parcelable
 import androidx.activity.result.contract.ActivityResultContract
@@ -9,7 +8,7 @@ import androidx.annotation.VisibleForTesting.PACKAGE_PRIVATE
 import com.freeletics.mad.navigator.PermissionsResultRequest.PermissionResult
 import com.freeletics.mad.navigator.internal.DestinationId
 import com.freeletics.mad.navigator.internal.InternalNavigatorApi
-import com.freeletics.mad.navigator.internal.RequestPermissionsContract.Companion.enrichResult
+import com.freeletics.mad.navigator.internal.RequestPermissionsContract
 import dev.drewhamilton.poko.Poko
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.trySendBlocking
@@ -46,6 +45,11 @@ public sealed class ResultOwner<R> {
     }
 }
 
+public sealed class ContractResultOwner<I, O, R> : ResultOwner<R>() {
+    @InternalNavigatorApi
+    public abstract val contract: ActivityResultContract<I, O>
+}
+
 /**
  * Class returned from [NavEventNavigator.registerForActivityResult].
  *
@@ -55,20 +59,14 @@ public sealed class ResultOwner<R> {
  *    request
  */
 public class ActivityResultRequest<I, O> internal constructor(
-    @property:InternalNavigatorApi public val contract: ActivityResultContract<I, O>,
-) : ResultOwner<O>() {
-
-    @InternalNavigatorApi
-    public fun handleResult(result: O) {
-        onResult(result)
-    }
-}
+    @property:InternalNavigatorApi override val contract: ActivityResultContract<I, O>,
+) : ContractResultOwner<I, O, O>()
 
 /**
  * Class returned from [NavEventNavigator.registerForPermissionsResult].
  *
  * This class has two purposes:
- *  - It exposes a [results] `Flow` that can be used to observe incoming permission results
+ *  - It exposes a `results` `Flow` that can be used to observe incoming permission results
  *  - It can be passed to [NavEventNavigator.requestPermissions] to trigger the execution of a
  *    permissions request
  *
@@ -78,13 +76,10 @@ public class ActivityResultRequest<I, O> internal constructor(
  *  about the whether a permission rationale should be shown.
  */
 public class PermissionsResultRequest internal constructor() :
-    ResultOwner<Map<String, PermissionResult>>() {
+    ContractResultOwner<List<String>, Map<String, Boolean>, Map<String, PermissionResult>>() {
 
-    @InternalNavigatorApi
-    public fun handleResult(resultMap: Map<String, Boolean>, context: Context) {
-        val result = enrichResult(context, resultMap)
-        onResult(result)
-    }
+    @property:InternalNavigatorApi
+    override val contract: RequestPermissionsContract = RequestPermissionsContract()
 
     /**
      * The status of the requested permission.

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/NavigationSetup.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/NavigationSetup.kt
@@ -1,15 +1,18 @@
 package com.freeletics.mad.navigator.internal
 
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.os.Parcelable
 import androidx.activity.result.ActivityResultLauncher
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import com.freeletics.mad.navigator.ActivityResultRequest
+import com.freeletics.mad.navigator.ContractResultOwner
 import com.freeletics.mad.navigator.NavEvent
 import com.freeletics.mad.navigator.NavEventNavigator
 import com.freeletics.mad.navigator.NavigationResultRequest
 import com.freeletics.mad.navigator.PermissionsResultRequest
+import com.freeletics.mad.navigator.internal.RequestPermissionsContract.Companion.enrichResult
 import kotlinx.parcelize.Parcelize
 
 @SuppressLint("VisibleForTests") // VisibleForTests(otherwise = INTERNAL) does not exist
@@ -17,19 +20,17 @@ import kotlinx.parcelize.Parcelize
 public suspend fun NavEventNavigator.collectAndHandleNavEvents(
     lifecycle: Lifecycle,
     executor: NavigationExecutor,
-    activityLaunchers: Map<ActivityResultRequest<*, *>, ActivityResultLauncher<*>>,
-    permissionLaunchers: Map<PermissionsResultRequest, ActivityResultLauncher<List<String>>>
+    activityLaunchers: Map<ContractResultOwner<*, *, *>, ActivityResultLauncher<*>>,
 ) {
     navEvents.flowWithLifecycle(lifecycle, minActiveState = Lifecycle.State.RESUMED)
         .collect { event ->
-            executor.navigate(event, activityLaunchers, permissionLaunchers)
+            executor.navigate(event, activityLaunchers)
         }
 }
 
 private fun NavigationExecutor.navigate(
     event: NavEvent,
-    activityLaunchers: Map<ActivityResultRequest<*, *>, ActivityResultLauncher<*>>,
-    permissionLaunchers: Map<PermissionsResultRequest, ActivityResultLauncher<List<String>>>
+    activityLaunchers: Map<ContractResultOwner<*, *, *>, ActivityResultLauncher<*>>,
 ) {
     when (event) {
         is NavEvent.NavigateToEvent -> {
@@ -54,23 +55,24 @@ private fun NavigationExecutor.navigate(
             val request = event.request
             val launcher = activityLaunchers[request] ?: throw IllegalStateException(
                 "No launcher registered for $request!\nMake sure you called the appropriate " +
-                    "AbstractNavigator.registerFor... method"
+                    "NavEventNavigator.registerFor... method"
             )
             @Suppress("UNCHECKED_CAST")
             (launcher as ActivityResultLauncher<Any?>).launch(event.input)
         }
-        is NavEvent.PermissionsResultEvent -> {
-            val request = event.request
-            val launcher = permissionLaunchers[request] ?: throw IllegalStateException(
-                "No launcher registered for $request!\nMake sure you called the appropriate " +
-                    "AbstractNavigator.registerFor... method"
-            )
-            @Suppress("UNCHECKED_CAST")
-            (launcher as ActivityResultLauncher<Any?>).launch(event.permissions)
-        }
         is NavEvent.DestinationResultEvent<*> -> {
             savedStateHandleFor(event.key.destinationId)[event.key.requestKey] = event.result
         }
+    }
+}
+
+@InternalNavigatorApi
+@SuppressLint("VisibleForTests") // VisibleForTests(otherwise = INTERNAL) does not exist
+@Suppress("UNCHECKED_CAST")
+public fun <I, O, R> ContractResultOwner<I, O, R>.deliverResult(activity: Activity, result: O) {
+    when(this) {
+        is ActivityResultRequest<*, *> -> onResult(result as R)
+        is PermissionsResultRequest -> onResult(enrichResult(activity, result as Map<String, Boolean>))
     }
 }
 

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/RequestPermissionsContract.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/RequestPermissionsContract.kt
@@ -2,11 +2,11 @@ package com.freeletics.mad.navigator.internal
 
 import android.app.Activity
 import android.content.Context
-import android.content.ContextWrapper
 import android.content.Intent
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.app.ActivityCompat.shouldShowRequestPermissionRationale as shouldShowRationale
+import android.annotation.SuppressLint
 import com.freeletics.mad.navigator.PermissionsResultRequest.PermissionResult
 
 /**
@@ -37,11 +37,11 @@ public class RequestPermissionsContract :
     }
 
     internal companion object {
+        @SuppressLint("VisibleForTests") // VisibleForTests(otherwise = INTERNAL) does not exist
         internal fun enrichResult(
-            context: Context,
+            activity: Activity,
             resultMap: Map<String, Boolean>
         ): Map<String, PermissionResult> {
-            val activity = context.findActivity()
             return resultMap.mapValues { (permission, granted) ->
                 if (granted) {
                     PermissionResult.Granted
@@ -49,15 +49,6 @@ public class RequestPermissionsContract :
                     PermissionResult.Denied(shouldShowRationale(activity, permission))
                 }
             }
-        }
-
-        private fun Context.findActivity(): Activity {
-            var context = this
-            while (context is ContextWrapper) {
-                if (context is Activity) return context
-                context = context.baseContext
-            }
-            throw IllegalStateException("Permissions should be requested in the context of an Activity")
         }
     }
 }

--- a/navigator/runtime/src/test/java/com/freeletics/mad/navigator/NavEventNavigatorTest.kt
+++ b/navigator/runtime/src/test/java/com/freeletics/mad/navigator/NavEventNavigatorTest.kt
@@ -175,7 +175,7 @@ public class NavEventNavigatorTest {
             val permission = "android.permission.READ_CALENDAR"
             navigator.requestPermissions(launcher, permission)
 
-            assertThat(awaitItem()).isEqualTo(NavEvent.PermissionsResultEvent(launcher, listOf(permission)))
+            assertThat(awaitItem()).isEqualTo(NavEvent.ActivityResultEvent(launcher, listOf(permission)))
 
             cancel()
         }
@@ -237,7 +237,7 @@ public class NavEventNavigatorTest {
     public fun `registerForPermissionsResult after read is disallowed`(): Unit = runBlocking {
         val navigator = TestNavigator()
 
-        navigator. permissionsResultRequests
+        navigator.activityResultRequests
 
         val exception = assertThrows(IllegalStateException::class.java) {
             navigator.testRegisterForPermissionResult()


### PR DESCRIPTION
Instead if treating permission requests and activity results completely separately this introduces an intermediate `ContractResultOwner` interface for both of their result owners to allow us to handle them in the same way. Both use activity result contracts, the only difference is that the permission results get processed a bit before being passed on. With this change the whole registration and waiting for results part is merged internally. The public API stays separate.