### PR TITLE
run Anvil in all codegen tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,8 +79,10 @@ dependencyAnalysis {
             onUnusedDependencies {
                 // needed for compile testing
                 exclude(
-                    "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
+                    "androidx.compose.runtime:runtime",
+                    "com.gabrielittner.renderer:renderer",
                     "com.gabrielittner.renderer:connect",
+                    "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
                     "org.jetbrains.kotlin:kotlin-compiler-embeddable",
                     ":navigator:navigator-runtime-compose",
                     ":navigator:navigator-runtime-fragment",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -77,9 +77,10 @@ uri = { module = "com.eygraber:uri-kmp-android", version.ref = "uri" }
 
 inject = { module = "javax.inject:javax.inject", version.ref = "inject" }
 dagger = { module = "com.google.dagger:dagger", version.ref = "dagger" }
-anvil-compiler = { module = "com.squareup.anvil:compiler-api", version.ref = "anvil" }
 anvil-annotations = { module = "com.squareup.anvil:annotations", version.ref = "anvil" }
-anvil-utils = { module = "com.squareup.anvil:compiler-utils", version.ref = "anvil" }
+anvil-compiler = { module = "com.squareup.anvil:compiler", version.ref = "anvil" }
+anvil-compiler-api = { module = "com.squareup.anvil:compiler-api", version.ref = "anvil" }
+anvil-compiler-utils = { module = "com.squareup.anvil:compiler-utils", version.ref = "anvil" }
 renderer = { module = "com.gabrielittner.renderer:renderer", version.ref = "renderer" }
 renderer-connect = { module = "com.gabrielittner.renderer:connect", version.ref = "renderer" }
 kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinpoet" }

--- a/whetstone/compiler-test/build.gradle
+++ b/whetstone/compiler-test/build.gradle
@@ -63,6 +63,7 @@ dependencies {
     testImplementation libs.truth
     testImplementation libs.kotlin.compile.testing
     testImplementation libs.androidx.compose.compiler
+    testImplementation libs.anvil.compiler
     testImplementation(libs.kotlin.compiler) { force = true }
 }
 
@@ -71,4 +72,3 @@ configurations.all {
         substitute module("com.freeletics.mad:state-machine") using project(":state-machine")
     }
 }
-

--- a/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
+++ b/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
@@ -35,6 +35,25 @@ internal class FileGeneratorTestCompose {
 
     @Test
     fun `generates code for ComposeScreenData`() {
+        val source = """
+            package com.test
+            
+            import androidx.compose.runtime.Composable
+            import com.freeletics.mad.whetstone.compose.ComposeScreen
+            import com.test.parent.TestParentScope
+            
+            @ComposeScreen(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+              stateMachine = TestStateMachine::class,
+            )
+            @Composable
+            public fun Test(
+              state: TestState,
+              sendAction: (TestAction) -> Unit
+            ) {}
+        """.trimIndent()
+
         val expected = """
             package com.test
 
@@ -122,12 +141,39 @@ internal class FileGeneratorTestCompose {
             
         """.trimIndent()
 
-        test(data, expected)
+        test(data, "com/test/Test.kt", source, expected)
     }
 
     @Test
     fun `generates code for ComposeScreenData with navigation`() {
         val withNavigation = data.copy(navigation = navigation)
+
+        val source = """
+            package com.test
+            
+            import androidx.compose.runtime.Composable
+            import com.freeletics.mad.whetstone.compose.ComposeScreen
+            import com.freeletics.mad.whetstone.compose.DestinationType
+            import com.freeletics.mad.whetstone.compose.NavDestination
+            import com.test.destination.TestDestinationScope
+            import com.test.parent.TestParentScope
+            
+            @ComposeScreen(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+              stateMachine = TestStateMachine::class,
+            )
+            @NavDestination(            
+              route = TestRoute::class,
+              type = DestinationType.SCREEN,
+              destinationScope = TestDestinationScope::class,
+            )
+            @Composable
+            public fun Test(
+              state: TestState,
+              sendAction: (TestAction) -> Unit
+            ) {}
+        """.trimIndent()
 
         val expected = """
             package com.test
@@ -236,7 +282,7 @@ internal class FileGeneratorTestCompose {
             
         """.trimIndent()
 
-        test(withNavigation, expected)
+        test(withNavigation, "com/test/Test.kt", source, expected)
     }
 
     @Test
@@ -245,6 +291,38 @@ internal class FileGeneratorTestCompose {
             navigation = navigation,
             navEntryData = navEntryData
         )
+
+        val source = """
+            package com.test
+            
+            import androidx.compose.runtime.Composable
+            import com.freeletics.mad.whetstone.compose.ComposeScreen
+            import com.freeletics.mad.whetstone.compose.DestinationType
+            import com.freeletics.mad.whetstone.compose.NavDestination
+            import com.freeletics.mad.whetstone.NavEntryComponent
+            import com.test.destination.TestDestinationScope
+            import com.test.parent.TestParentScope
+            
+            @ComposeScreen(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+              stateMachine = TestStateMachine::class,
+            )
+            @NavDestination(            
+              route = TestRoute::class,
+              type = DestinationType.SCREEN,
+              destinationScope = TestDestinationScope::class,
+            )
+            @NavEntryComponent(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+            )
+            @Composable
+            public fun Test(
+              state: TestState,
+              sendAction: (TestAction) -> Unit
+            ) {}
+        """.trimIndent()
 
         val expected = """
             package com.test
@@ -422,7 +500,7 @@ internal class FileGeneratorTestCompose {
 
         """.trimIndent()
 
-        test(withNavEntry, expected)
+        test(withNavEntry, "com/test/Test.kt", source, expected)
     }
 
     @Test
@@ -440,6 +518,28 @@ internal class FileGeneratorTestCompose {
                 )
             )
         )
