### PR TITLE
add testing artifact for navigator

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -60,6 +60,7 @@ jobs:
           sed -i 's/# Modern Android Development - The Freeletics Way/# Overview/' docs/index.md
           # Set current version in docs
           sed -i "s/<latest-version>/$(git describe --tags --abbrev=0)/" docs/navigator/get-started.md
+          sed -i "s/<latest-version>/$(git describe --tags --abbrev=0)/" docs/navigator/testing.md
           sed -i "s/<latest-version>/$(git describe --tags --abbrev=0)/" docs/whetstone/get-started.md
           sed -i "s/<latest-version>/$(git describe --tags --abbrev=0)/" docs/whetstone/navigation.md
           sed -i "s/<latest-version>/$(git describe --tags --abbrev=0)/" docs/helpers.md
@@ -70,8 +71,12 @@ jobs:
           cp -R navigator/runtime-compose/build/dokka/html/. docs/navigator/API/runtime-compose/
           mkdir -p docs/navigator/API/runtime-fragment
           cp -R navigator/runtime-fragment/build/dokka/html/. docs/navigator/API/runtime-fragment/
+          mkdir -p docs/navigator/API/testing
+          cp -R navigator/testing/build/dokka/html/. docs/navigator/API/testing/
           mkdir -p docs/helpers/API/state-machine
           cp -R state-machine/build/dokka/html/. docs/helpers/API/state-machine/
+          mkdir -p docs/helpers/API/state-machine-testing
+          cp -R state-machine/testing/build/dokka/html/. docs/helpers/API/state-machine-testing/
           mkdir -p docs/helpers/API/text-resource
           cp -R text-resource/build/dokka/html/. docs/helpers/API/text-resource/
           mkdir -p docs/whetstone/API/runtime

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 Change Log
 ==========
 
