### PR TITLE
fix deep links that contain ActivityRoutes

### DIFF
--- a/navigator/androidx-nav/src/main/java/com/freeletics/mad/navigator/internal/AndroidXDeepLinkHandler.kt
+++ b/navigator/androidx-nav/src/main/java/com/freeletics/mad/navigator/internal/AndroidXDeepLinkHandler.kt
@@ -3,9 +3,11 @@ package com.freeletics.mad.navigator.internal
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
+import android.os.Parcelable
 import androidx.navigation.NavController.Companion.KEY_DEEP_LINK_ARGS
 import androidx.navigation.NavController.Companion.KEY_DEEP_LINK_IDS
 import com.eygraber.uri.Uri
+import com.freeletics.mad.navigator.ActivityRoute
 import com.freeletics.mad.navigator.BaseRoute
 import com.freeletics.mad.navigator.DeepLink
 import com.freeletics.mad.navigator.DeepLink.Companion.EXTRA_DEEPLINK_ROUTES
@@ -45,7 +47,7 @@ public fun Activity.handleDeepLink(
 
 private fun Intent.setNavDeepLinkExtras() {
     @Suppress("DEPRECATION")
-    val routes = getParcelableArrayListExtra<BaseRoute>(EXTRA_DEEPLINK_ROUTES)
+    val routes = getParcelableArrayListExtra<Parcelable>(EXTRA_DEEPLINK_ROUTES)
     if (routes != null) {
         val extra = 1
         val deepLinkIds = IntArray(routes.size + extra)
@@ -55,8 +57,15 @@ private fun Intent.setNavDeepLinkExtras() {
         deepLinkArgs.add(Bundle.EMPTY)
 
         routes.forEachIndexed { index, route ->
-            deepLinkIds[index + 1] = route.destinationId()
-            deepLinkArgs.add(route.getArguments())
+            if (route is BaseRoute) {
+                deepLinkIds[index + 1] = route.destinationId()
+                deepLinkArgs.add(route.getArguments())
+            } else if (route is ActivityRoute) {
+                deepLinkIds[index + 1] = route.destinationId()
+                deepLinkArgs.add(route.getArguments())
+            } else {
+                throw IllegalArgumentException("Unknown type of route $route")
+            }
         }
 
         putExtra(KEY_DEEP_LINK_IDS, deepLinkIds)


### PR DESCRIPTION
The code was only expecting `BaseRoute` but it can bei either `ActivityRoute` or `BaseRoute`.