+
+        val source = """
+            package com.test
+            
+            import androidx.compose.runtime.Composable
+            import com.freeletics.mad.whetstone.compose.ComposeScreen
+            import com.test.other.TestClass2
+            import com.test.parent.TestParentScope
+            
+            @ComposeScreen(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+              stateMachine = TestStateMachine::class,
+            )
+            @Composable
+            public fun Test2(
+                state: TestState,
+                sendAction: (TestAction) -> Unit,
+                testClass: TestClass,
+                test: TestClass2,
+            ) {}
+        """.trimIndent()
 
         val expected = """
             package com.test
@@ -537,6 +637,6 @@ internal class FileGeneratorTestCompose {
             
         """.trimIndent()
 
-        test(withInjectedParameters, expected)
+        test(withInjectedParameters, "com/test/Test2.kt", source, expected)
     }
 }

--- a/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
+++ b/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
@@ -36,6 +36,24 @@ internal class FileGeneratorTestComposeFragment {
 
     @Test
     fun `generates code for ComposeFragmentData`() {
+        val source = """
+            package com.test
+            
+            import androidx.compose.runtime.Composable
+            import com.freeletics.mad.whetstone.fragment.ComposeFragment
+            import com.test.parent.TestParentScope
+            
+            @ComposeFragment(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+              stateMachine = TestStateMachine::class,
+            )
+            @Composable
+            public fun Test(
+              state: TestState,
+              sendAction: (TestAction) -> Unit
+            ) {}
+        """.trimIndent()
 
         val expected = """
             package com.test
@@ -146,12 +164,39 @@ internal class FileGeneratorTestComposeFragment {
             
         """.trimIndent()
 
-        test(data, expected)
+        test(data, "com/test/Test.kt", source, expected)
     }
 
     @Test
     fun `generates code for ComposeFragmentData with navigation`() {
         val withNavigation = data.copy(navigation = navigation)
+
+        val source = """
+            package com.test
+            
+            import androidx.compose.runtime.Composable
+            import com.freeletics.mad.whetstone.fragment.ComposeFragment
+            import com.freeletics.mad.whetstone.fragment.DestinationType
+            import com.freeletics.mad.whetstone.fragment.NavDestination
+            import com.test.destination.TestDestinationScope
+            import com.test.parent.TestParentScope
+            
+            @ComposeFragment(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+              stateMachine = TestStateMachine::class,
+            )
+            @NavDestination(            
+              route = TestRoute::class,
+              type = DestinationType.SCREEN,
+              destinationScope = TestDestinationScope::class,
+            )
+            @Composable
+            public fun Test(
+              state: TestState,
+              sendAction: (TestAction) -> Unit
+            ) {}
+        """.trimIndent()
 
         val expected = """
             package com.test
@@ -284,7 +329,7 @@ internal class FileGeneratorTestComposeFragment {
             
         """.trimIndent()
 
-        test(withNavigation, expected)
+        test(withNavigation, "com/test/Test.kt", source, expected)
     }
 
     @Test
@@ -293,6 +338,38 @@ internal class FileGeneratorTestComposeFragment {
             navigation = navigation,
             navEntryData = navEntryData
         )
+
+        val source = """
+            package com.test
+            
+            import androidx.compose.runtime.Composable
+            import com.freeletics.mad.whetstone.fragment.ComposeFragment
+            import com.freeletics.mad.whetstone.fragment.DestinationType
+            import com.freeletics.mad.whetstone.fragment.NavDestination
+            import com.freeletics.mad.whetstone.NavEntryComponent
+            import com.test.destination.TestDestinationScope
+            import com.test.parent.TestParentScope
+            
+            @ComposeFragment(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+              stateMachine = TestStateMachine::class,
+            )
+            @NavDestination(            
+              route = TestRoute::class,
+              type = DestinationType.SCREEN,
+              destinationScope = TestDestinationScope::class,
+            )
+            @NavEntryComponent(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+            )
+            @Composable
+            public fun Test(
+              state: TestState,
+              sendAction: (TestAction) -> Unit
+            ) {}
+        """.trimIndent()
 
         val expected = """
             package com.test
@@ -494,7 +571,7 @@ internal class FileGeneratorTestComposeFragment {
 
         """.trimIndent()
 
-        test(withNavEntry, expected)
+        test(withNavEntry, "com/test/Test.kt", source, expected)
     }
 
     @Test
