### PR TITLE
use DisposeOnViewTreeLifecycleDestroyed for compose in fragments

### DIFF
--- a/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
+++ b/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
@@ -147,7 +147,7 @@ internal class FileGeneratorTestComposeFragment {
                 }
 
                 return ComposeView(requireContext()).apply {
-                  setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnLifecycleDestroyed(viewLifecycleOwner))
+                  setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
 
                   setContent {
                     WhetstoneTest(whetstoneTestComponent)
@@ -304,7 +304,7 @@ internal class FileGeneratorTestComposeFragment {
                 }
             
                 return ComposeView(requireContext()).apply {
-                  setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnLifecycleDestroyed(viewLifecycleOwner))
+                  setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
 
                   setContent {
                     WhetstoneTest(whetstoneTestComponent)
@@ -487,7 +487,7 @@ internal class FileGeneratorTestComposeFragment {
                 }
 
                 return ComposeView(requireContext()).apply {
-                  setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnLifecycleDestroyed(viewLifecycleOwner))
+                  setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
 
                   setContent {
                     WhetstoneTest(whetstoneTestComponent)
@@ -727,7 +727,7 @@ internal class FileGeneratorTestComposeFragment {
                 }
 
                 return ComposeView(requireContext()).apply {
-                  setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnLifecycleDestroyed(viewLifecycleOwner))
+                  setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
 
                   setContent {
                     WhetstoneTest(whetstoneTestComponent)
@@ -935,7 +935,7 @@ internal class FileGeneratorTestComposeFragment {
                 }
 
                 return ComposeView(requireContext()).apply {
-                  setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnLifecycleDestroyed(viewLifecycleOwner))
+                  setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
 
                   setContent {
                     WhetstoneTest(whetstoneTestComponent)
@@ -1109,7 +1109,7 @@ internal class FileGeneratorTestComposeFragment {
                 }
 
                 return ComposeView(requireContext()).apply {
-                  setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnLifecycleDestroyed(viewLifecycleOwner))
+                  setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
 
                   setContent {
                     WhetstoneTest2(whetstoneTest2Component)

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/fragment/ComposeFragmentGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/fragment/ComposeFragmentGenerator.kt
@@ -17,8 +17,7 @@ internal class ComposeFragmentGenerator(
             // requireContext: external method
             .beginControlFlow("return %T(requireContext()).apply {", composeView)
             // setViewCompositionStrategy: external method
-            // viewLifecycleOwner: external method
-            .addStatement("setViewCompositionStrategy(%T(viewLifecycleOwner))", disposeOnLifecycleDestroyed)
+            .addStatement("setViewCompositionStrategy(%T)", disposeOnLifecycleDestroyed)
             .add("\n")
             // setContent: external method
             .beginControlFlow("setContent {")

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
@@ -79,7 +79,7 @@ internal val getValue = MemberName("androidx.compose.runtime", "getValue")
 internal val rememberCoroutineScope = MemberName("androidx.compose.runtime", "rememberCoroutineScope")
 internal val composeView = ClassName("androidx.compose.ui.platform", "ComposeView")
 internal val viewCompositionStrategy = ClassName("androidx.compose.ui.platform", "ViewCompositionStrategy")
-internal val disposeOnLifecycleDestroyed = viewCompositionStrategy.nestedClass("DisposeOnLifecycleDestroyed")
+internal val disposeOnLifecycleDestroyed = viewCompositionStrategy.nestedClass("DisposeOnViewTreeLifecycleDestroyed")
 
 // Android
 internal val layoutInflater = ClassName("android.view", "LayoutInflater")


### PR DESCRIPTION
Notiiced that the docs now recommend `DisposeOnViewTreeLifecycleDestroyed` instead of `DisposeOnLifecycleDestroyed`https://developer.android.com/jetpack/compose/interop/interop-apis#compose-in-fragments