### PR TITLE
move NavigationExecutor.Store to standalone class in runtime

### DIFF
--- a/navigator/androidx-nav/src/main/java/com/freeletics/mad/navigator/internal/StoreViewModel.kt
+++ b/navigator/androidx-nav/src/main/java/com/freeletics/mad/navigator/internal/StoreViewModel.kt
@@ -4,23 +4,8 @@ import androidx.lifecycle.ViewModel
 import java.io.Closeable
 import kotlin.reflect.KClass
 
-internal class StoreViewModel : ViewModel(), NavigationExecutor.Store {
-    private val storedObjects = mutableMapOf<KClass<*>, Any>()
-
-    override fun <T : Any> getOrCreate(key: KClass<T>, factory: () -> T): T {
-        @Suppress("UNCHECKED_CAST")
-        var storedObject = storedObjects[key] as T?
-        if (storedObject == null) {
-            storedObject = factory()
-            storedObjects[key] = storedObject
-            if (storedObject is Closeable) {
-                addCloseable(storedObject)
-            }
-        }
-        return storedObject
-    }
-
-    override fun onCleared() {
-        storedObjects.clear()
-    }
+internal class StoreViewModel private constructor(
+    store: NavigationExecutorStore
+) : ViewModel(store), NavigationExecutor.Store by store {
+    constructor() : this(NavigationExecutorStore())
 }

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/NavigationExecutorStore.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/NavigationExecutorStore.kt
@@ -1,0 +1,28 @@
+package com.freeletics.mad.navigator.internal
+
+import java.io.Closeable
+import kotlin.reflect.KClass
+
+@InternalNavigatorApi
+public class NavigationExecutorStore : NavigationExecutor.Store, Closeable {
+    private val storedObjects = mutableMapOf<KClass<*>, Any>()
+
+    override fun <T : Any> getOrCreate(key: KClass<T>, factory: () -> T): T {
+        @Suppress("UNCHECKED_CAST")
+        var storedObject = storedObjects[key] as T?
+        if (storedObject == null) {
+            storedObject = factory()
+            storedObjects[key] = storedObject
+        }
+        return storedObject
+    }
+
+    override fun close() {
+        storedObjects.forEach { (_, storedObject) ->
+            if (storedObject is Closeable) {
+                storedObject.close()
+            }
+        }
+        storedObjects.clear()
+    }
+}

--- a/navigator/runtime/src/test/java/com/freeletics/mad/navigator/internal/NavgationExecutorStoreTest.kt
+++ b/navigator/runtime/src/test/java/com/freeletics/mad/navigator/internal/NavgationExecutorStoreTest.kt
@@ -1,0 +1,78 @@
+package com.freeletics.mad.navigator.internal
+
+import com.google.common.truth.Truth.assertThat
+import java.io.Closeable
+import org.junit.Test
+
+internal class NavgationExecutorStoreTest {
+
+    private val underTest = NavigationExecutorStore()
+
+    @Test
+    fun `store returns value from factory`() {
+        var counter = 0
+        val value = underTest.getOrCreate(Int::class) { ++counter }
+        assertThat(value).isEqualTo(1)
+
+    }
+
+    @Test
+    fun `store always returns the same value for the same key`() {
+        var counter = 0
+        val value1 = underTest.getOrCreate(Int::class) { ++counter }
+        assertThat(value1).isEqualTo(1)
+        val value2 = underTest.getOrCreate(Int::class) { ++counter }
+        assertThat(value2).isEqualTo(1)
+        val value3 = underTest.getOrCreate(Int::class) { ++counter }
+        assertThat(value3).isEqualTo(1)
+        val value4 = underTest.getOrCreate(Int::class) { ++counter }
+        assertThat(value4).isEqualTo(1)
+    }
+
+    @Test
+    fun `store returns new value after close`() {
+        var counter = 0
+        val value1 = underTest.getOrCreate(Int::class) { counter }
+        assertThat(value1).isEqualTo(0)
+        counter = 5
+        val value2 = underTest.getOrCreate(Int::class) { counter }
+        assertThat(value2).isEqualTo(0)
+
+        underTest.close()
+        val value3 = underTest.getOrCreate(Int::class) { counter }
+        assertThat(value3).isEqualTo(5)
+    }
+
+    @Test
+    fun `store keeps values for separate keys separate`() {
+        var counter1 = 0
+        var counter2 = 5L
+        val value1 = underTest.getOrCreate(Int::class) { ++counter1 }
+        assertThat(value1).isEqualTo(1)
+        val value2 = underTest.getOrCreate(Long::class) { ++counter2 }
+        assertThat(value2).isEqualTo(6)
+        val value3 = underTest.getOrCreate(Int::class) { ++counter1 }
+        assertThat(value3).isEqualTo(1)
+        val value4 = underTest.getOrCreate(Long::class) { ++counter2 }
+        assertThat(value4).isEqualTo(6)
+    }
+
+    @Test
+    fun `store always returns the same object for key`() {
+        val closeable = Closeable {  }
+        val value1 = underTest.getOrCreate(Closeable::class) { closeable }
+        assertThat(value1).isEqualTo(closeable)
+        val value2 = underTest.getOrCreate(Closeable::class) { closeable }
+        assertThat(value2).isEqualTo(closeable)
+    }
+
+    @Test
+    fun `store closes stored Closeables on close`() {
+        var closed = false
+        val closeable = Closeable { closed = true }
+        underTest.getOrCreate(Closeable::class) { closeable }
+
+        underTest.close()
+        assertThat(closed).isTrue()
+    }
+}


### PR DESCRIPTION
Extracted this from my experimental navigator implementation. This way all navigator implementations can share the same store. For this to work the store itself isn't a `ViewModel` anymore (the experimental implementation tries to just have one ViewModel per Activity instead of one per back stack entry), so the AndroidX implementation still has a `StoreViewModel` that is just delegating to the actual store. The only thing we are loosing is the `addCloseable` which needed to be replaced with manually iterating. 

Also added tests for the store.