### PR TITLE
add AppScope and make it the default parent/destinationScope

### DIFF
--- a/docs/whetstone/get-started.md
+++ b/docs/whetstone/get-started.md
@@ -58,7 +58,7 @@ it falls into the `Fragment` category.
     ```kotlin
     @ComposeScreen(
         scope = ExampleScope::class,
-        parentScope = AppScope::class,
+        parentScope = AppScope::class, // AppScope is the default value and can be omitted
         stateMachine = ExampleStateMachine::class,
     )
     @Composable
@@ -89,7 +89,7 @@ it falls into the `Fragment` category.
     ```kotlin
     @ComposeFragment(
         scope = ExampleScope::class,
-        parentScope = AppScope::class,
+        parentScope = AppScope::class, // AppScope is the default value and can be omitted
         stateMachine = ExampleStateMachine::class,
     )
     @Composable
@@ -127,7 +127,7 @@ it falls into the `Fragment` category.
     ```kotlin
     @RendererFragment(
         scope = ExampleScope::class,
-        parentScope = AppScope::class,
+        parentScope = AppScope::class, // AppScope is the default value and can be omitted
         stateMachine = ExampleStateMachine::class,
         rendererFactory = ExampleRenderer.Factory::class, // references the factory below
     )
@@ -208,7 +208,7 @@ internal class ExampleStateMachine @Inject constructor(
     ```kotlin
     @ComposeScreen(
         scope = ExampleScope::class, // uses our marker class
-        parentScope = AppScope::class, // the scope of the app level component
+        parentScope = AppScope::class, // the scope of the app level component, AppScope is the default value and can be omitted
         stateMachine = ExampleStateMachine::class, // the state machine used for this ui
     )
     @Composable
