### PR TITLE
fix name shadowed warning and enforce no warnings in tests

### DIFF
--- a/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
+++ b/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
@@ -55,6 +55,7 @@ internal class FileGeneratorTestCompose {
               stateMachine = TestStateMachine::class,
             )
             @Composable
+            @Suppress("unused_parameter")
             public fun Test(
               state: TestState,
               sendAction: (TestAction) -> Unit
@@ -124,8 +125,8 @@ internal class FileGeneratorTestCompose {
             @OptIn(InternalWhetstoneApi::class)
             public fun WhetstoneTest(arguments: Bundle): Unit {
               val component = rememberComponent(TestParentScope::class, arguments) { parentComponent:
-                  WhetstoneTestComponent.ParentComponent, savedStateHandle, arguments ->
-                parentComponent.whetstoneTestComponentFactory().create(savedStateHandle, arguments)
+                  WhetstoneTestComponent.ParentComponent, savedStateHandle, argumentsForComponent ->
+                parentComponent.whetstoneTestComponentFactory().create(savedStateHandle, argumentsForComponent)
               }
 
               WhetstoneTest(component)
@@ -175,6 +176,7 @@ internal class FileGeneratorTestCompose {
               destinationScope = TestDestinationScope::class,
             )
             @Composable
+            @Suppress("unused_parameter")
             public fun Test(
               state: TestState,
               sendAction: (TestAction) -> Unit
@@ -252,8 +254,9 @@ internal class FileGeneratorTestCompose {
             @OptIn(InternalWhetstoneApi::class)
             public fun WhetstoneTest(testRoute: TestRoute): Unit {
               val component = rememberComponent(TestParentScope::class, TestDestinationScope::class, testRoute)
-                  { parentComponent: WhetstoneTestComponent.ParentComponent, savedStateHandle, testRoute ->
-                parentComponent.whetstoneTestComponentFactory().create(savedStateHandle, testRoute)
+                  { parentComponent: WhetstoneTestComponent.ParentComponent, savedStateHandle,
+                  testRouteForComponent ->
+                parentComponent.whetstoneTestComponentFactory().create(savedStateHandle, testRouteForComponent)
               }
 
               NavigationSetup(component.navEventNavigator)
@@ -321,6 +324,7 @@ internal class FileGeneratorTestCompose {
               parentScope = TestParentScope::class,
             )
             @Composable
+            @Suppress("unused_parameter")
             public fun Test(
               state: TestState,
               sendAction: (TestAction) -> Unit
@@ -409,8 +413,9 @@ internal class FileGeneratorTestCompose {
             @OptIn(InternalWhetstoneApi::class)
             public fun WhetstoneTest(testRoute: TestRoute): Unit {
               val component = rememberComponent(TestParentScope::class, TestDestinationScope::class, testRoute)
-                  { parentComponent: WhetstoneTestComponent.ParentComponent, savedStateHandle, testRoute ->
-                parentComponent.whetstoneTestComponentFactory().create(savedStateHandle, testRoute)
+                  { parentComponent: WhetstoneTestComponent.ParentComponent, savedStateHandle,
+                  testRouteForComponent ->
+                parentComponent.whetstoneTestComponentFactory().create(savedStateHandle, testRouteForComponent)
               }
 
               NavigationSetup(component.navEventNavigator)
@@ -536,6 +541,7 @@ internal class FileGeneratorTestCompose {
               scope = TestScreen::class,
             )
             @Composable
+            @Suppress("unused_parameter")
             public fun Test(
               state: TestState,
               sendAction: (TestAction) -> Unit
@@ -623,8 +629,8 @@ internal class FileGeneratorTestCompose {
             @OptIn(InternalWhetstoneApi::class)
             public fun WhetstoneTest(testRoute: TestRoute): Unit {
               val component = rememberComponent(AppScope::class, AppScope::class, testRoute) { parentComponent:
-                  WhetstoneTestComponent.ParentComponent, savedStateHandle, testRoute ->
-                parentComponent.whetstoneTestComponentFactory().create(savedStateHandle, testRoute)
+                  WhetstoneTestComponent.ParentComponent, savedStateHandle, testRouteForComponent ->
+                parentComponent.whetstoneTestComponentFactory().create(savedStateHandle, testRouteForComponent)
               }
 
               NavigationSetup(component.navEventNavigator)
@@ -758,6 +764,7 @@ internal class FileGeneratorTestCompose {
               stateMachine = TestStateMachine::class,
             )
             @Composable
+            @Suppress("unused_parameter")
             public fun Test2(
                 state: TestState,
                 sendAction: (TestAction) -> Unit,
@@ -843,8 +850,8 @@ internal class FileGeneratorTestCompose {
             @OptIn(InternalWhetstoneApi::class)
             public fun WhetstoneTest2(arguments: Bundle): Unit {
               val component = rememberComponent(TestParentScope::class, arguments) { parentComponent:
-                  WhetstoneTest2Component.ParentComponent, savedStateHandle, arguments ->
-                parentComponent.whetstoneTest2ComponentFactory().create(savedStateHandle, arguments)
+                  WhetstoneTest2Component.ParentComponent, savedStateHandle, argumentsForComponent ->
+                parentComponent.whetstoneTest2ComponentFactory().create(savedStateHandle, argumentsForComponent)
               }
 
               WhetstoneTest2(component)

--- a/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
+++ b/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
@@ -56,6 +56,7 @@ internal class FileGeneratorTestComposeFragment {
               stateMachine = TestStateMachine::class,
             )
             @Composable
+            @Suppress("unused_parameter")
             public fun Test(
               state: TestState,
               sendAction: (TestAction) -> Unit
@@ -139,8 +140,9 @@ internal class FileGeneratorTestComposeFragment {
                 if (!::whetstoneTestComponent.isInitialized) {
                   val arguments = requireArguments()
                   whetstoneTestComponent = component(TestParentScope::class, arguments) { parentComponent:
-                      WhetstoneTestComponent.ParentComponent, savedStateHandle, arguments ->
-                    parentComponent.whetstoneTestComponentFactory().create(savedStateHandle, arguments)
+                      WhetstoneTestComponent.ParentComponent, savedStateHandle, argumentsForComponent ->
+                    parentComponent.whetstoneTestComponentFactory().create(savedStateHandle,
+                        argumentsForComponent)
                   }
                 }
 
@@ -198,6 +200,7 @@ internal class FileGeneratorTestComposeFragment {
               destinationScope = TestDestinationScope::class,
             )
             @Composable
+            @Suppress("unused_parameter")
             public fun Test(
               state: TestState,
               sendAction: (TestAction) -> Unit
@@ -292,8 +295,9 @@ internal class FileGeneratorTestComposeFragment {
                   val testRoute = requireRoute<TestRoute>()
                   whetstoneTestComponent = component(TestParentScope::class, TestDestinationScope::class,
                       testRoute) { parentComponent: WhetstoneTestComponent.ParentComponent, savedStateHandle,
-                      testRoute ->
-                    parentComponent.whetstoneTestComponentFactory().create(savedStateHandle, testRoute)
+                      testRouteForComponent ->
+                    parentComponent.whetstoneTestComponentFactory().create(savedStateHandle,
+                        testRouteForComponent)
                   }
             
                   handleNavigation(this, whetstoneTestComponent.navEventNavigator)
@@ -368,6 +372,7 @@ internal class FileGeneratorTestComposeFragment {
               parentScope = TestParentScope::class,
             )
             @Composable
+            @Suppress("unused_parameter")
             public fun Test(
               state: TestState,
               sendAction: (TestAction) -> Unit
@@ -473,8 +478,9 @@ internal class FileGeneratorTestComposeFragment {
                   val testRoute = requireRoute<TestRoute>()
                   whetstoneTestComponent = component(TestParentScope::class, TestDestinationScope::class,
                       testRoute) { parentComponent: WhetstoneTestComponent.ParentComponent, savedStateHandle,
-                      testRoute ->
-                    parentComponent.whetstoneTestComponentFactory().create(savedStateHandle, testRoute)
+                      testRouteForComponent ->
+                    parentComponent.whetstoneTestComponentFactory().create(savedStateHandle,
+                        testRouteForComponent)
                   }
 
                   handleNavigation(this, whetstoneTestComponent.navEventNavigator)
@@ -607,6 +613,7 @@ internal class FileGeneratorTestComposeFragment {
               scope = TestScreen::class,
             )
             @Composable
+            @Suppress("unused_parameter")
             public fun Test(
               state: TestState,
               sendAction: (TestAction) -> Unit
@@ -710,8 +717,10 @@ internal class FileGeneratorTestComposeFragment {
                 if (!::whetstoneTestComponent.isInitialized) {
                   val testRoute = requireRoute<TestRoute>()
                   whetstoneTestComponent = component(AppScope::class, AppScope::class, testRoute) {
-                      parentComponent: WhetstoneTestComponent.ParentComponent, savedStateHandle, testRoute ->
-                    parentComponent.whetstoneTestComponentFactory().create(savedStateHandle, testRoute)
+                      parentComponent: WhetstoneTestComponent.ParentComponent, savedStateHandle,
+                      testRouteForComponent ->
+                    parentComponent.whetstoneTestComponentFactory().create(savedStateHandle,
+                        testRouteForComponent)
                   }
 
                   handleNavigation(this, whetstoneTestComponent.navEventNavigator)
@@ -835,6 +844,7 @@ internal class FileGeneratorTestComposeFragment {
               fragmentBaseClass = DialogFragment::class,
             )
             @Composable
+            @Suppress("unused_parameter")
             public fun Test(
               state: TestState,
               sendAction: (TestAction) -> Unit
@@ -918,8 +928,9 @@ internal class FileGeneratorTestComposeFragment {
                 if (!::whetstoneTestComponent.isInitialized) {
                   val arguments = requireArguments()
                   whetstoneTestComponent = component(TestParentScope::class, arguments) { parentComponent:
-                      WhetstoneTestComponent.ParentComponent, savedStateHandle, arguments ->
-                    parentComponent.whetstoneTestComponentFactory().create(savedStateHandle, arguments)
+                      WhetstoneTestComponent.ParentComponent, savedStateHandle, argumentsForComponent ->
+                    parentComponent.whetstoneTestComponentFactory().create(savedStateHandle,
+                        argumentsForComponent)
                   }
                 }
 
@@ -991,6 +1002,7 @@ internal class FileGeneratorTestComposeFragment {
               stateMachine = TestStateMachine::class,
             )
             @Composable
+            @Suppress("unused_parameter")
             public fun Test2(
               state: TestState,
               sendAction: (TestAction) -> Unit,
@@ -1090,8 +1102,9 @@ internal class FileGeneratorTestComposeFragment {
                 if (!::whetstoneTest2Component.isInitialized) {
                   val arguments = requireArguments()
                   whetstoneTest2Component = component(TestParentScope::class, arguments) { parentComponent:
-                      WhetstoneTest2Component.ParentComponent, savedStateHandle, arguments ->
-                    parentComponent.whetstoneTest2ComponentFactory().create(savedStateHandle, arguments)
+                      WhetstoneTest2Component.ParentComponent, savedStateHandle, argumentsForComponent ->
+                    parentComponent.whetstoneTest2ComponentFactory().create(savedStateHandle,
+                        argumentsForComponent)
                   }
                 }
 

--- a/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestRendererFragment.kt
+++ b/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestRendererFragment.kt
@@ -134,8 +134,9 @@ internal class FileGeneratorTestRendererFragment {
                   val arguments = requireArguments()
                   whetstoneTestRendererComponent = component(TestParentScope::class, arguments) {
                       parentComponent: WhetstoneTestRendererComponent.ParentComponent, savedStateHandle,
-                      arguments ->
-                    parentComponent.whetstoneTestRendererComponentFactory().create(savedStateHandle, arguments)
+                      argumentsForComponent ->
+                    parentComponent.whetstoneTestRendererComponentFactory().create(savedStateHandle,
+                        argumentsForComponent)
                   }
                 }
             
@@ -267,8 +268,9 @@ internal class FileGeneratorTestRendererFragment {
                   val testRoute = requireRoute<TestRoute>()
                   whetstoneTestRendererComponent = component(TestParentScope::class,
                       TestDestinationScope::class, testRoute) { parentComponent:
-                      WhetstoneTestRendererComponent.ParentComponent, savedStateHandle, testRoute ->
-                    parentComponent.whetstoneTestRendererComponentFactory().create(savedStateHandle, testRoute)
+                      WhetstoneTestRendererComponent.ParentComponent, savedStateHandle, testRouteForComponent ->
+                    parentComponent.whetstoneTestRendererComponentFactory().create(savedStateHandle,
+                        testRouteForComponent)
                   }
             
                   handleNavigation(this, whetstoneTestRendererComponent.navEventNavigator)
@@ -428,8 +430,9 @@ internal class FileGeneratorTestRendererFragment {
                   val testRoute = requireRoute<TestRoute>()
                   whetstoneTestRendererComponent = component(TestParentScope::class,
                       TestDestinationScope::class, testRoute) { parentComponent:
-                      WhetstoneTestRendererComponent.ParentComponent, savedStateHandle, testRoute ->
-                    parentComponent.whetstoneTestRendererComponentFactory().create(savedStateHandle, testRoute)
+                      WhetstoneTestRendererComponent.ParentComponent, savedStateHandle, testRouteForComponent ->
+                    parentComponent.whetstoneTestRendererComponentFactory().create(savedStateHandle,
+                        testRouteForComponent)
                   }
 
                   handleNavigation(this, whetstoneTestRendererComponent.navEventNavigator)
@@ -646,8 +649,9 @@ internal class FileGeneratorTestRendererFragment {
                   val testRoute = requireRoute<TestRoute>()
                   whetstoneTestRendererComponent = component(AppScope::class, AppScope::class, testRoute) {
                       parentComponent: WhetstoneTestRendererComponent.ParentComponent, savedStateHandle,
-                      testRoute ->
-                    parentComponent.whetstoneTestRendererComponentFactory().create(savedStateHandle, testRoute)
+                      testRouteForComponent ->
+                    parentComponent.whetstoneTestRendererComponentFactory().create(savedStateHandle,
+                        testRouteForComponent)
                   }
 
                   handleNavigation(this, whetstoneTestRendererComponent.navEventNavigator)
@@ -835,8 +839,9 @@ internal class FileGeneratorTestRendererFragment {
                   val arguments = requireArguments()
                   whetstoneTestRendererComponent = component(TestParentScope::class, arguments) {
                       parentComponent: WhetstoneTestRendererComponent.ParentComponent, savedStateHandle,
-                      arguments ->
-                    parentComponent.whetstoneTestRendererComponentFactory().create(savedStateHandle, arguments)
+                      argumentsForComponent ->
+                    parentComponent.whetstoneTestRendererComponentFactory().create(savedStateHandle,
+                        argumentsForComponent)
                   }
                 }
             

--- a/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/TestHelper.kt
+++ b/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/TestHelper.kt
@@ -95,4 +95,5 @@ private fun KotlinCompilation.configure() {
     jvmTarget = "11"
     inheritClassPath = true
     messageOutputStream = System.out // see diagnostics in real time
+    allWarningsAsErrors = true
 }

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/compose/ComposeScreenGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/compose/ComposeScreenGenerator.kt
@@ -22,23 +22,24 @@ internal class ComposeScreenGenerator(
 
     internal fun generate(): FunSpec {
         val parameter = data.navigation.asParameter()
+        val innerParameterName = "${parameter.name}ForComponent"
         return FunSpec.builder(composableName)
             .addAnnotation(composable)
             .addAnnotation(optInAnnotation())
             .addParameter(parameter)
             .also {
                 if (data.navigation != null) {
-                    it.beginControlFlow("val component = %M(%T::class, %T::class, %N) { parentComponent: %T, savedStateHandle, %N ->",
+                    it.beginControlFlow("val component = %M(%T::class, %T::class, %N) { parentComponent: %T, savedStateHandle, %L ->",
                         rememberComponent, data.parentScope, data.navigation.destinationScope,
-                        parameter, retainedParentComponentClassName, parameter)
+                        parameter, retainedParentComponentClassName, innerParameterName)
                 } else {
-                    it.beginControlFlow("val component = %M(%T::class, %N) { parentComponent: %T, savedStateHandle, %N ->",
+                    it.beginControlFlow("val component = %M(%T::class, %N) { parentComponent: %T, savedStateHandle, %L ->",
                         rememberComponent, data.parentScope, parameter,
-                        retainedParentComponentClassName, parameter)
+                        retainedParentComponentClassName, innerParameterName)
                 }
             }
-            .addStatement("parentComponent.%L().%L(savedStateHandle, %N)",
-                retainedParentComponentGetterName, retainedComponentFactoryCreateName, parameter)
+            .addStatement("parentComponent.%L().%L(savedStateHandle, %L)",
+                retainedParentComponentGetterName, retainedComponentFactoryCreateName, innerParameterName)
             .endControlFlow()
             .addCode("\n")
             .addCode(composableNavigationSetup())

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/fragment/BaseFragmentGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/fragment/BaseFragmentGenerator.kt
@@ -40,6 +40,7 @@ internal abstract class BaseFragmentGenerator<T : FragmentData> : Generator<T>()
 
     private fun onCreateViewFun(): FunSpec {
         val argumentsParameter = data.navigation.asParameter()
+        val innerParameterName = "${argumentsParameter.name}ForComponent"
         return FunSpec.builder("onCreateView")
             .addModifiers(OVERRIDE)
             .addParameter("inflater", layoutInflater)
@@ -52,19 +53,19 @@ internal abstract class BaseFragmentGenerator<T : FragmentData> : Generator<T>()
             .addCode("\n")
             .also {
                 if (data.navigation != null) {
-                    it.beginControlFlow("%L = %M(%T::class, %T::class, %N) { parentComponent: %T, savedStateHandle, %N ->",
+                    it.beginControlFlow("%L = %M(%T::class, %T::class, %N) { parentComponent: %T, savedStateHandle, %L ->",
                         retainedComponentClassName.propertyName, fragmentComponent, data.parentScope,
                         data.navigation!!.destinationScope, argumentsParameter,
-                        retainedParentComponentClassName, argumentsParameter)
+                        retainedParentComponentClassName, innerParameterName)
                 } else {
-                    it.beginControlFlow("%L = %M(%T::class, %N) { parentComponent: %T, savedStateHandle, %N ->",
+                    it.beginControlFlow("%L = %M(%T::class, %N) { parentComponent: %T, savedStateHandle, %L ->",
                         retainedComponentClassName.propertyName, fragmentComponent, data.parentScope,
-                        argumentsParameter, retainedParentComponentClassName, argumentsParameter)
+                        argumentsParameter, retainedParentComponentClassName, innerParameterName)
                 }
             }
-            .addStatement("parentComponent.%L().%L(savedStateHandle, %N)",
+            .addStatement("parentComponent.%L().%L(savedStateHandle, %L)",
                 retainedParentComponentGetterName, retainedComponentFactoryCreateName,
-                argumentsParameter)
+                innerParameterName)
             .endControlFlow()
             .addCode(navigationCode())
             .endControlFlow()


### PR DESCRIPTION
Tests now use allWarningsAsError when compiling the generated code to avoid this from happening again.