+## 0.11.0 **UNRELEASED**
+
+### Navigator
+
+- new `navigator-testing` artifact to test `NavEventNavigator`, [see docs](https://freeletics.github.io/mad/navigator/testing/)
+- `NavEvent` and other APIs that were marked as visible for testing are now marked as internal
+- compose navigation APIs are not annotated with `ExperimentalMaterialNavigationApi` anymore
+
+### StateMachine
+
+- new `state-machine-testing` artifact, [see docs](https://freeletics.github.io/mad/helpers/#statemachine)
+
+
 ## 0.10.1 *(2022-01-13)*
 
 ### Navigator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ Change Log
 ### StateMachine
 
 - new `state-machine-testing` artifact, [see docs](https://freeletics.github.io/mad/helpers/#statemachine)
-- compose navigation APIs are not annotated with `ExperimentalMaterialNavigationApi` anymore
 
 ### Whetstone
 

--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,6 @@ apiValidation {
     ignoredProjects += ["compiler"]
 
     nonPublicMarkers += [
-        "androidx.annotation.VisibleForTesting",
         "com.freeletics.mad.navigator.internal.InternalNavigatorApi",
         "com.freeletics.mad.whetstone.internal.InternalWhetstoneApi",
     ]

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -15,6 +15,12 @@ to it by simply launching them from a `CoroutineScope` created with `rememberCor
 implementation("com.freeletics.mad:state-machine:<latest-version>")
 ```
 
+Additionally there is a test artifact that provides `StateMachine.test` and `StateMachine.testIn`
+extension functions.
+
+```groovy
+testImplementation("com.freeletics.mad:state-machine-testing:<latest-version>")
+```
 
 ## TextResource
 

--- a/docs/navigator/testing.md
+++ b/docs/navigator/testing.md
@@ -1,18 +1,101 @@
 # Testing
 
-The `NavEventNavigator` exposes a `navEvents` property that has `Flow<NavEvent>` as type. On any
-of the navigation calls this `Flow` will emit a new `NavEvent`. To test logic that triggers
-navigation this can be used together with the [Turbine library](https://github.com/cashapp/turbine)
-to assert that the correct events are emitted.
+The library has an optional test artifact that provides an additional test artifact that makes
+it possible to test navigation logic through `NavEventNavigator` without running on an Android 
+device or emulator. The test artifact is heavily inspired by the 
+[Turbine library](https://github.com/cashapp/turbine) and also used it internally.
+
+
+## Dependency
+
+```groovy
+testImplementation("com.freeletics.mad:navigator-testing:<latest-version>")
+```
+
+
+## Standalone navigation tests
+
+When testing a `NavEventNavigator` on its own call the `test` extension function on it
 
 ```kotlin
-navigator.navEvents.test {
-    navigator.navigateTo(TestRoute())
-    assertThat(awaitItem).isEqualTo(NavEvent.NavigateToEvent(TestRoute()))
-    navigator.navigateBack()
-    assertThat(awaitItem).isEqualTo(NavEvent.BackEvent)
+
+navigator.test {
+    // assertions
 }
 ```
 
-This is a very simplified example, in reality the test would most likely not call the navigator
-itself but some other code that uses the navigator internally.
+This will start collecting events from the navigator and then calls the given block with 
+`NavigatorTurbine` as a receiver:
+
+```kotlin
+
+navigator.test {
+    awaitNavigateTo(ExampleRoute("1"))
+    awaitNavigateTo(ExampleRoute("2"))
+    awaitNavigateBack()
+}
+```
+
+The collection is automatically cancelled at the end of the `test` block.
+
+## Navigation and other state
+
+If the test does not just validate the navigation logic but also other things like for example
+state changes a `NavigatorTurbine` can be obtained by calling `testIn`
+
+```kotlin
+runTest {
+    val otherTurbine = someFlow.testIn(this)
+    val navigatorTurbine = navigator.testIn(this)
+    assertEquals(newState, otherTurbine.awaitItem())
+    navigatorTurbine.awaitNavigateTo(ExampleRoute("1"))
+    
+    otherTurbine.cancel()
+    navigatorTurbine.cancel()
+}
+```
+
+Unlike `test`, the `testIn` extension function can not automatically clean up its coroutine, so it
+is required to manually call `cancel` at the end of the test.
+
+## Cancellation
+
+While `test` and `testIn` have different ways of cancellation, both will validate that all 
+navigation events have been consumed upon cancellation. If there are any unconsumed events
+that were not handled through one of the `await...` functions an `AssertionError` will be thrown
+during the cancellation.
+
+
+## Back presses
+
+For tests of classes or functions that collect `NavEventNavigator.backPresses()` it is possible
+to manually trigger a back press emission by calling the `NavEventNavigator.dispatchBackPress()`
+function.
+
+`NavigatorTurbine` also has a `dispatchBackPress()` function which can be directly called from
+within a `test` block.
+
+
+## Result receivers
+
+When testing code that deals with `Activity`, permission or navigation results it is often needed
+to send fake results to the collector. The library provides a `sendResult` extension function for 
+each request type to do that.
+
+For example if there would be the following navigator:
+
+```kotlin
+class MyNavigator : NavEventNavigator() {
+    val permissionRequest = registerForPermissionsResult()
+}
+```
+
+If the code under test collects `permissionRequest.results`, it would be possible to call 
+`navigator.permissionRequest.sendResult("permission", PermissionResult.GRANTED)` to simulate 
+the request succeeding.
+
+
+## Navigation result senders
+
+When testing a component that delivers navigation results a `NavigationResultRequest.Key` is usally
+required. Tests can obtain such a key with the `fakeNavigationResultKey` helper method.

--- a/docs/navigator/testing.md
+++ b/docs/navigator/testing.md
@@ -3,7 +3,7 @@
 The library has an optional test artifact that provides an additional test artifact that makes
 it possible to test navigation logic through `NavEventNavigator` without running on an Android 
 device or emulator. The test artifact is heavily inspired by the 
-[Turbine library](https://github.com/cashapp/turbine) and also used it internally.
+[Turbine library](https://github.com/cashapp/turbine) and is also using it internally.
 
 
 ## Dependency
@@ -97,5 +97,5 @@ the request succeeding.
 
 ## Navigation result senders
 
-When testing a component that delivers navigation results a `NavigationResultRequest.Key` is usally
+When testing a component that delivers navigation results a `NavigationResultRequest.Key` is usually
 required. Tests can obtain such a key with the `fakeNavigationResultKey` helper method.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ nav:
           - 'Runtime': navigator/API/runtime/index.html
           - 'Runtime Compose': navigator/API/runtime-compose/index.html
           - 'Runtime Fragment': navigator/API/runtime-fragment/index.html
+          - 'Testing': navigator/API/testing/index.html
   - 'Whetstone':
       - whetstone/get-started.md
       - whetstone/navigation.md
@@ -45,6 +46,7 @@ nav:
       - helpers.md
       - 'API':
           - 'StateMachine': helpers/API/state-machine/index.html
+          - 'StateMachineTesting': helpers/API/state-machine-testing/index.html
           - 'TextResource': helpers/API/text-resource/index.html
   - changelog.md
 

--- a/navigator/runtime/api/navigator-runtime.api
+++ b/navigator/runtime/api/navigator-runtime.api
@@ -116,7 +116,6 @@ public final class com/freeletics/mad/navigator/NavRouteKt {
 }
 
 public final class com/freeletics/mad/navigator/NavigationResultRequest : com/freeletics/mad/navigator/ResultOwner {
-	public static final field Companion Lcom/freeletics/mad/navigator/NavigationResultRequest$Companion;
 	public final fun getKey ()Lcom/freeletics/mad/navigator/NavigationResultRequest$Key;
 }
 
@@ -145,6 +144,7 @@ public abstract interface class com/freeletics/mad/navigator/PermissionsResultRe
 }
 
 public final class com/freeletics/mad/navigator/PermissionsResultRequest$PermissionResult$Denied : com/freeletics/mad/navigator/PermissionsResultRequest$PermissionResult {
+	public fun <init> (Z)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getShouldShowRationale ()Z
 	public fun hashCode ()I

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEvent.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEvent.kt
@@ -1,12 +1,9 @@
 package com.freeletics.mad.navigator
 
 import android.os.Parcelable
-import androidx.annotation.VisibleForTesting
-import androidx.annotation.VisibleForTesting.PACKAGE_PRIVATE
-import androidx.annotation.VisibleForTesting.PRIVATE
 import com.freeletics.mad.navigator.internal.DestinationId
+import com.freeletics.mad.navigator.internal.InternalNavigatorApi
 import dev.drewhamilton.poko.Poko
-import kotlin.reflect.KClass
 
 /**
  * Represents a navigation event that is being sent by a [NavEventNavigator] and handled by
@@ -16,13 +13,13 @@ import kotlin.reflect.KClass
  * Custom subclasses of `NavEvent` can be sent using [NavEventNavigator.sendNavEvent] but require
  * providing a custom `NavEventNavigationHandler` that supports handling those events.
  */
-@VisibleForTesting(otherwise = PACKAGE_PRIVATE)
+@InternalNavigatorApi
 public sealed interface NavEvent {
 
     /**
      * Navigates to the given [route].
      */
-    @VisibleForTesting(otherwise = PACKAGE_PRIVATE)
+    @InternalNavigatorApi
     @Poko
     public class NavigateToEvent(
         internal val route: NavRoute,
@@ -32,7 +29,7 @@ public sealed interface NavEvent {
      * Navigates to the given [root]. The current back stack will be popped and saved.
      * Whether the backstack of the given route is restored depends on [restoreRootState].
      */
-    @VisibleForTesting(otherwise = PACKAGE_PRIVATE)
+    @InternalNavigatorApi
     @Poko
     public class NavigateToRootEvent(
         internal val root: NavRoot,
@@ -43,7 +40,7 @@ public sealed interface NavEvent {
     /**
      * Navigates to the given [route].
      */
-    @VisibleForTesting(otherwise = PACKAGE_PRIVATE)
+    @InternalNavigatorApi
     @Poko
     public class NavigateToActivityEvent(
         internal val route: ActivityRoute,
@@ -52,39 +49,30 @@ public sealed interface NavEvent {
     /**
      * Navigates up.
      */
-    @VisibleForTesting(otherwise = PACKAGE_PRIVATE)
+    @InternalNavigatorApi
     public object UpEvent : NavEvent
 
     /**
      * Navigates back.
      */
-    @VisibleForTesting(otherwise = PACKAGE_PRIVATE)
+    @InternalNavigatorApi
     public object BackEvent : NavEvent
 
     /**
      * Navigates back to the given [popUpTo]. If [inclusive] is `true` the destination itself
      * will also be popped of the back stack.
      */
-    @VisibleForTesting(otherwise = PACKAGE_PRIVATE)
+    @InternalNavigatorApi
     @Poko
     public class BackToEvent(
         internal val popUpTo: DestinationId<*>,
         internal val inclusive: Boolean,
     ) : NavEvent
 
-    // TODO: remove after introducing a testing artifact
-    @VisibleForTesting(otherwise = PRIVATE)
-    public companion object {
-        public fun BackToEvent(
-            popUpTo: KClass<out NavRoute>,
-            inclusive: Boolean,
-        ): BackToEvent = BackToEvent(DestinationId(popUpTo), inclusive)
-    }
-
     /**
      * Launches the [request] to retrieve an event.
      */
-    @VisibleForTesting(otherwise = PACKAGE_PRIVATE)
+    @InternalNavigatorApi
     @Poko
     public class ActivityResultEvent<I>(
         internal val request: ContractResultOwner<I, *, *>,
@@ -94,7 +82,7 @@ public sealed interface NavEvent {
     /**
      * Delivers the [result] to the destination that created [key].
      */
-    @VisibleForTesting(otherwise = PACKAGE_PRIVATE)
+    @InternalNavigatorApi
     @Poko
     public class DestinationResultEvent<O : Parcelable>(
         internal val key: NavigationResultRequest.Key<O>,

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
@@ -20,7 +20,6 @@ import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flow
 
 /**
- * A navigator TODO
  * This allows to trigger navigation actions from outside the view layer
  * without keeping references to Android framework classes that might leak. It also improves
  * the testability of your navigation logic since it is possible to just write test that

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
@@ -3,8 +3,6 @@ package com.freeletics.mad.navigator
 import android.os.Parcelable
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContract
-import androidx.annotation.VisibleForTesting
-import androidx.annotation.VisibleForTesting.PACKAGE_PRIVATE
 import com.freeletics.mad.navigator.NavEvent.ActivityResultEvent
 import com.freeletics.mad.navigator.NavEvent.BackEvent
 import com.freeletics.mad.navigator.NavEvent.BackToEvent
@@ -22,9 +20,8 @@ import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flow
 
 /**
- * A navigator that allows to fire [events][NavEvent] through it's methods. These
- * events are publicly exposed through the [navEvents] [Flow] that can be collected and acted upon
- * by a `NavigationHandler`. This allows to trigger navigation actions from outside the view layer
+ * A navigator TODO
+ * This allows to trigger navigation actions from outside the view layer
  * without keeping references to Android framework classes that might leak. It also improves
  * the testability of your navigation logic since it is possible to just write test that
  * the correct events were emitted.
@@ -37,10 +34,7 @@ public open class NavEventNavigator {
 
     private val _navEvents = Channel<NavEvent>(Channel.UNLIMITED)
 
-    /**
-     * A [Flow] to collect [NavEvents][NavEvent] produced by this navigator.
-     */
-    @VisibleForTesting(otherwise = PACKAGE_PRIVATE)
+    @InternalNavigatorApi
     public val navEvents: Flow<NavEvent> = flow {
         for (result in _navEvents) {
             emit(result)
@@ -183,21 +177,21 @@ public open class NavEventNavigator {
     }
 
     /**
-     * Triggers a new [NavEvent] that launches the given [launcher].
+     * Triggers a new [NavEvent] that launches the given [request].
      *
-     * The [launcher] can be obtained by calling [registerForActivityResult].
+     * The [request] can be obtained by calling [registerForActivityResult].
      */
-    public fun navigateForResult(launcher: ActivityResultRequest<Void?, *>) {
-        navigateForResult(launcher, null)
+    public fun navigateForResult(request: ActivityResultRequest<Void?, *>) {
+        navigateForResult(request, null)
     }
 
     /**
-     * Triggers a new [NavEvent] that launches the given [launcher] with the given [input].
+     * Triggers a new [NavEvent] that launches the given [request] with the given [input].
      *
-     * The [launcher] can be obtained by calling [registerForActivityResult].
+     * The [request] can be obtained by calling [registerForActivityResult].
      */
-    public fun <I> navigateForResult(launcher: ActivityResultRequest<I, *>, input: I) {
-        val event = ActivityResultEvent(launcher, input)
+    public fun <I> navigateForResult(request: ActivityResultRequest<I, *>, input: I) {
+        val event = ActivityResultEvent(request, input)
         sendNavEvent(event)
     }
 
@@ -296,6 +290,6 @@ public open class NavEventNavigator {
             return _navigationResultRequests.toList()
         }
 
-    @VisibleForTesting(otherwise = PACKAGE_PRIVATE)
+    @InternalNavigatorApi
     public val onBackPressedCallback: OnBackPressedCallback get() = _onBackPressedCallback
 }

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/ResultOwner.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/ResultOwner.kt
@@ -3,8 +3,6 @@ package com.freeletics.mad.navigator
 import android.os.Parcel
 import android.os.Parcelable
 import androidx.activity.result.contract.ActivityResultContract
-import androidx.annotation.VisibleForTesting
-import androidx.annotation.VisibleForTesting.PACKAGE_PRIVATE
 import com.freeletics.mad.navigator.PermissionsResultRequest.PermissionResult
 import com.freeletics.mad.navigator.internal.DestinationId
 import com.freeletics.mad.navigator.internal.InternalNavigatorApi
@@ -39,7 +37,7 @@ public sealed class ResultOwner<R> {
      * Deliver a new [result] to [results]. This method should be called by a
      * `NavEventNavigationHandler`.
      */
-    @VisibleForTesting(otherwise = PACKAGE_PRIVATE)
+    @InternalNavigatorApi
     public fun onResult(result: R) {
         val channelResult = _results.trySendBlocking(result)
         check(channelResult.isSuccess)
@@ -113,7 +111,7 @@ public class PermissionsResultRequest internal constructor() :
          * the prompt without making a choice.
          */
         @Poko
-        public class Denied @VisibleForTesting(otherwise = PACKAGE_PRIVATE) constructor(
+        public class Denied(
             public val shouldShowRationale: Boolean,
         ) : PermissionResult
     }
@@ -134,7 +132,7 @@ public class NavigationResultRequest<R : Parcelable> internal constructor(
      */
     @Poko
     @Parcelize
-    public class Key<R : Parcelable> internal constructor(
+    public class Key<R : Parcelable> @InternalNavigatorApi constructor(
         internal val destinationId: DestinationId<*>,
         internal val requestKey: String
     ) : Parcelable {
@@ -153,10 +151,10 @@ public class NavigationResultRequest<R : Parcelable> internal constructor(
     }
 
     // TODO: remove after introducing a testing artifact
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    public companion object {
-        public fun <R : Parcelable> Key(cls: KClass<out BaseRoute>, requestKey: String): Key<R> {
-            return Key(DestinationId(cls), requestKey)
-        }
-    }
+//    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+//    public companion object {
+//        public fun <R : Parcelable> Key(cls: KClass<out BaseRoute>, requestKey: String): Key<R> {
+//            return Key(DestinationId(cls), requestKey)
+//        }
+//    }
 }

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/ResultOwner.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/ResultOwner.kt
@@ -151,10 +151,4 @@ public class NavigationResultRequest<R : Parcelable> internal constructor(
     }
 
     // TODO: remove after introducing a testing artifact
-//    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-//    public companion object {
-//        public fun <R : Parcelable> Key(cls: KClass<out BaseRoute>, requestKey: String): Key<R> {
-//            return Key(DestinationId(cls), requestKey)
-//        }
-//    }
 }

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/NavigationSetup.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/NavigationSetup.kt
@@ -15,7 +15,6 @@ import com.freeletics.mad.navigator.PermissionsResultRequest
 import com.freeletics.mad.navigator.internal.RequestPermissionsContract.Companion.enrichResult
 import kotlinx.parcelize.Parcelize
 
-@SuppressLint("VisibleForTests") // VisibleForTests(otherwise = INTERNAL) does not exist
 @InternalNavigatorApi
 public suspend fun NavEventNavigator.collectAndHandleNavEvents(
     lifecycle: Lifecycle,
@@ -67,7 +66,6 @@ private fun NavigationExecutor.navigate(
 }
 
 @InternalNavigatorApi
-@SuppressLint("VisibleForTests") // VisibleForTests(otherwise = INTERNAL) does not exist
 @Suppress("UNCHECKED_CAST")
 public fun <I, O, R> ContractResultOwner<I, O, R>.deliverResult(activity: Activity, result: O) {
     when(this) {
@@ -76,7 +74,6 @@ public fun <I, O, R> ContractResultOwner<I, O, R>.deliverResult(activity: Activi
     }
 }
 
-@SuppressLint("VisibleForTests") // VisibleForTests(otherwise = INTERNAL) does not exist
 @InternalNavigatorApi
 public suspend fun <R : Parcelable> NavigationExecutor.collectAndHandleNavigationResults(
     request: NavigationResultRequest<R>,

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/RequestPermissionsContract.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/RequestPermissionsContract.kt
@@ -37,7 +37,6 @@ public class RequestPermissionsContract :
     }
 
     internal companion object {
-        @SuppressLint("VisibleForTests") // VisibleForTests(otherwise = INTERNAL) does not exist
         internal fun enrichResult(
             activity: Activity,
             resultMap: Map<String, Boolean>

--- a/navigator/testing/api/testing.api
+++ b/navigator/testing/api/testing.api
@@ -1,0 +1,33 @@
+public abstract interface class com/freeletics/mad/navigator/NavigatorTurbine {
+	public abstract fun awaitNavigateBack (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun awaitNavigateBackTo (Lkotlin/reflect/KClass;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun awaitNavigateForResult (Lcom/freeletics/mad/navigator/ActivityResultRequest;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun awaitNavigateForResult (Lcom/freeletics/mad/navigator/ActivityResultRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun awaitNavigateTo (Lcom/freeletics/mad/navigator/ActivityRoute;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun awaitNavigateTo (Lcom/freeletics/mad/navigator/NavRoute;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun awaitNavigateToRoot (Lcom/freeletics/mad/navigator/NavRoot;ZZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun awaitNavigateUp (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun awaitNavigationResult (Lcom/freeletics/mad/navigator/NavigationResultRequest$Key;Landroid/os/Parcelable;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun awaitRequestPermissions (Lcom/freeletics/mad/navigator/PermissionsResultRequest;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun awaitRequestPermissions (Lcom/freeletics/mad/navigator/PermissionsResultRequest;[Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun cancel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun cancelAndIgnoreRemainingNavEvents (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun dispatchBackPress ()V
+}
+
+public final class com/freeletics/mad/navigator/NavigatorTurbineKt {
+	public static final fun dispatchBackPress (Lcom/freeletics/mad/navigator/NavEventNavigator;)V
+	public static final fun test-C2H2yOE (Lcom/freeletics/mad/navigator/NavEventNavigator;Lkotlin/time/Duration;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun test-C2H2yOE$default (Lcom/freeletics/mad/navigator/NavEventNavigator;Lkotlin/time/Duration;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun testIn-5_5nbZA (Lcom/freeletics/mad/navigator/NavEventNavigator;Lkotlinx/coroutines/CoroutineScope;Lkotlin/time/Duration;Ljava/lang/String;)Lcom/freeletics/mad/navigator/NavigatorTurbine;
+	public static synthetic fun testIn-5_5nbZA$default (Lcom/freeletics/mad/navigator/NavEventNavigator;Lkotlinx/coroutines/CoroutineScope;Lkotlin/time/Duration;Ljava/lang/String;ILjava/lang/Object;)Lcom/freeletics/mad/navigator/NavigatorTurbine;
+}
+
+public final class com/freeletics/mad/navigator/ResultOwnerTestingKt {
+	public static final fun sendResult (Lcom/freeletics/mad/navigator/ActivityResultRequest;Ljava/lang/Object;)V
+	public static final fun sendResult (Lcom/freeletics/mad/navigator/NavigationResultRequest;Landroid/os/Parcelable;)V
+	public static final fun sendResult (Lcom/freeletics/mad/navigator/PermissionsResultRequest;Ljava/lang/String;Lcom/freeletics/mad/navigator/PermissionsResultRequest$PermissionResult;)V
+	public static final fun sendResult (Lcom/freeletics/mad/navigator/PermissionsResultRequest;Ljava/util/Map;)V
+	public static final fun sendResult (Lcom/freeletics/mad/navigator/PermissionsResultRequest;[Lkotlin/Pair;)V
+}
+

--- a/navigator/testing/build.gradle
+++ b/navigator/testing/build.gradle
@@ -1,0 +1,57 @@
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.dokka)
+    alias(libs.plugins.publish)
+}
+
+android {
+    namespace = "com.freeletics.mad.navigator.testing"
+    compileSdkVersion libs.versions.android.compile.get().toInteger()
+
+    defaultConfig {
+        minSdkVersion libs.versions.android.min.get().toInteger()
+    }
+
+    buildFeatures {
+        buildConfig = false
+    }
+
+    // still needed for Android projects despite toolchain
+    compileOptions {
+        sourceCompatibility(JavaVersion.toVersion(libs.versions.java.get()))
+        targetCompatibility(JavaVersion.toVersion(libs.versions.java.get()))
+    }
+}
+
+// workaround for https://youtrack.jetbrains.com/issue/KT-37652
+android.kotlinOptions.freeCompilerArgs += "-Xexplicit-api=strict"
+
+kotlin {
+    explicitApi()
+
+    jvmToolchain {
+        languageVersion.set(JavaLanguageVersion.of(libs.versions.java.get().toInteger()))
+    }
+
+    sourceSets.all {
+        languageSettings {
+            optIn("com.freeletics.mad.navigator.internal.InternalNavigatorApi")
+        }
+    }
+}
+
+// workaround for https://issuetracker.google.com/issues/194113162
+tasks.withType(JavaCompile).configureEach {
+    javaCompiler = javaToolchains.compilerFor {
+        languageVersion = JavaLanguageVersion.of(libs.versions.java.get().toInteger())
+    }
+}
+
+dependencies {
+    api project(":navigator:navigator-runtime")
+    api libs.coroutines.core
+    api libs.turbine
+    implementation libs.androidx.activity
+    implementation libs.truth
+}

--- a/navigator/testing/gradle.properties
+++ b/navigator/testing/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=navigator-testing
+POM_NAME=Navigator Testing
+POM_DESCRIPTION=Navigator Testing

--- a/navigator/testing/src/main/java/com/freeletics/mad/navigator/NavigatorTurbine.kt
+++ b/navigator/testing/src/main/java/com/freeletics/mad/navigator/NavigatorTurbine.kt
@@ -68,8 +68,7 @@ public interface NavigatorTurbine {
      * Assert that the next event received was a navigation event to the given [route]. This function
      * will suspend if no events have been received.
      *
-     * Throws:
-     * AssertionError - if the next event was not a matching event.
+     * @throws AssertionError - if the next event was not a matching event.
      */
     public suspend fun awaitNavigateTo(route: NavRoute)
 
@@ -77,8 +76,7 @@ public interface NavigatorTurbine {
      * Assert that the next event received was a navigation event to the given [root]. This function
      * will suspend if no events have been received.
      *
-     * Throws:
-     * AssertionError - if the next event was not a matching event.
+     * @throws AssertionError - if the next event was not a matching event.
      */
     public suspend fun awaitNavigateToRoot(
         root: NavRoot,
@@ -90,8 +88,7 @@ public interface NavigatorTurbine {
      * Assert that the next event received was a navigation event to the given [route]. This function
      * will suspend if no events have been received.
      *
-     * Throws:
-     * AssertionError - if the next event was not a matching event.
+     * @throws AssertionError - if the next event was not a matching event.
      */
     public suspend fun awaitNavigateTo(route: ActivityRoute)
 
@@ -108,8 +105,7 @@ public interface NavigatorTurbine {
      * Assert that the next event received was a back navigation event. This function
      * will suspend if no events have been received.
      *
-     * Throws:
-     * AssertionError - if the next event was not a matching event.
+     * @throws AssertionError - if the next event was not a matching event.
      */
     public suspend fun awaitNavigateBack()
 
@@ -117,8 +113,7 @@ public interface NavigatorTurbine {
      * Assert that the next event received was a "back to" navigation event with matching parameters.
      * This function will suspend if no events have been received.
      *
-     * Throws:
-     * AssertionError - if the next event was not a matching event.
+     * @throws AssertionError - if the next event was not a matching event.
      */
     public suspend fun <T: BaseRoute> awaitNavigateBackTo(
         popUpTo: KClass<T>,
@@ -129,8 +124,7 @@ public interface NavigatorTurbine {
      * Assert that the next event received was a navigate for result event to [request].
      * This function will suspend if no events have been received.
      *
-     * Throws:
-     * AssertionError - if the next event was not a matching event.
+     * @throws AssertionError - if the next event was not a matching event.
      */
     public suspend fun awaitNavigateForResult(request: ActivityResultRequest<Void?, *>)
 
@@ -138,8 +132,7 @@ public interface NavigatorTurbine {
      * Assert that the next event received was a navigate for result event to [request].
      * This function will suspend if no events have been received.
      *
-     * Throws:
-     * AssertionError - if the next event was not a matching event.
+     * @throws AssertionError - if the next event was not a matching event.
      */
     public suspend fun <I> awaitNavigateForResult(request: ActivityResultRequest<I, *>, input: I)
 
@@ -147,8 +140,7 @@ public interface NavigatorTurbine {
      * Assert that the next event received was a permission request. This function will suspend
      * if no events have been received.
      *
-     * Throws:
-     * AssertionError - if the next event was not a matching event.
+     * @throws AssertionError - if the next event was not a matching event.
      */
     public suspend fun awaitRequestPermissions(
         request: PermissionsResultRequest,
@@ -159,8 +151,7 @@ public interface NavigatorTurbine {
      * Assert that the next event received was a permission request. This function will suspend
      * if no events have been received.
      *
-     * Throws:
-     * AssertionError - if the next event was not a matching event.
+     * @throws AssertionError - if the next event was not a matching event.
      */
     public suspend fun awaitRequestPermissions(
         request: PermissionsResultRequest,
@@ -171,8 +162,7 @@ public interface NavigatorTurbine {
      * Assert that the next event received was a navigation result. This function will suspend
      * if no events have been received.
      *
-     * Throws:
-     * AssertionError - if the next event was not a matching event.
+     * @throws AssertionError - if the next event was not a matching event.
      */
     public suspend fun <O : Parcelable> awaitNavigationResult(
         key: NavigationResultRequest.Key<O>,
@@ -182,8 +172,7 @@ public interface NavigatorTurbine {
     /**
      * Cancel this [NavigatorTurbine].
      *
-     * Throws:
-     * AssertionError - if there are any unconsumed events.
+     * @throws AssertionError - if there are any unconsumed events.
      */
     public suspend fun cancel()
 

--- a/navigator/testing/src/main/java/com/freeletics/mad/navigator/NavigatorTurbine.kt
+++ b/navigator/testing/src/main/java/com/freeletics/mad/navigator/NavigatorTurbine.kt
@@ -1,0 +1,285 @@
+package com.freeletics.mad.navigator
+
+import android.os.Parcelable
+import app.cash.turbine.ReceiveTurbine
+import app.cash.turbine.test
+import app.cash.turbine.testIn
+import com.freeletics.mad.navigator.internal.DestinationId
+import com.google.common.truth.Truth
+import kotlin.reflect.KClass
+import kotlin.time.Duration
+import kotlinx.coroutines.CoroutineScope
+
+/**
+ * Collects events from [NavEventNavigator] and and allows the [validate] lambda to consume
+ * and assert properties on them in order. If any exception occurs during validation the
+ * exception is rethrown from this method.
+ *
+ * [timeout] - If non-null, overrides the current Turbine timeout inside validate.
+ */
+public suspend fun NavEventNavigator.test(
+    timeout: Duration? = null,
+    name: String? = null,
+    validate: suspend NavigatorTurbine.() -> Unit,
+) {
+    val navigator = this
+    navEvents.test(timeout, name) {
+        val turbine = DefaultNavigatorTurbine(navigator, this)
+        validate(turbine)
+    }
+}
+
+/**
+ * Collects events from [NavEventNavigator] and returns a [NavigatorTurbine] for consuming
+ * and asserting properties on them in order. If any exception occurs during validation the
+ * exception is rethrown from this method.
+ *
+ * Unlike test which automatically cancels the flow at the end of the lambda, the returned
+ * NavigatorTurbine be explicitly canceled.
+ *
+ * [timeout] - If non-null, overrides the current Turbine timeout inside validate.
+ */
+public fun NavEventNavigator.testIn(
+    scope: CoroutineScope,
+    timeout: Duration? = null,
+    name: String? = null,
+): NavigatorTurbine {
+    val turbine = navEvents.testIn(scope, timeout, name)
+    return DefaultNavigatorTurbine(this, turbine)
+}
+
+/**
+ * Causes an emission to the current [NavEventNavigator.backPresses] collector to make it possible
+ * to simulate a back press in tests that check custom back press logic.
+ */
+public fun NavEventNavigator.dispatchBackPress() {
+    onBackPressedCallback.handleOnBackPressed()
+}
+
+public interface NavigatorTurbine {
+
+    /**
+     * Causes an emission to the current [NavEventNavigator.backPresses] collector to make it possible
+     * to simulate a back press in tests that check custom back press logic.
+     */
+    public fun dispatchBackPress()
+
+    /**
+     * Assert that the next event received was a navigation event to the given [route]. This function
+     * will suspend if no events have been received.
+     *
+     * Throws:
+     * AssertionError - if the next event was not a matching event.
+     */
+    public suspend fun awaitNavigateTo(route: NavRoute)
+
+    /**
+     * Assert that the next event received was a navigation event to the given [root]. This function
+     * will suspend if no events have been received.
+     *
+     * Throws:
+     * AssertionError - if the next event was not a matching event.
+     */
+    public suspend fun awaitNavigateToRoot(
+        root: NavRoot,
+        restoreRootState: Boolean,
+        saveCurrentRootState: Boolean,
+    )
+
+    /**
+     * Assert that the next event received was a navigation event to the given [route]. This function
+     * will suspend if no events have been received.
+     *
+     * Throws:
+     * AssertionError - if the next event was not a matching event.
+     */
+    public suspend fun awaitNavigateTo(route: ActivityRoute)
+
+    /**
+     * Assert that the next event received was an "up" navigation event. This function
+     * will suspend if no events have been received.
+     *
+     * Throws:
+     * AssertionError - if the next event was not a matching event.
+     */
+    public suspend fun awaitNavigateUp()
+
+    /**
+     * Assert that the next event received was a back navigation event. This function
+     * will suspend if no events have been received.
+     *
+     * Throws:
+     * AssertionError - if the next event was not a matching event.
+     */
+    public suspend fun awaitNavigateBack()
+
+    /**
+     * Assert that the next event received was a "back to" navigation event with matching parameters.
+     * This function will suspend if no events have been received.
+     *
+     * Throws:
+     * AssertionError - if the next event was not a matching event.
+     */
+    public suspend fun <T: BaseRoute> awaitNavigateBackTo(
+        popUpTo: KClass<T>,
+        inclusive: Boolean
+    )
+
+    /**
+     * Assert that the next event received was a navigate for result event to [request].
+     * This function will suspend if no events have been received.
+     *
+     * Throws:
+     * AssertionError - if the next event was not a matching event.
+     */
+    public suspend fun awaitNavigateForResult(request: ActivityResultRequest<Void?, *>)
+
+    /**
+     * Assert that the next event received was a navigate for result event to [request].
+     * This function will suspend if no events have been received.
+     *
+     * Throws:
+     * AssertionError - if the next event was not a matching event.
+     */
+    public suspend fun <I> awaitNavigateForResult(request: ActivityResultRequest<I, *>, input: I)
+
+    /**
+     * Assert that the next event received was a permission request. This function will suspend
+     * if no events have been received.
+     *
+     * Throws:
+     * AssertionError - if the next event was not a matching event.
+     */
+    public suspend fun awaitRequestPermissions(
+        request: PermissionsResultRequest,
+        vararg permissions: String
+    )
+
+    /**
+     * Assert that the next event received was a permission request. This function will suspend
+     * if no events have been received.
+     *
+     * Throws:
+     * AssertionError - if the next event was not a matching event.
+     */
+    public suspend fun awaitRequestPermissions(
+        request: PermissionsResultRequest,
+        permissions: List<String>
+    )
+
+    /**
+     * Assert that the next event received was a navigation result. This function will suspend
+     * if no events have been received.
+     *
+     * Throws:
+     * AssertionError - if the next event was not a matching event.
+     */
+    public suspend fun <O : Parcelable> awaitNavigationResult(
+        key: NavigationResultRequest.Key<O>,
+        result: O
+    )
+
+    /**
+     * Cancel this [NavigatorTurbine].
+     *
+     * Throws:
+     * AssertionError - if there are any unconsumed events.
+     */
+    public suspend fun cancel()
+
+    /**
+     * Cancel this [NavigatorTurbine]. The difference to [cancel] is any unconsumed event will be
+     * ignored and no error will be thrown.
+     */
+    public suspend fun cancelAndIgnoreRemainingNavEvents()
+}
+
+internal class DefaultNavigatorTurbine(
+    private val navigator: NavEventNavigator,
+    private val turbine: ReceiveTurbine<NavEvent>,
+) : NavigatorTurbine {
+
+    override fun dispatchBackPress() {
+        navigator.onBackPressedCallback.handleOnBackPressed()
+    }
+
+    override suspend fun awaitNavigateTo(route: NavRoute) {
+        val event = NavEvent.NavigateToEvent(route)
+        Truth.assertThat(turbine.awaitItem()).isEqualTo(event)
+    }
+
+    override suspend fun awaitNavigateToRoot(
+        root: NavRoot,
+        restoreRootState: Boolean,
+        saveCurrentRootState: Boolean,
+    ) {
+        val event = NavEvent.NavigateToRootEvent(root, restoreRootState, saveCurrentRootState)
+        Truth.assertThat(turbine.awaitItem()).isEqualTo(event)
+    }
+
+    override suspend fun awaitNavigateTo(route: ActivityRoute) {
+        val event = NavEvent.NavigateToActivityEvent(route)
+        Truth.assertThat(turbine.awaitItem()).isEqualTo(event)
+    }
+
+    override suspend fun awaitNavigateUp() {
+        val event = NavEvent.UpEvent
+        Truth.assertThat(turbine.awaitItem()).isEqualTo(event)
+    }
+
+    override suspend fun awaitNavigateBack() {
+        val event = NavEvent.BackEvent
+        Truth.assertThat(turbine.awaitItem()).isEqualTo(event)
+    }
+
+    override suspend fun <T: BaseRoute> awaitNavigateBackTo(
+        popUpTo: KClass<T>,
+        inclusive: Boolean
+    ) {
+        val event = NavEvent.BackToEvent(DestinationId(popUpTo), inclusive)
+        Truth.assertThat(turbine.awaitItem()).isEqualTo(event)
+    }
+
+    override suspend fun awaitNavigateForResult(request: ActivityResultRequest<Void?, *>) {
+        awaitNavigateForResult(request, null)
+    }
+
+    override suspend fun <I> awaitNavigateForResult(
+        request: ActivityResultRequest<I, *>,
+        input: I
+    ) {
+        val event = NavEvent.ActivityResultEvent(request, input)
+        Truth.assertThat(turbine.awaitItem()).isEqualTo(event)
+    }
+
+    override suspend fun awaitRequestPermissions(
+        request: PermissionsResultRequest,
+        vararg permissions: String
+    ) {
+        awaitRequestPermissions(request, permissions.toList())
+    }
+
+    override suspend fun awaitRequestPermissions(
+        request: PermissionsResultRequest,
+        permissions: List<String>
+    ) {
+        val event = NavEvent.ActivityResultEvent(request, permissions)
+        Truth.assertThat(turbine.awaitItem()).isEqualTo(event)
+    }
+
+    override suspend fun <O : Parcelable> awaitNavigationResult(
+        key: NavigationResultRequest.Key<O>,
+        result: O
+    ) {
+        val event = NavEvent.DestinationResultEvent(key, result)
+        Truth.assertThat(turbine.awaitItem()).isEqualTo(event)
+    }
+
+    override suspend fun cancel() {
+        turbine.cancel()
+    }
+
+    override suspend fun cancelAndIgnoreRemainingNavEvents() {
+        turbine.cancelAndIgnoreRemainingEvents()
+    }
+}

--- a/navigator/testing/src/main/java/com/freeletics/mad/navigator/NavigatorTurbine.kt
+++ b/navigator/testing/src/main/java/com/freeletics/mad/navigator/NavigatorTurbine.kt
@@ -96,8 +96,7 @@ public interface NavigatorTurbine {
      * Assert that the next event received was an "up" navigation event. This function
      * will suspend if no events have been received.
      *
-     * Throws:
-     * AssertionError - if the next event was not a matching event.
+     * @throws AssertionError - if the next event was not a matching event.
      */
     public suspend fun awaitNavigateUp()
 

--- a/navigator/testing/src/main/java/com/freeletics/mad/navigator/ResultOwnerTesting.kt
+++ b/navigator/testing/src/main/java/com/freeletics/mad/navigator/ResultOwnerTesting.kt
@@ -1,0 +1,56 @@
+package com.freeletics.mad.navigator
+
+import android.os.Parcelable
+import com.freeletics.mad.navigator.PermissionsResultRequest.PermissionResult
+import com.freeletics.mad.navigator.internal.DestinationId
+
+/**
+ * Send a fake result to collectors of this request. Can be used to test the result handling
+ * logic.
+ */
+public fun <O> ActivityResultRequest<*, O>.sendResult(result: O) {
+    onResult(result)
+}
+
+/**
+ * Send a fake result to collectors of this request. Can be used to test the result handling
+ * logic.
+ */
+public fun PermissionsResultRequest.sendResult(permission: String, result: PermissionResult) {
+    onResult(mapOf(permission to result))
+}
+
+/**
+ * Send a fake result to collectors of this request. Can be used to test the result handling
+ * logic.
+ */
+public fun PermissionsResultRequest.sendResult(vararg pairs: Pair<String, PermissionResult>) {
+    onResult(mapOf(*pairs))
+}
+
+/**
+ * Send a fake result to collectors of this request. Can be used to test the result handling
+ * logic.
+ */
+public fun PermissionsResultRequest.sendResult(result: Map<String, PermissionResult>) {
+    onResult(result)
+}
+
+/**
+ * Send a fake result to collectors of this request. Can be used to test the result handling
+ * logic.
+ */
+public fun <R : Parcelable> NavigationResultRequest<R>.sendResult(result: R) {
+    onResult(result)
+}
+
+/**
+ * Creates a [NavigationResultRequest.Key] for testing purposes. This should only be used for
+ * testing the result sender that retrieves a key as part of its argument.
+ *
+ * To test the result receiver use a real key from a request obtained by
+ * [NavEventNavigator.registerForNavigationResult].
+ */
+public inline fun <reified R : Parcelable> fakeNavigationResultKey(): NavigationResultRequest.Key<R> {
+    return NavigationResultRequest.Key(DestinationId(NavRoute::class), R::class.qualifiedName!!)
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,10 +16,9 @@ dependencyResolutionManagement {
     // repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
 }
 
-
-include ":navigator:androidx-nav"
-include ":navigator:runtime", ":navigator:runtime-compose", ":navigator:runtime-fragment"
-include ":state-machine"
+include ":navigator:runtime", ":navigator:testing"
+include ":navigator:androidx-nav", ":navigator:runtime-compose", ":navigator:runtime-fragment"
+include ":state-machine", ":state-machine:testing"
 include ":text-resource"
 include ":whetstone:compiler", ":whetstone:compiler-test"
 include ":whetstone:runtime", ":whetstone:runtime-compose", ":whetstone:runtime-fragment"

--- a/state-machine/testing/api/testing.api
+++ b/state-machine/testing/api/testing.api
@@ -1,0 +1,14 @@
+public abstract interface class com/freeletics/mad/statemachine/StateMachineTurbine {
+	public abstract fun awaitState (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun cancel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun cancelAndIgnoreRemainingStates (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun dispatch (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/freeletics/mad/statemachine/StateMachineTurbineKt {
+	public static final fun test-C2H2yOE (Lcom/freeletics/mad/statemachine/StateMachine;Lkotlin/time/Duration;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun test-C2H2yOE$default (Lcom/freeletics/mad/statemachine/StateMachine;Lkotlin/time/Duration;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun testIn-5_5nbZA (Lcom/freeletics/mad/statemachine/StateMachine;Lkotlinx/coroutines/CoroutineScope;Lkotlin/time/Duration;Ljava/lang/String;)Lcom/freeletics/mad/statemachine/StateMachineTurbine;
+	public static synthetic fun testIn-5_5nbZA$default (Lcom/freeletics/mad/statemachine/StateMachine;Lkotlinx/coroutines/CoroutineScope;Lkotlin/time/Duration;Ljava/lang/String;ILjava/lang/Object;)Lcom/freeletics/mad/statemachine/StateMachineTurbine;
+}
+

--- a/state-machine/testing/build.gradle
+++ b/state-machine/testing/build.gradle
@@ -1,0 +1,49 @@
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.dokka)
+    alias(libs.plugins.publish)
+}
+
+android {
+    namespace = "com.freeletics.mad.statemachine.testing"
+    compileSdkVersion libs.versions.android.compile.get().toInteger()
+
+    defaultConfig {
+        minSdkVersion libs.versions.android.min.get().toInteger()
+    }
+
+    buildFeatures {
+        buildConfig = false
+    }
+
+    // still needed for Android projects despite toolchain
+    compileOptions {
+        sourceCompatibility(JavaVersion.toVersion(libs.versions.java.get()))
+        targetCompatibility(JavaVersion.toVersion(libs.versions.java.get()))
+    }
+}
+
+// workaround for https://youtrack.jetbrains.com/issue/KT-37652
+android.kotlinOptions.freeCompilerArgs += "-Xexplicit-api=strict"
+
+kotlin {
+    explicitApi()
+
+    jvmToolchain {
+        languageVersion.set(JavaLanguageVersion.of(libs.versions.java.get().toInteger()))
+    }
+}
+
+// workaround for https://issuetracker.google.com/issues/194113162
+tasks.withType(JavaCompile).configureEach {
+    javaCompiler = javaToolchains.compilerFor {
+        languageVersion = JavaLanguageVersion.of(libs.versions.java.get().toInteger())
+    }
+}
+
+dependencies {
+    api project(":state-machine")
+    api libs.coroutines.core
+    api libs.turbine
+}

--- a/state-machine/testing/gradle.properties
+++ b/state-machine/testing/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=state-machine-testing
+POM_NAME=StateMachine Testing
+POM_DESCRIPTION=StateMachine Testing

--- a/state-machine/testing/src/main/java/com/freeletics/mad/statemachine/StateMachineTurbine.kt
+++ b/state-machine/testing/src/main/java/com/freeletics/mad/statemachine/StateMachineTurbine.kt
@@ -55,16 +55,14 @@ public interface StateMachineTurbine<State : Any, Action : Any> {
      * Assert that the next event received was a new state. This function will suspend
      * if no events have been received.
      *
-     * Throws:
-     * AssertionError - if the next event was not a matching event.
+     * @throws AssertionError - if the next event was not a matching event.
      */
     public suspend fun awaitState(): State
 
     /**
      * Cancel this [StateMachineTurbine].
      *
-     * Throws:
-     * AssertionError - if there are any unconsumed events.
+     * @throws AssertionError - if there are any unconsumed events.
      */
     public suspend fun cancel()
 

--- a/state-machine/testing/src/main/java/com/freeletics/mad/statemachine/StateMachineTurbine.kt
+++ b/state-machine/testing/src/main/java/com/freeletics/mad/statemachine/StateMachineTurbine.kt
@@ -1,0 +1,98 @@
+package com.freeletics.mad.statemachine
+
+import app.cash.turbine.ReceiveTurbine
+import app.cash.turbine.test
+import app.cash.turbine.testIn
+import kotlin.time.Duration
+import kotlinx.coroutines.CoroutineScope
+
+/**
+ * Collects `state` from [StateMachine] and and allows the [validate] lambda to consume
+ * and assert properties on them in order. If any exception occurs during validation the
+ * exception is rethrown from this method.
+ *
+ * [timeout] - If non-null, overrides the current Turbine timeout inside validate.
+ */
+public suspend fun <State : Any, Action : Any> StateMachine<State, Action>.test(
+    timeout: Duration? = null,
+    name: String? = null,
+    validate: suspend StateMachineTurbine<State, Action>.() -> Unit,
+) {
+    val stateMachine = this
+    state.test(timeout, name) {
+        val turbine = DefaultStateMachineTurbine(stateMachine, this)
+        validate(turbine)
+    }
+}
+
+/**
+ * Collects `state` from [StateMachine] and returns a [StateMachineTurbine] for consuming
+ * and asserting properties on them in order. If any exception occurs during validation the
+ * exception is rethrown from this method.
+ *
+ * Unlike test which automatically cancels the flow at the end of the lambda, the returned
+ * StateMachineTurbine be explicitly canceled.
+ *
+ * [timeout] - If non-null, overrides the current Turbine timeout inside validate.
+ */
+public fun <State : Any, Action : Any> StateMachine<State, Action>.testIn(
+    scope: CoroutineScope,
+    timeout: Duration? = null,
+    name: String? = null,
+): StateMachineTurbine<State, Action> {
+    val turbine = state.testIn(scope, timeout, name)
+    return DefaultStateMachineTurbine(this, turbine)
+}
+
+public interface StateMachineTurbine<State : Any, Action : Any> {
+
+    /**
+     * Dispatch an [action] to the [StateMachine] under test.
+     */
+    public suspend fun dispatch(action: Action)
+
+    /**
+     * Assert that the next event received was a new state. This function will suspend
+     * if no events have been received.
+     *
+     * Throws:
+     * AssertionError - if the next event was not a matching event.
+     */
+    public suspend fun awaitState(): State
+
+    /**
+     * Cancel this [StateMachineTurbine].
+     *
+     * Throws:
+     * AssertionError - if there are any unconsumed events.
+     */
+    public suspend fun cancel()
+
+    /**
+     * Cancel this [StateMachineTurbine]. The difference to [cancel] is any unconsumed event will be
+     * ignored and no error will be thrown.
+     */
+    public suspend fun cancelAndIgnoreRemainingStates()
+}
+
+internal class DefaultStateMachineTurbine<State : Any, Action : Any>(
+    private val stateMachine: StateMachine<State, Action>,
+    private val turbine: ReceiveTurbine<State>,
+) : StateMachineTurbine<State, Action> {
+
+    override suspend fun dispatch(action: Action) {
+        stateMachine.dispatch(action)
+    }
+
+    override suspend fun awaitState(): State {
+        return turbine.awaitItem()
+    }
+
+    override suspend fun cancel() {
+        turbine.cancel()
+    }
+
+    override suspend fun cancelAndIgnoreRemainingStates() {
+        turbine.cancelAndIgnoreRemainingEvents()
+    }
+}


### PR DESCRIPTION
and also one for `StateMachine`. These are modeled after Turbine and sit on top of that. This allows to make all `VisibleForTesting` code internal or at least mark it as internal. The docs are also inspired/adapted from Turbine's docs.