@@ -225,7 +225,7 @@ internal class ExampleStateMachine @Inject constructor(
     ```kotlin
     @ComposeFragment(
         scope = ExampleScope::class, // uses our marker class
-        parentScope = AppScope::class, // the scope of the app level component
+        parentScope = AppScope::class, // the scope of the app level component, AppScope is the default value and can be omitted
         stateMachine = ExampleStateMachine::class, // the state machine used for this ui
     )
     @Composable
@@ -242,7 +242,7 @@ internal class ExampleStateMachine @Inject constructor(
     ```kotlin
     @RendererFragment(
         scope = ExampleScope::class, // uses our marker class
-        parentScope = AppScope::class, // the scope of the app level component
+        parentScope = AppScope::class, // the scope of the app level component, AppScope is the default value and can be omitted
         rendererFactory = ExampleRenderer.Factory::class, // references the factory below
         stateMachine = ExampleStateMachine::class, // the state machine used for this ui
     )
@@ -263,7 +263,7 @@ Using this would require a one time setup in the app so that the screens can loo
 component through `getSystemService` to retrieve the parent component:
 
 ```kotlin
-@Singleton
+@AppScope
 @MergeComponent(scope = AppScope::class)
 interface AppComponent {
     // allows an Activity to get all generated NavDestinations to set up the NavHost
@@ -279,7 +279,7 @@ class App : Application() {
 
     private val component: AppComponent = DaggerAppComponent.factory().create(this)
     
-    override fun getSystemService(name: String): Any? {
+    override fun getSystemService(name: String): Any {
         if (name == AppScope::class.qualifiedName) {
             return component
         }

--- a/docs/whetstone/navigation.md
+++ b/docs/whetstone/navigation.md
@@ -44,10 +44,10 @@ on the appropriate `whetstone-navigation` artifact needs to be added:
     ```kotlin
     @ComposeDestination(
         route = ExampleRoute::class,
-        parentScope = AppScope::class,
+        parentScope = AppScope::class, // AppScope is the default value and can be omitted
         stateMachine = ExampleStateMachine::class,
         destinationType = DestintionType.SCREEN,
-        destinationScope = AppScope::class,
+        destinationScope = AppScope::class, // AppScope is the default value and can be omitted
     )
     @Composable
     fun ExampleUi(...) {...} // same as in general guide
@@ -67,10 +67,10 @@ on the appropriate `whetstone-navigation` artifact needs to be added:
     ```kotlin
     @ComposeDestination(
         route = ExampleRoute::class,
-        parentScope = AppScope::class,
+        parentScope = AppScope::class, // AppScope is the default value and can be omitted
         stateMachine = ExampleStateMachine::class,
         destinationType = DestintionType.SCREEN,
-        destinationScope = AppScope::class,
+        destinationScope = AppScope::class, // AppScope is the default value and can be omitted
     )
     @Composable
     fun ExampleUi(...) {...} // same as in general guide
@@ -89,10 +89,10 @@ on the appropriate `whetstone-navigation` artifact needs to be added:
     ```kotlin
     @RendererDestination(
         route = ExampleRoute::class,
-        parentScope = AppScope::class,
+        parentScope = AppScope::class, // AppScope is the default value and can be omitted
         stateMachine = ExampleStateMachine::class,
         destinationType = DestintionType.SCREEN,
-        destinationScope = AppScope::class,
+        destinationScope = AppScope::class, // AppScope is the default value and can be omitted
         rendererFactory = ExampleRenderer.Factory::class,
     )
     internal class ExampleRenderer ... // same as in general guide
@@ -145,10 +145,10 @@ class ExampleNavigator @Inject constructor() : NavEventNavigator() {
     ```kotlin
     @ComposeDestination(
         route = ExampleRoute::class, // the route used to navigate to ExampleUi
-        parentScope = AppScope::class, // the scope of the app level component
+        parentScope = AppScope::class, // the scope of the app level component, AppScope is the default value and can be omitted
         stateMachine = ExampleStateMachine::class, // the state machine used for this ui
         destinationType = DestinationType.SCREEN, // whether it's a screen, dialog or bottom sheet
-        destinationScope = AppScope::class, // contribute the generated destination to AppScope
+        destinationScope = AppScope::class, // contribute the generated destination to AppScope, AppScope is the default value and can be omitted
     )
     @Composable
     internal fun ExampleUi(
@@ -164,10 +164,10 @@ class ExampleNavigator @Inject constructor() : NavEventNavigator() {
     ```kotlin
     @ComposeDestination(
         route = ExampleRoute::class, // the route used to navigate to ExampleUi
-        parentScope = AppScope::class, // the scope of the app level component
+        parentScope = AppScope::class, // the scope of the app level component, AppScope is the default value and can be omitted
         stateMachine = ExampleStateMachine::class, // the state machine used for this ui
         destinationType = DestinationType.SCREEN, // whether it's a screen, dialog or bottom sheet
-        destinationScope = AppScope::class, // contribute the generated destination to AppScope
+        destinationScope = AppScope::class, // contribute the generated destination to AppScope, AppScope is the default value and can be omitted
     )
     @Composable
     internal fun ExampleUi(
@@ -183,11 +183,11 @@ class ExampleNavigator @Inject constructor() : NavEventNavigator() {
     ```kotlin
     @RendererDestination(
         route = ExampleRoute::class, // the route used to navigate to ExampleRenderer
-        parentScope = AppScope::class, // the scope of the app level component
+        parentScope = AppScope::class, // the scope of the app level component, AppScope is the default value and can be omitted
         rendererFactory = ExampleRenderer.Factory::class, // references the factory below
         stateMachine = ExampleStateMachine::class, // the state machine used fo
         destinationType = DestinationType.SCREEN, // whether it's a screen, dialog or bottom sheet
-        destinationScope = AppScope::class, // contribute the generated destination to AppScope
+        destinationScope = AppScope::class, // contribute the generated destination to AppScope, AppScope is the default value and can be omitted
     )
     internal class ExampleRenderer @AssistedInject constructor(
         @Assisted private val binding: ExampleViewBinding,

--- a/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
+++ b/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
@@ -1,5 +1,6 @@
 package com.freeletics.mad.whetstone.codegen
 
+import com.freeletics.mad.whetstone.AppScope
 import com.freeletics.mad.whetstone.ComposableParameter
 import com.freeletics.mad.whetstone.ComposeScreenData
 import com.freeletics.mad.whetstone.NavEntryData
@@ -10,6 +11,7 @@ import com.squareup.kotlinpoet.MAP
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.SET
 import com.squareup.kotlinpoet.STRING
+import com.squareup.kotlinpoet.asClassName
 import org.junit.Test
 
 internal class FileGeneratorTestCompose {
@@ -502,6 +504,220 @@ internal class FileGeneratorTestCompose {
         """.trimIndent()
 
         test(withNavEntry, "com/test/Test.kt", source, expected)
+    }
+
+    @Test
+    fun `generates code for ComposeScreenData with default values`() {
+        val navigation = navigation.copy(destinationScope = AppScope::class.asClassName())
+        val withDefaultValues = data.copy(
+            scope = navigation.route,
+            parentScope = AppScope::class.asClassName(),
+            navigation = navigation,
+            navEntryData = navEntryData.copy(
+                parentScope = AppScope::class.asClassName(),
+                navigation = navigation
+            ),
+        )
+
+        val source = """
+            package com.test
+            
+            import androidx.compose.runtime.Composable
+            import com.freeletics.mad.whetstone.compose.ComposeDestination
+            import com.freeletics.mad.whetstone.compose.DestinationType
+            import com.freeletics.mad.whetstone.NavEntryComponent
+            
+            @ComposeDestination(
+              route = TestRoute::class,
+              stateMachine = TestStateMachine::class,
+              destinationType = DestinationType.SCREEN,
+            )
+            @NavEntryComponent(
+              scope = TestScreen::class,
+            )
+            @Composable
+            public fun Test(
+              state: TestState,
+              sendAction: (TestAction) -> Unit
+            ) {}
+        """.trimIndent()
+
+        val expected = """
+            package com.test
+
+            import android.content.Context
+            import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.rememberCoroutineScope
+            import androidx.lifecycle.SavedStateHandle
+            import com.freeletics.mad.navigator.NavEventNavigator
+            import com.freeletics.mad.navigator.`internal`.InternalNavigatorApi
+            import com.freeletics.mad.navigator.`internal`.NavigationExecutor
+            import com.freeletics.mad.navigator.compose.NavDestination
+            import com.freeletics.mad.navigator.compose.NavigationSetup
+            import com.freeletics.mad.navigator.compose.ScreenDestination
+            import com.freeletics.mad.whetstone.AppScope
+            import com.freeletics.mad.whetstone.NavEntry
+            import com.freeletics.mad.whetstone.ScopeTo
+            import com.freeletics.mad.whetstone.`internal`.DestinationComponent
+            import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
+            import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetter
+            import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetterKey
+            import com.freeletics.mad.whetstone.`internal`.asComposeState
+            import com.freeletics.mad.whetstone.`internal`.navEntryComponent
+            import com.freeletics.mad.whetstone.compose.`internal`.rememberComponent
+            import com.squareup.anvil.annotations.ContributesMultibinding
+            import com.squareup.anvil.annotations.ContributesSubcomponent
+            import com.squareup.anvil.annotations.ContributesTo
+            import dagger.BindsInstance
+            import dagger.Module
+            import dagger.Provides
+            import dagger.multibindings.IntoSet
+            import dagger.multibindings.Multibinds
+            import java.io.Closeable
+            import javax.inject.Inject
+            import kotlin.Any
+            import kotlin.OptIn
+            import kotlin.Unit
+            import kotlin.collections.Set
+            import kotlinx.coroutines.launch
+
+            @OptIn(InternalWhetstoneApi::class)
+            @ScopeTo(TestRoute::class)
+            @ContributesSubcomponent(
+              scope = TestRoute::class,
+              parentScope = AppScope::class,
+            )
+            public interface WhetstoneTestComponent : Closeable {
+              public val testStateMachine: TestStateMachine
+
+              public val navEventNavigator: NavEventNavigator
+
+              public val closeables: Set<Closeable>
+    
+              public override fun close(): Unit {
+                closeables.forEach {
+                  it.close()
+                }
+              }
+
+              @ContributesSubcomponent.Factory
+              public interface Factory {
+                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
+                    testRoute: TestRoute): WhetstoneTestComponent
+              }
+
+              @ContributesTo(AppScope::class)
+              public interface ParentComponent {
+                public fun whetstoneTestComponentFactory(): Factory
+              }
+            }
+
+            @Module
+            @ContributesTo(TestRoute::class)
+            public interface WhetstoneTestModule {
+              @Multibinds
+              public fun bindCloseables(): Set<Closeable>
+            }
+
+            @Composable
+            @OptIn(InternalWhetstoneApi::class)
+            public fun WhetstoneTest(testRoute: TestRoute): Unit {
+              val component = rememberComponent(AppScope::class, AppScope::class, testRoute) { parentComponent:
+                  WhetstoneTestComponent.ParentComponent, savedStateHandle, testRoute ->
+                parentComponent.whetstoneTestComponentFactory().create(savedStateHandle, testRoute)
+              }
+
+              NavigationSetup(component.navEventNavigator)
+
+              WhetstoneTest(component)
+            }
+
+            @Composable
+            @OptIn(InternalWhetstoneApi::class)
+            private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
+              val stateMachine = component.testStateMachine
+              val state = stateMachine.asComposeState()
+              val currentState = state.value
+              if (currentState != null) {
+                val scope = rememberCoroutineScope()
+                Test(
+                  state = currentState,
+                  sendAction = { scope.launch { stateMachine.dispatch(it) } },
+                )
+              }
+            }
+
+            @Module
+            @ContributesTo(AppScope::class)
+            public object WhetstoneTestNavDestinationModule {
+              @Provides
+              @IntoSet
+              public fun provideNavDestination(): NavDestination = ScreenDestination<TestRoute> {
+                WhetstoneTest(it)
+              }
+            }
+
+            @OptIn(InternalWhetstoneApi::class)
+            @ScopeTo(TestScreen::class)
+            @ContributesSubcomponent(
+              scope = TestScreen::class,
+              parentScope = AppScope::class,
+            )
+            public interface WhetstoneTestScreenNavEntryComponent : Closeable {
+              @get:NavEntry(TestScreen::class)
+              public val closeables: Set<Closeable>
+    
+              public override fun close(): Unit {
+                closeables.forEach {
+                  it.close()
+                }
+              }
+
+              @ContributesSubcomponent.Factory
+              public interface Factory {
+                public fun create(@BindsInstance @NavEntry(TestScreen::class)
+                    savedStateHandle: SavedStateHandle, @BindsInstance @NavEntry(TestScreen::class)
+                    testRoute: TestRoute): WhetstoneTestScreenNavEntryComponent
+              }
+
+              @ContributesTo(AppScope::class)
+              public interface ParentComponent {
+                public fun whetstoneTestScreenNavEntryComponentFactory(): Factory
+              }
+            }
+
+            @Module
+            @ContributesTo(TestScreen::class)
+            public interface WhetstoneTestScreenNavEntryModule {
+              @Multibinds
+              @NavEntry(TestScreen::class)
+              public fun bindCloseables(): Set<Closeable>
+            }
+
+            @OptIn(InternalWhetstoneApi::class)
+            @NavEntryComponentGetterKey(TestScreen::class)
+            @ContributesMultibinding(
+              AppScope::class,
+              NavEntryComponentGetter::class,
+            )
+            public class TestScreenNavEntryComponentGetter @Inject constructor() : NavEntryComponentGetter {
+              @OptIn(InternalWhetstoneApi::class, InternalNavigatorApi::class)
+              public override fun retrieve(executor: NavigationExecutor, context: Context): Any =
+                  navEntryComponent(TestRoute::class, executor, context, AppScope::class, AppScope::class) {
+                  parentComponent: WhetstoneTestScreenNavEntryComponent.ParentComponent, savedStateHandle,
+                  testRoute ->
+                parentComponent.whetstoneTestScreenNavEntryComponentFactory().create(savedStateHandle,
+                    testRoute)
+              }
+            }
+
+            @ContributesTo(AppScope::class)
+            @OptIn(InternalWhetstoneApi::class)
+            public interface WhetstoneTestScreenNavEntryDestinationComponent : DestinationComponent
+
+        """.trimIndent()
+
+        test(withDefaultValues, "com/test/Test.kt", source, expected)
     }
 
     @Test

--- a/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
+++ b/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
@@ -1,5 +1,6 @@
 package com.freeletics.mad.whetstone.codegen
 
+import com.freeletics.mad.whetstone.AppScope
 import com.freeletics.mad.whetstone.ComposableParameter
 import com.freeletics.mad.whetstone.ComposeFragmentData
 import com.freeletics.mad.whetstone.NavEntryData
@@ -10,6 +11,7 @@ import com.squareup.kotlinpoet.MAP
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.SET
 import com.squareup.kotlinpoet.STRING
+import com.squareup.kotlinpoet.asClassName
 import org.junit.Test
 
 internal class FileGeneratorTestComposeFragment {
@@ -573,6 +575,243 @@ internal class FileGeneratorTestComposeFragment {
         """.trimIndent()
 
         test(withNavEntry, "com/test/Test.kt", source, expected)
+    }
+
+    @Test
+    fun `generates code for ComposeFragmentData with default values`() {
+        val navigation = navigation.copy(destinationScope = AppScope::class.asClassName())
+        val withDefaultValues = data.copy(
+            scope = navigation.route,
+            parentScope = AppScope::class.asClassName(),
+            navigation = navigation,
+            navEntryData = navEntryData.copy(
+                parentScope = AppScope::class.asClassName(),
+                navigation = navigation
+            ),
+        )
+
+        val source = """
+            package com.test
+            
+            import androidx.compose.runtime.Composable
+            import com.freeletics.mad.whetstone.fragment.ComposeDestination
+            import com.freeletics.mad.whetstone.fragment.DestinationType
+            import com.freeletics.mad.whetstone.NavEntryComponent
+            
+            @ComposeDestination(
+              route = TestRoute::class,
+              stateMachine = TestStateMachine::class,
+              destinationType = DestinationType.SCREEN,
+            )
+            @NavEntryComponent(
+              scope = TestScreen::class,
+            )
+            @Composable
+            public fun Test(
+              state: TestState,
+              sendAction: (TestAction) -> Unit
+            ) {}
+        """.trimIndent()
+
+        val expected = """
+            package com.test
+
+            import android.content.Context
+            import android.os.Bundle
+            import android.view.LayoutInflater
+            import android.view.View
+            import android.view.ViewGroup
+            import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.rememberCoroutineScope
+            import androidx.compose.ui.platform.ComposeView
+            import androidx.compose.ui.platform.ViewCompositionStrategy
+            import androidx.fragment.app.Fragment
+            import androidx.lifecycle.SavedStateHandle
+            import com.freeletics.mad.navigator.NavEventNavigator
+            import com.freeletics.mad.navigator.`internal`.InternalNavigatorApi
+            import com.freeletics.mad.navigator.`internal`.NavigationExecutor
+            import com.freeletics.mad.navigator.fragment.NavDestination
+            import com.freeletics.mad.navigator.fragment.ScreenDestination
+            import com.freeletics.mad.navigator.fragment.handleNavigation
+            import com.freeletics.mad.navigator.fragment.requireRoute
+            import com.freeletics.mad.whetstone.AppScope
+            import com.freeletics.mad.whetstone.NavEntry
+            import com.freeletics.mad.whetstone.ScopeTo
+            import com.freeletics.mad.whetstone.`internal`.DestinationComponent
+            import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
+            import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetter
+            import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetterKey
+            import com.freeletics.mad.whetstone.`internal`.asComposeState
+            import com.freeletics.mad.whetstone.`internal`.navEntryComponent
+            import com.freeletics.mad.whetstone.fragment.`internal`.component
+            import com.squareup.anvil.annotations.ContributesMultibinding
+            import com.squareup.anvil.annotations.ContributesSubcomponent
+            import com.squareup.anvil.annotations.ContributesTo
+            import dagger.BindsInstance
+            import dagger.Module
+            import dagger.Provides
+            import dagger.multibindings.IntoSet
+            import dagger.multibindings.Multibinds
+            import java.io.Closeable
+            import javax.inject.Inject
+            import kotlin.Any
+            import kotlin.OptIn
+            import kotlin.Unit
+            import kotlin.collections.Set
+            import kotlinx.coroutines.launch
+
+            @OptIn(InternalWhetstoneApi::class)
+            @ScopeTo(TestRoute::class)
+            @ContributesSubcomponent(
+              scope = TestRoute::class,
+              parentScope = AppScope::class,
+            )
+            public interface WhetstoneTestComponent : Closeable {
+              public val testStateMachine: TestStateMachine
+
+              public val navEventNavigator: NavEventNavigator
+
+              public val closeables: Set<Closeable>
+    
+              public override fun close(): Unit {
+                closeables.forEach {
+                  it.close()
+                }
+              }
+
+              @ContributesSubcomponent.Factory
+              public interface Factory {
+                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
+                    testRoute: TestRoute): WhetstoneTestComponent
+              }
+
+              @ContributesTo(AppScope::class)
+              public interface ParentComponent {
+                public fun whetstoneTestComponentFactory(): Factory
+              }
+            }
+
+            @Module
+            @ContributesTo(TestRoute::class)
+            public interface WhetstoneTestModule {
+              @Multibinds
+              public fun bindCloseables(): Set<Closeable>
+            }
+
+            @OptIn(InternalWhetstoneApi::class)
+            public class WhetstoneTestFragment : Fragment() {
+              private lateinit var whetstoneTestComponent: WhetstoneTestComponent
+
+              public override fun onCreateView(
+                inflater: LayoutInflater,
+                container: ViewGroup?,
+                savedInstanceState: Bundle?,
+              ): View {
+                if (!::whetstoneTestComponent.isInitialized) {
+                  val testRoute = requireRoute<TestRoute>()
+                  whetstoneTestComponent = component(AppScope::class, AppScope::class, testRoute) {
+                      parentComponent: WhetstoneTestComponent.ParentComponent, savedStateHandle, testRoute ->
+                    parentComponent.whetstoneTestComponentFactory().create(savedStateHandle, testRoute)
+                  }
+
+                  handleNavigation(this, whetstoneTestComponent.navEventNavigator)
+                }
+
+                return ComposeView(requireContext()).apply {
+                  setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnLifecycleDestroyed(viewLifecycleOwner))
+
+                  setContent {
+                    WhetstoneTest(whetstoneTestComponent)
+                  }
+                }
+              }
+            }
+
+            @Composable
+            @OptIn(InternalWhetstoneApi::class)
+            private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
+              val stateMachine = component.testStateMachine
+              val state = stateMachine.asComposeState()
+              val currentState = state.value
+              if (currentState != null) {
+                val scope = rememberCoroutineScope()
+                Test(
+                  state = currentState,
+                  sendAction = { scope.launch { stateMachine.dispatch(it) } },
+                )
+              }
+            }
+
+            @Module
+            @ContributesTo(AppScope::class)
+            public object WhetstoneTestNavDestinationModule {
+              @Provides
+              @IntoSet
+              public fun provideNavDestination(): NavDestination = ScreenDestination<TestRoute,
+                  WhetstoneTestFragment>()
+            }
+
+            @OptIn(InternalWhetstoneApi::class)
+            @ScopeTo(TestScreen::class)
+            @ContributesSubcomponent(
+              scope = TestScreen::class,
+              parentScope = AppScope::class,
+            )
+            public interface WhetstoneTestScreenNavEntryComponent : Closeable {
+              @get:NavEntry(TestScreen::class)
+              public val closeables: Set<Closeable>
+    
+              public override fun close(): Unit {
+                closeables.forEach {
+                  it.close()
+                }
+              }
+
+              @ContributesSubcomponent.Factory
+              public interface Factory {
+                public fun create(@BindsInstance @NavEntry(TestScreen::class)
+                    savedStateHandle: SavedStateHandle, @BindsInstance @NavEntry(TestScreen::class)
+                    testRoute: TestRoute): WhetstoneTestScreenNavEntryComponent
+              }
+
+              @ContributesTo(AppScope::class)
+              public interface ParentComponent {
+                public fun whetstoneTestScreenNavEntryComponentFactory(): Factory
+              }
+            }
+
+            @Module
+            @ContributesTo(TestScreen::class)
+            public interface WhetstoneTestScreenNavEntryModule {
+              @Multibinds
+              @NavEntry(TestScreen::class)
+              public fun bindCloseables(): Set<Closeable>
+            }
+
+            @OptIn(InternalWhetstoneApi::class)
+            @NavEntryComponentGetterKey(TestScreen::class)
+            @ContributesMultibinding(
+              AppScope::class,
+              NavEntryComponentGetter::class,
+            )
+            public class TestScreenNavEntryComponentGetter @Inject constructor() : NavEntryComponentGetter {
+              @OptIn(InternalWhetstoneApi::class, InternalNavigatorApi::class)
+              public override fun retrieve(executor: NavigationExecutor, context: Context): Any =
+                  navEntryComponent(TestRoute::class, executor, context, AppScope::class, AppScope::class) {
+                  parentComponent: WhetstoneTestScreenNavEntryComponent.ParentComponent, savedStateHandle,
+                  testRoute ->
+                parentComponent.whetstoneTestScreenNavEntryComponentFactory().create(savedStateHandle,
+                    testRoute)
+              }
+            }
+
+            @ContributesTo(AppScope::class)
+            @OptIn(InternalWhetstoneApi::class)
+            public interface WhetstoneTestScreenNavEntryDestinationComponent : DestinationComponent
+
+        """.trimIndent()
+
+        test(withDefaultValues, "com/test/Test.kt", source, expected)
     }
 
     @Test

--- a/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestRendererFragment.kt
+++ b/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestRendererFragment.kt
@@ -1,9 +1,11 @@
 package com.freeletics.mad.whetstone.codegen
 
+import com.freeletics.mad.whetstone.AppScope
 import com.freeletics.mad.whetstone.NavEntryData
 import com.freeletics.mad.whetstone.Navigation
 import com.freeletics.mad.whetstone.RendererFragmentData
 import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.asClassName
 import org.junit.Test
 
 internal class FileGeneratorTestRendererFragment {
@@ -509,6 +511,224 @@ internal class FileGeneratorTestRendererFragment {
         """.trimIndent()
 
         test(withDestination, "com/test/TestRenderer.kt", source, expected)
+    }
+
+    @Test
+    fun `generates code for RendererFragmentData with default values`() {
+        val navigation = navigation.copy(destinationScope = AppScope::class.asClassName())
+        val withDefaultValues = data.copy(
+            scope = navigation.route,
+            parentScope = AppScope::class.asClassName(),
+            navigation = navigation,
+            navEntryData = navEntryData.copy(
+                parentScope = AppScope::class.asClassName(),
+                navigation = navigation
+            ),
+        )
+
+        val source = """
+            package com.test
+            
+            import android.view.View
+            import com.freeletics.mad.whetstone.fragment.RendererDestination
+            import com.freeletics.mad.whetstone.fragment.DestinationType
+            import com.freeletics.mad.whetstone.NavEntryComponent
+            import com.gabrielittner.renderer.ViewRenderer
+            
+            @RendererDestination(
+              route = TestRoute::class,
+              stateMachine = TestStateMachine::class,
+              rendererFactory = TestRenderer.Factory::class,
+              destinationType = DestinationType.SCREEN,
+            )
+            @NavEntryComponent(
+              scope = TestScreen::class,
+            )
+            public class TestRenderer(view: View) : ViewRenderer<TestState, TestAction>(view) {
+              override fun renderToView(state: TestState) {}
+            
+              public abstract class Factory : ViewRenderer.Factory<TestBinding, TestRenderer>({ _, _, _ -> TestBinding() })
+            }
+        """.trimIndent()
+
+        val expected = """
+            package com.test
+
+            import android.content.Context
+            import android.os.Bundle
+            import android.view.LayoutInflater
+            import android.view.View
+            import android.view.ViewGroup
+            import androidx.fragment.app.Fragment
+            import androidx.lifecycle.SavedStateHandle
+            import com.freeletics.mad.navigator.NavEventNavigator
+            import com.freeletics.mad.navigator.`internal`.InternalNavigatorApi
+            import com.freeletics.mad.navigator.`internal`.NavigationExecutor
+            import com.freeletics.mad.navigator.fragment.NavDestination
+            import com.freeletics.mad.navigator.fragment.ScreenDestination
+            import com.freeletics.mad.navigator.fragment.handleNavigation
+            import com.freeletics.mad.navigator.fragment.requireRoute
+            import com.freeletics.mad.whetstone.AppScope
+            import com.freeletics.mad.whetstone.NavEntry
+            import com.freeletics.mad.whetstone.ScopeTo
+            import com.freeletics.mad.whetstone.`internal`.DestinationComponent
+            import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
+            import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetter
+            import com.freeletics.mad.whetstone.`internal`.NavEntryComponentGetterKey
+            import com.freeletics.mad.whetstone.`internal`.navEntryComponent
+            import com.freeletics.mad.whetstone.fragment.`internal`.component
+            import com.gabrielittner.renderer.connect.connect
+            import com.squareup.anvil.annotations.ContributesMultibinding
+            import com.squareup.anvil.annotations.ContributesSubcomponent
+            import com.squareup.anvil.annotations.ContributesTo
+            import dagger.BindsInstance
+            import dagger.Module
+            import dagger.Provides
+            import dagger.multibindings.IntoSet
+            import dagger.multibindings.Multibinds
+            import java.io.Closeable
+            import javax.inject.Inject
+            import kotlin.Any
+            import kotlin.OptIn
+            import kotlin.Unit
+            import kotlin.collections.Set
+
+            @OptIn(InternalWhetstoneApi::class)
+            @ScopeTo(TestRoute::class)
+            @ContributesSubcomponent(
+              scope = TestRoute::class,
+              parentScope = AppScope::class,
+            )
+            public interface WhetstoneTestRendererComponent : Closeable {
+              public val testStateMachine: TestStateMachine
+
+              public val navEventNavigator: NavEventNavigator
+
+              public val testRendererFactory: TestRenderer.Factory
+
+              public val closeables: Set<Closeable>
+    
+              public override fun close(): Unit {
+                closeables.forEach {
+                  it.close()
+                }
+              }
+
+              @ContributesSubcomponent.Factory
+              public interface Factory {
+                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
+                    testRoute: TestRoute): WhetstoneTestRendererComponent
+              }
+
+              @ContributesTo(AppScope::class)
+              public interface ParentComponent {
+                public fun whetstoneTestRendererComponentFactory(): Factory
+              }
+            }
+
+            @Module
+            @ContributesTo(TestRoute::class)
+            public interface WhetstoneTestRendererModule {
+              @Multibinds
+              public fun bindCloseables(): Set<Closeable>
+            }
+
+            @OptIn(InternalWhetstoneApi::class)
+            public class WhetstoneTestRendererFragment : Fragment() {
+              private lateinit var whetstoneTestRendererComponent: WhetstoneTestRendererComponent
+
+              public override fun onCreateView(
+                inflater: LayoutInflater,
+                container: ViewGroup?,
+                savedInstanceState: Bundle?,
+              ): View {
+                if (!::whetstoneTestRendererComponent.isInitialized) {
+                  val testRoute = requireRoute<TestRoute>()
+                  whetstoneTestRendererComponent = component(AppScope::class, AppScope::class, testRoute) {
+                      parentComponent: WhetstoneTestRendererComponent.ParentComponent, savedStateHandle,
+                      testRoute ->
+                    parentComponent.whetstoneTestRendererComponentFactory().create(savedStateHandle, testRoute)
+                  }
+
+                  handleNavigation(this, whetstoneTestRendererComponent.navEventNavigator)
+                }
+
+                val renderer = whetstoneTestRendererComponent.testRendererFactory.inflate(inflater, container)
+                connect(renderer, whetstoneTestRendererComponent.testStateMachine)
+                return renderer.rootView
+              }
+            }
+
+            @Module
+            @ContributesTo(AppScope::class)
+            public object WhetstoneTestRendererNavDestinationModule {
+              @Provides
+              @IntoSet
+              public fun provideNavDestination(): NavDestination = ScreenDestination<TestRoute,
+                  WhetstoneTestRendererFragment>()
+            }
+
+            @OptIn(InternalWhetstoneApi::class)
+            @ScopeTo(TestScreen::class)
+            @ContributesSubcomponent(
+              scope = TestScreen::class,
+              parentScope = AppScope::class,
+            )
+            public interface WhetstoneTestScreenNavEntryComponent : Closeable {
+              @get:NavEntry(TestScreen::class)
+              public val closeables: Set<Closeable>
+    
+              public override fun close(): Unit {
+                closeables.forEach {
+                  it.close()
+                }
+              }
+
+              @ContributesSubcomponent.Factory
+              public interface Factory {
+                public fun create(@BindsInstance @NavEntry(TestScreen::class)
+                    savedStateHandle: SavedStateHandle, @BindsInstance @NavEntry(TestScreen::class)
+                    testRoute: TestRoute): WhetstoneTestScreenNavEntryComponent
+              }
+
+              @ContributesTo(AppScope::class)
+              public interface ParentComponent {
+                public fun whetstoneTestScreenNavEntryComponentFactory(): Factory
+              }
+            }
+
+            @Module
+            @ContributesTo(TestScreen::class)
+            public interface WhetstoneTestScreenNavEntryModule {
+              @Multibinds
+              @NavEntry(TestScreen::class)
+              public fun bindCloseables(): Set<Closeable>
+            }
+
+            @OptIn(InternalWhetstoneApi::class)
+            @NavEntryComponentGetterKey(TestScreen::class)
+            @ContributesMultibinding(
+              AppScope::class,
+              NavEntryComponentGetter::class,
+            )
+            public class TestScreenNavEntryComponentGetter @Inject constructor() : NavEntryComponentGetter {
+              @OptIn(InternalWhetstoneApi::class, InternalNavigatorApi::class)
+              public override fun retrieve(executor: NavigationExecutor, context: Context): Any =
+                  navEntryComponent(TestRoute::class, executor, context, AppScope::class, AppScope::class) {
+                  parentComponent: WhetstoneTestScreenNavEntryComponent.ParentComponent, savedStateHandle,
+                  testRoute ->
+                parentComponent.whetstoneTestScreenNavEntryComponentFactory().create(savedStateHandle,
+                    testRoute)
+              }
+            }
+
+            @ContributesTo(AppScope::class)
+            @OptIn(InternalWhetstoneApi::class)
+            public interface WhetstoneTestScreenNavEntryDestinationComponent : DestinationComponent
+            
+        """.trimIndent()
+
+        test(withDefaultValues, "com/test/TestRenderer.kt", source, expected)
     }
 
     @Test

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
@@ -22,6 +22,7 @@ internal val composeNavDestinationFqName = FqName(composeNavDestination.canonica
 internal val composeRootNavDestination = ClassName("com.freeletics.mad.whetstone.compose", "RootNavDestination")
 internal val composeRootNavDestinationFqName = FqName(composeRootNavDestination.canonicalName)
 internal val scopeTo = ClassName("com.freeletics.mad.whetstone", "ScopeTo")
+internal val appScope = ClassName("com.freeletics.mad.whetstone", "AppScope")
 internal val navEntry = ClassName("com.freeletics.mad.whetstone", "NavEntry")
 internal val navEntryComponent = ClassName("com.freeletics.mad.whetstone", "NavEntryComponent")
 internal val navEntryComponentFqName = FqName(navEntryComponent.canonicalName)

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/parser/CommonParser.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/parser/CommonParser.kt
@@ -3,6 +3,7 @@ package com.freeletics.mad.whetstone.parser
 import com.freeletics.mad.whetstone.ComposableParameter
 import com.freeletics.mad.whetstone.NavEntryData
 import com.freeletics.mad.whetstone.Navigation
+import com.freeletics.mad.whetstone.codegen.util.appScope
 import com.freeletics.mad.whetstone.codegen.util.navEntryComponentFqName
 import com.squareup.anvil.annotations.ExperimentalAnvilApi
 import com.squareup.anvil.compiler.internal.reference.AnnotatedReference
@@ -21,7 +22,7 @@ internal val AnnotationReference.route: ClassName
 
 @OptIn(ExperimentalAnvilApi::class)
 internal val AnnotationReference.parentScope: ClassName
-    get() = requireClassArgument("parentScope", 1)
+    get() = optionalClassArgument("parentScope", 1)?: appScope
 
 @OptIn(ExperimentalAnvilApi::class)
 internal val AnnotationReference.stateMachine: ClassName
@@ -33,7 +34,7 @@ internal val AnnotationReference.destinationType: String
 
 @OptIn(ExperimentalAnvilApi::class)
 internal val AnnotationReference.destinationScope: ClassName
-    get() = requireClassArgument("destinationScope", 4)
+    get() = optionalClassArgument("destinationScope", 4) ?: appScope
 
 @OptIn(ExperimentalAnvilApi::class)
 internal fun AnnotatedReference.navEntryData(

--- a/whetstone/navigation-compose/src/main/java/com/freeletics/mad/whetstone/compose/ComposeDestination.kt
+++ b/whetstone/navigation-compose/src/main/java/com/freeletics/mad/whetstone/compose/ComposeDestination.kt
@@ -2,6 +2,7 @@ package com.freeletics.mad.whetstone.compose
 
 import com.freeletics.mad.navigator.BaseRoute
 import com.freeletics.mad.statemachine.StateMachine
+import com.freeletics.mad.whetstone.AppScope
 import kotlin.reflect.KClass
 
 /**
@@ -19,8 +20,8 @@ import kotlin.reflect.KClass
 @Retention(AnnotationRetention.RUNTIME)
 public annotation class ComposeDestination(
     val route: KClass<out BaseRoute>,
-    val parentScope: KClass<*>,
+    val parentScope: KClass<*> = AppScope::class,
     val stateMachine: KClass<out StateMachine<*, *>>,
     val destinationType: DestinationType = DestinationType.SCREEN,
-    val destinationScope: KClass<*>,
+    val destinationScope: KClass<*> = AppScope::class,
 )

--- a/whetstone/navigation-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/ComposeDestination.kt
+++ b/whetstone/navigation-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/ComposeDestination.kt
@@ -3,6 +3,7 @@ package com.freeletics.mad.whetstone.fragment
 import androidx.fragment.app.Fragment
 import com.freeletics.mad.navigator.BaseRoute
 import com.freeletics.mad.statemachine.StateMachine
+import com.freeletics.mad.whetstone.AppScope
 import kotlin.reflect.KClass
 
 /**
@@ -20,9 +21,9 @@ import kotlin.reflect.KClass
 @Retention(AnnotationRetention.RUNTIME)
 public annotation class ComposeDestination(
     val route: KClass<out BaseRoute>,
-    val parentScope: KClass<*>,
+    val parentScope: KClass<*> = AppScope::class,
     val stateMachine: KClass<out StateMachine<*, *>>,
     val destinationType: DestinationType = DestinationType.SCREEN,
-    val destinationScope: KClass<*>,
+    val destinationScope: KClass<*> = AppScope::class,
     val fragmentBaseClass: KClass<out Fragment> = Fragment::class,
 )

--- a/whetstone/navigation-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/RendererDestination.kt
+++ b/whetstone/navigation-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/RendererDestination.kt
@@ -3,6 +3,7 @@ package com.freeletics.mad.whetstone.fragment
 import androidx.fragment.app.Fragment
 import com.freeletics.mad.navigator.BaseRoute
 import com.freeletics.mad.statemachine.StateMachine
+import com.freeletics.mad.whetstone.AppScope
 import com.gabrielittner.renderer.ViewRenderer
 import kotlin.reflect.KClass
 
@@ -20,10 +21,10 @@ import kotlin.reflect.KClass
 @Retention(AnnotationRetention.RUNTIME)
 public annotation class RendererDestination(
     val route: KClass<out BaseRoute>,
-    val parentScope: KClass<*>,
+    val parentScope: KClass<*> = AppScope::class,
     val stateMachine: KClass<out StateMachine<*, *>>,
     val destinationType: DestinationType = DestinationType.SCREEN,
-    val destinationScope: KClass<*>,
+    val destinationScope: KClass<*> = AppScope::class,
     val fragmentBaseClass: KClass<out Fragment> = Fragment::class,
     val rendererFactory: KClass<out ViewRenderer.Factory<*, *>>,
 )

--- a/whetstone/navigation/src/main/java/com/freeletics/mad/whetstone/NavEntryComponent.kt
+++ b/whetstone/navigation/src/main/java/com/freeletics/mad/whetstone/NavEntryComponent.kt
@@ -46,5 +46,5 @@ import kotlin.reflect.KClass
 @Retention(RUNTIME)
 public annotation class NavEntryComponent(
     val scope: KClass<*>,
-    val parentScope: KClass<*>,
+    val parentScope: KClass<*> = AppScope::class,
 )

--- a/whetstone/runtime-compose/src/main/java/com/freeletics/mad/whetstone/compose/ComposeScreen.kt
+++ b/whetstone/runtime-compose/src/main/java/com/freeletics/mad/whetstone/compose/ComposeScreen.kt
@@ -1,6 +1,7 @@
 package com.freeletics.mad.whetstone.compose
 
 import com.freeletics.mad.statemachine.StateMachine
+import com.freeletics.mad.whetstone.AppScope
 import kotlin.reflect.KClass
 
 /**
@@ -19,6 +20,6 @@ import kotlin.reflect.KClass
 @Retention(AnnotationRetention.RUNTIME)
 public annotation class ComposeScreen(
     val scope: KClass<*>,
-    val parentScope: KClass<*>,
+    val parentScope: KClass<*> = AppScope::class,
     val stateMachine: KClass<out StateMachine<*, *>>,
 )

--- a/whetstone/runtime-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/ComposeFragment.kt
+++ b/whetstone/runtime-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/ComposeFragment.kt
@@ -2,6 +2,7 @@ package com.freeletics.mad.whetstone.fragment
 
 import androidx.fragment.app.Fragment
 import com.freeletics.mad.statemachine.StateMachine
+import com.freeletics.mad.whetstone.AppScope
 import kotlin.reflect.KClass
 
 /**
@@ -17,7 +18,7 @@ import kotlin.reflect.KClass
 @Retention(AnnotationRetention.RUNTIME)
 public annotation class ComposeFragment(
     val scope: KClass<*>,
-    val parentScope: KClass<*>,
+    val parentScope: KClass<*> = AppScope::class,
     val stateMachine: KClass<out StateMachine<*, *>>,
     val fragmentBaseClass: KClass<out Fragment> = Fragment::class,
 )

--- a/whetstone/runtime-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/RendererFragment.kt
+++ b/whetstone/runtime-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/RendererFragment.kt
@@ -2,6 +2,7 @@ package com.freeletics.mad.whetstone.fragment
 
 import androidx.fragment.app.Fragment
 import com.freeletics.mad.statemachine.StateMachine
+import com.freeletics.mad.whetstone.AppScope
 import com.gabrielittner.renderer.ViewRenderer
 import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.annotation.AnnotationTarget.CLASS
@@ -19,7 +20,7 @@ import kotlin.reflect.KClass
 @Retention(RUNTIME)
 public annotation class RendererFragment(
     val scope: KClass<*>,
-    val parentScope: KClass<*>,
+    val parentScope: KClass<*> = AppScope::class,
     val stateMachine: KClass<out StateMachine<*, *>>,
     val fragmentBaseClass: KClass<out Fragment> = Fragment::class,
     val rendererFactory: KClass<out ViewRenderer.Factory<*, *>>,

--- a/whetstone/runtime/api/runtime.api
+++ b/whetstone/runtime/api/runtime.api
@@ -1,3 +1,6 @@
+public abstract interface class com/freeletics/mad/whetstone/AppScope {
+}
+
 public abstract interface annotation class com/freeletics/mad/whetstone/ScopeTo : java/lang/annotation/Annotation {
 	public abstract fun marker ()Ljava/lang/Class;
 }

--- a/whetstone/runtime/src/main/java/com/freeletics/mad/whetstone/AppScope.kt
+++ b/whetstone/runtime/src/main/java/com/freeletics/mad/whetstone/AppScope.kt
@@ -1,0 +1,6 @@
+package com.freeletics.mad.whetstone
+
+/**
+ * A default scope marker that represents an app wide scope
+ */
+public sealed interface AppScope


### PR DESCRIPTION
This makes it unnecessary to explicitly specify `parentScope` and `destinationScope` for most cases. In our app you basically only need parent scope you have a nav entry component that you use as parent. The reason why I went with `AppScope` over using `Singleton` like we currently do is that it is what Anvil's docs suggest and also what is used by others. Also makes it so that all scoping will happen through `@ScopeTo(...)` and not a mix of annotations.

closes #284 