### PR TITLE
don't use * for inline class parameters

### DIFF
--- a/navigator/androidx-nav/src/main/java/com/freeletics/mad/navigator/internal/AndroidXNavigationExecutor.kt
+++ b/navigator/androidx-nav/src/main/java/com/freeletics/mad/navigator/internal/AndroidXNavigationExecutor.kt
@@ -50,11 +50,11 @@ public class AndroidXNavigationExecutor(
         savedStateHandleFor(key.destinationId)[key.requestKey] = result
     }
 
-    override fun navigateBackTo(destinationId: DestinationId<*>, isInclusive: Boolean) {
+    override fun <T : BaseRoute> navigateBackTo(destinationId: DestinationId<T>, isInclusive: Boolean) {
         controller.popBackStack(destinationId.destinationId(), isInclusive)
     }
 
-    override fun savedStateHandleFor(destinationId: DestinationId<*>): SavedStateHandle {
+    override fun <T : BaseRoute> savedStateHandleFor(destinationId: DestinationId<T>): SavedStateHandle {
         return entryFor(destinationId).savedStateHandle
     }
 
@@ -62,7 +62,7 @@ public class AndroidXNavigationExecutor(
         return entryFor(destinationId).arguments.requireRoute()
     }
 
-    override fun viewModelStoreFor(destinationId: DestinationId<*>): ViewModelStore {
+    override fun <T : BaseRoute> viewModelStoreFor(destinationId: DestinationId<T>): ViewModelStore {
         return entryFor(destinationId).viewModelStore
     }
 

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
@@ -112,8 +112,8 @@ public open class NavEventNavigator {
     }
 
     @PublishedApi
-    internal fun <O : Parcelable> registerForNavigationResult(
-        id: DestinationId<*>,
+    internal fun <T : BaseRoute, O : Parcelable> registerForNavigationResult(
+        id: DestinationId<T>,
         resultType: String
     ): NavigationResultRequest<O> {
         checkAllowedToAddRequests()
@@ -178,7 +178,7 @@ public open class NavEventNavigator {
     }
 
     @PublishedApi
-    internal fun navigateBackTo(popUpTo: DestinationId<*>, inclusive: Boolean = false) {
+    internal fun <T: BaseRoute> navigateBackTo(popUpTo: DestinationId<T>, inclusive: Boolean = false) {
         val event = BackToEvent(popUpTo, inclusive)
         sendNavEvent(event)
     }

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/NavigationExecutor.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/NavigationExecutor.kt
@@ -16,9 +16,9 @@ public interface NavigationExecutor {
     public fun navigate(route: ActivityRoute)
     public fun navigateUp()
     public fun navigateBack()
-    public fun navigateBackTo(destinationId: DestinationId<*>, isInclusive: Boolean)
+    public fun <T : BaseRoute> navigateBackTo(destinationId: DestinationId<T>, isInclusive: Boolean)
     public fun deliverResult(key: NavigationResultRequest.Key<*>, result: Parcelable)
     public fun <T : BaseRoute> routeFor(destinationId: DestinationId<T>): T
-    public fun savedStateHandleFor(destinationId: DestinationId<*>): SavedStateHandle
-    public fun viewModelStoreFor(destinationId: DestinationId<*>): ViewModelStore
+    public fun <T : BaseRoute> savedStateHandleFor(destinationId: DestinationId<T>): SavedStateHandle
+    public fun <T : BaseRoute> viewModelStoreFor(destinationId: DestinationId<T>): ViewModelStore
 }


### PR DESCRIPTION
Fixes a javac error that happens when kapt runs over a class that extends NavEventNavigator
```
/Users/gabriel/freeletics/feature/debug-panel/src/debug/java/com/freeletics/feature/debugpanel/DebugPanelNavigator.kt:7: error: cannot access NavEventNavigator
  bad class file: /Users/gabriel/.gradle/caches/transforms-3/0c0cf4c7f07ccc37490f57e5e3562fba/transformed/navigator-0.10.0-prep-SNAPSHOT-api.jar(/com/freeletics/mad/navigator/NavEventNavigator.class)
    undeclared type variable: T
    Please remove or make sure it appears in the correct subdirectory of the classpath.
```
```
Caused by: org.jetbrains.kotlin.kapt3.base.util.KaptBaseError: Error while annotation processing
        at org.jetbrains.kotlin.kapt3.base.AnnotationProcessingKt.doAnnotationProcessing(annotationProcessing.kt:132)
        at org.jetbrains.kotlin.kapt3.base.AnnotationProcessingKt.doAnnotationProcessing$default(annotationProcessing.kt:31)
        at org.jetbrains.kotlin.kapt3.base.Kapt.kapt(Kapt.kt:47)
        ... 34 more
```