@@ -502,6 +579,27 @@ internal class FileGeneratorTestComposeFragment {
         val dialogFragment = data.copy(
             fragmentBaseClass = ClassName("androidx.fragment.app", "DialogFragment")
         )
+
+        val source = """
+            package com.test
+            
+            import androidx.compose.runtime.Composable
+            import androidx.fragment.app.DialogFragment
+            import com.freeletics.mad.whetstone.fragment.ComposeFragment
+            import com.test.parent.TestParentScope
+            
+            @ComposeFragment(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+              stateMachine = TestStateMachine::class,
+              fragmentBaseClass = DialogFragment::class,
+            )
+            @Composable
+            public fun Test(
+              state: TestState,
+              sendAction: (TestAction) -> Unit
+            ) {}
+        """.trimIndent()
 
         val expected = """
             package com.test
@@ -612,7 +710,7 @@ internal class FileGeneratorTestComposeFragment {
 
         """.trimIndent()
 
-        test(dialogFragment, expected)
+        test(dialogFragment, "com/test/Test.kt", source, expected)
     }
 
     @Test
@@ -630,6 +728,28 @@ internal class FileGeneratorTestComposeFragment {
                 )
             )
         )
+
+        val source = """
+            package com.test
+            
+            import androidx.compose.runtime.Composable
+            import com.freeletics.mad.whetstone.fragment.ComposeFragment
+            import com.test.other.TestClass2
+            import com.test.parent.TestParentScope
+            
+            @ComposeFragment(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+              stateMachine = TestStateMachine::class,
+            )
+            @Composable
+            public fun Test2(
+              state: TestState,
+              sendAction: (TestAction) -> Unit,
+                testClass: TestClass,
+                test: TestClass2,
+            ) {}
+        """.trimIndent()
 
         val expected = """
             package com.test
@@ -749,6 +869,6 @@ internal class FileGeneratorTestComposeFragment {
             
         """.trimIndent()
 
-        test(withInjectedParameters, expected)
+        test(withInjectedParameters, "com/test/Test2.kt", source, expected)
     }
 }

