### PR TITLE
Optin on `ExperimentalMaterialNavigationApi`

### DIFF
--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavDestination.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavDestination.kt
@@ -7,7 +7,6 @@ import com.freeletics.mad.navigator.BaseRoute
 import com.freeletics.mad.navigator.NavRoute
 import com.freeletics.mad.navigator.internal.ActivityDestinationId
 import com.freeletics.mad.navigator.internal.DestinationId
-import com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi
 
 /**
  * A destination that can be navigated to. See [NavHost] for how to configure a `NavGraph` with it.
@@ -52,13 +51,11 @@ internal class DialogDestination<T : NavRoute>(
  * when navigating to it by using an instance of [T].
  */
 @Suppress("FunctionName")
-@ExperimentalMaterialNavigationApi
 public inline fun <reified T : NavRoute> BottomSheetDestination(
     noinline bottomSheetContent: @Composable (T) -> Unit,
 ): NavDestination = BottomSheetDestination(DestinationId(T::class), bottomSheetContent)
 
 @PublishedApi
-@ExperimentalMaterialNavigationApi
 internal class BottomSheetDestination<T : NavRoute>(
     internal val id: DestinationId<T>,
     internal val bottomSheetContent: @Composable (T) -> Unit,

--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavHost.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavHost.kt
@@ -55,7 +55,7 @@ import com.google.accompanist.navigation.material.rememberBottomSheetNavigator
  * The [destinationChangedCallback] can be used to be notified when the current destination
  * changes. Note that this will not be invoked when navigating to a [ActivityDestination].
  */
-@ExperimentalMaterialNavigationApi
+@OptIn(ExperimentalMaterialNavigationApi::class)
 @Composable
 public fun NavHost(
     startRoute: BaseRoute,


### PR DESCRIPTION
Optin on `ExperimentalMaterialNavigationApi` to not expose internal usage of accompanist material navigation API.