--- a/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/TestHelper.kt
+++ b/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/TestHelper.kt
@@ -5,39 +5,117 @@ import com.freeletics.mad.whetstone.ComposeFragmentData
 import com.freeletics.mad.whetstone.ComposeScreenData
 import com.freeletics.mad.whetstone.RendererFragmentData
 import com.google.common.truth.Truth.assertThat
+import com.squareup.anvil.compiler.AnvilCommandLineProcessor
+import com.squareup.anvil.compiler.AnvilComponentRegistrar
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
+import com.tschuchort.compiletesting.PluginOption
 import com.tschuchort.compiletesting.SourceFile
+import java.io.File
+import java.nio.file.Files
 
-public fun test(data: ComposeScreenData, expected: String) {
+public fun test(data: ComposeScreenData, fileName: String, source: String, expected: String) {
     val actual = FileGenerator().generate(data).toString()
     assertThat(actual).isEqualTo(expected)
-    compile(actual)
+    compile(fileName, source, actual)
+    compileWithAnvil(fileName, source, actual)
 }
 
-public fun test(data: ComposeFragmentData, expected: String) {
+public fun test(data: ComposeFragmentData, fileName: String, source: String, expected: String) {
     val actual = FileGenerator().generate(data).toString()
     assertThat(actual).isEqualTo(expected)
-    compile(actual)
+    compile(fileName, source, actual)
+    compileWithAnvil(fileName, source, actual)
 }
 
-public fun test(data: RendererFragmentData, expected: String) {
+public fun test(data: RendererFragmentData, fileName: String, source: String, expected: String) {
     val actual = FileGenerator().generate(data).toString()
     assertThat(actual).isEqualTo(expected)
-    compile(actual)
+    compile(fileName, source, actual)
+    compileWithAnvil(fileName, source, actual)
 }
 
-private fun compile(source: String) {
-    val result = KotlinCompilation().apply {
-        sources = listOf(SourceFile.kotlin("WhetstoneTest.kt", source))
-        compilerPlugins = listOf(ComposeComponentRegistrar())
-        kotlincArguments = listOf(
-            "-P",
-            "plugin:androidx.compose.compiler.plugins.kotlin:suppressKotlinVersionCompatibilityCheck=1.7.22"
+private fun compile(fileName: String, source: String, output: String) {
+    val compilation = KotlinCompilation().apply {
+        configure()
+
+        sources = listOf(
+            sourceFile(fileName, source),
+            sourceFile(fileName.testFileName(), output),
         )
-        jvmTarget = "11"
-        inheritClassPath = true
-        messageOutputStream = System.out // see diagnostics in real time
-    }.compile()
-    assertThat(result.exitCode).isEqualTo(ExitCode.OK)
+    }
+
+    assertThat(compilation.compile().exitCode).isEqualTo(ExitCode.OK)
+}
+
+private fun compileWithAnvil(fileName: String, source: String, output: String) {
+    val compilation = KotlinCompilation().apply {
+        configure()
+        configureAnvil()
+
+        sources = listOf(
+            sourceFile(fileName, source),
+        )
+    }
+
+    assertThat(compilation.compile().exitCode).isEqualTo(ExitCode.OK)
+    assertThat(compilation.generatedFile(fileName)).isEqualTo(output)
+}
+
+private fun KotlinCompilation.sourceFile(name: String, content: String): SourceFile {
+    val path = "${workingDir.absolutePath}/sources/src/main/kotlin/$name"
+    Files.createDirectories(File(path).parentFile!!.toPath())
+    return SourceFile.kotlin(path, content)
+}
+
+private fun KotlinCompilation.generatedFile(name: String): String {
+    val path = "${workingDir.absolutePath}/build/anvil/${name.testFileName()}"
+    return File(path).readText()
+}
+
+private fun String.testFileName(): String {
+    val path = substringBeforeLast("/")
+    val name = substringAfterLast("/")
+    return "$path/Whetstone$name"
+}
+
+private fun KotlinCompilation.configure() {
+    compilerPlugins = compilerPlugins + listOf(ComposeComponentRegistrar())
+    kotlincArguments = kotlincArguments + listOf(
+        "-P",
+        "plugin:androidx.compose.compiler.plugins.kotlin:suppressKotlinVersionCompatibilityCheck=1.7.22"
+    )
+    jvmTarget = "11"
+    inheritClassPath = true
+    messageOutputStream = System.out // see diagnostics in real time
+}
+
+private fun KotlinCompilation.configureAnvil() {
+    compilerPlugins = compilerPlugins + listOf(AnvilComponentRegistrar())
+
+    val anvilCommandLineProcessor = AnvilCommandLineProcessor()
+    commandLineProcessors = listOf(anvilCommandLineProcessor)
+
+    pluginOptions = listOf(
+        PluginOption(
+            pluginId = anvilCommandLineProcessor.pluginId,
+            optionName = "src-gen-dir",
+            optionValue = File(workingDir, "build/anvil").absolutePath
+        ),
+        PluginOption(
+            pluginId = anvilCommandLineProcessor.pluginId,
+            optionName = "generate-dagger-factories",
+            optionValue = "false"
+        ),
+        PluginOption(
+            pluginId = anvilCommandLineProcessor.pluginId,
+            optionName = "generate-dagger-factories-only",
+            optionValue = "false"
+        ),
+        PluginOption(
+            pluginId = anvilCommandLineProcessor.pluginId,
+            optionName = "disable-component-merging",
+            optionValue = "false"
+        )
+    )
 }

--- a/whetstone/compiler-test/src/test/kotlin/com/test/TestFixtures.kt
+++ b/whetstone/compiler-test/src/test/kotlin/com/test/TestFixtures.kt
@@ -2,12 +2,9 @@ package com.test
 
 import android.os.Parcel
 import android.view.View
-import androidx.compose.runtime.Composable
 import androidx.viewbinding.ViewBinding
 import com.freeletics.mad.navigator.NavRoute
 import com.freeletics.mad.statemachine.StateMachine
-import com.gabrielittner.renderer.ViewRenderer
-import com.test.other.TestClass2
 import kotlinx.coroutines.flow.Flow
 
 public class TestScreen
@@ -18,30 +15,8 @@ public class TestRoute : NavRoute {
     override fun writeToParcel(p0: Parcel, p1: Int) {}
 }
 
-@Suppress("UNUSED_PARAMETER")
-@Composable
-public fun Test(
-    state: TestState,
-    sendAction: (TestAction) -> Unit
-) {}
-
-@Suppress("UNUSED_PARAMETER")
-@Composable
-public fun Test2(
-    testClass: TestClass,
-    test: TestClass2,
-    state: TestState,
-    sendAction: (TestAction) -> Unit
-) {}
-
 public class TestBinding : ViewBinding {
     override fun getRoot(): View = throw UnsupportedOperationException("Not implemented")
-}
-
-public class TestRenderer(view: View) : ViewRenderer<TestState, TestAction>(view) {
-    override fun renderToView(state: TestState) {}
-
-    public abstract class Factory : ViewRenderer.Factory<TestBinding, TestRenderer>({ _, _, _ -> TestBinding() })
 }
 
 public class TestStateMachine : StateMachine<TestState, TestAction> {

--- a/whetstone/compiler/build.gradle
+++ b/whetstone/compiler/build.gradle
@@ -14,10 +14,10 @@ kotlin {
 
 dependencies {
     api libs.kotlin.compiler
-    api libs.anvil.compiler
+    api libs.anvil.compiler.api
     api libs.kotlinpoet
     implementation libs.anvil.annotations
-    implementation libs.anvil.utils
+    implementation libs.anvil.compiler.utils
 
     compileOnly libs.auto.service.annotations
     kapt libs.auto.service.compiler


### PR DESCRIPTION
Builds on top of #280 so that there are less tests to update. With this each test defines a source file that matches the data that we define for that tests. This source file replaces the fixture classes we had before and we will do an additional check by running a Kotlin compilation with Anvil over it and also check the output of that. We can probably remove the manual `FileGenerator` invocation and data objects as a follow up but not 100% sure yet. 

The renderer tests have a few more changes because the `baseName` there was `Test` and not `TestRenderer` but the renderer was stilled called `TestRenderer`. 

Closes #249