### PR TITLE
automatically find ViewRenderer.Factory instead of requiring a parameter

### DIFF
--- a/docs/whetstone/get-started.md
+++ b/docs/whetstone/get-started.md
@@ -129,7 +129,6 @@ it falls into the `Fragment` category.
         scope = ExampleScope::class,
         parentScope = AppScope::class, // AppScope is the default value and can be omitted
         stateMachine = ExampleStateMachine::class,
-        rendererFactory = ExampleRenderer.Factory::class, // references the factory below
     )
     internal class ExampleRenderer @AssistedInject constructor(
         @Assisted private val binding: ExampleViewBinding,
@@ -145,8 +144,8 @@ it falls into the `Fragment` category.
     ```
     
     The generated `WhetstoneExampleRendererFragment` will use the generated component, the
-    annotated composable as well as the `stateMachine` and `rendererFactory` parameters from the
-    annotation. It will use factory to create a `Renderer` and use it as its view. It will then
+    annotated composable as well as the `stateMachine`. It will use the `ViewRenderer.Factory`
+    to create an istance of the `Renderer` and use it as its view. It will then
     automatically hook up the state machine with the renderer so that the state from the state machine
     is passed to the composable and actions from the latter are sent back to the
     state machine. The generated fragment will use the generated component
@@ -243,7 +242,6 @@ internal class ExampleStateMachine @Inject constructor(
     @RendererFragment(
         scope = ExampleScope::class, // uses our marker class
         parentScope = AppScope::class, // the scope of the app level component, AppScope is the default value and can be omitted
-        rendererFactory = ExampleRenderer.Factory::class, // references the factory below
         stateMachine = ExampleStateMachine::class, // the state machine used for this ui
     )
     internal class ExampleRenderer @AssistedInject constructor(

--- a/docs/whetstone/navigation.md
+++ b/docs/whetstone/navigation.md
@@ -93,7 +93,6 @@ on the appropriate `whetstone-navigation` artifact needs to be added:
         stateMachine = ExampleStateMachine::class,
         destinationType = DestintionType.SCREEN,
         destinationScope = AppScope::class, // AppScope is the default value and can be omitted
-        rendererFactory = ExampleRenderer.Factory::class,
     )
     internal class ExampleRenderer ... // same as in general guide
     ```
@@ -184,7 +183,6 @@ class ExampleNavigator @Inject constructor() : NavEventNavigator() {
     @RendererDestination(
         route = ExampleRoute::class, // the route used to navigate to ExampleRenderer
         parentScope = AppScope::class, // the scope of the app level component, AppScope is the default value and can be omitted
-        rendererFactory = ExampleRenderer.Factory::class, // references the factory below
         stateMachine = ExampleStateMachine::class, // the state machine used fo
         destinationType = DestinationType.SCREEN, // whether it's a screen, dialog or bottom sheet
         destinationScope = AppScope::class, // contribute the generated destination to AppScope, AppScope is the default value and can be omitted

--- a/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestRendererFragment.kt
+++ b/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestRendererFragment.kt
@@ -50,7 +50,6 @@ internal class FileGeneratorTestRendererFragment {
               scope = TestScreen::class,
               parentScope = TestParentScope::class,
               stateMachine = TestStateMachine::class,
-              rendererFactory = TestRenderer.Factory::class,
             )
             public class TestRenderer(view: View) : ViewRenderer<TestState, TestAction>(view) {
               override fun renderToView(state: TestState) {}
@@ -172,7 +171,6 @@ internal class FileGeneratorTestRendererFragment {
               route = TestRoute::class,
               parentScope = TestParentScope::class,
               stateMachine = TestStateMachine::class,
-              rendererFactory = TestRenderer.Factory::class,
               destinationType = DestinationType.SCREEN,
               destinationScope = TestDestinationScope::class,
             )
@@ -319,7 +317,6 @@ internal class FileGeneratorTestRendererFragment {
               route = TestRoute::class,
               parentScope = TestParentScope::class,
               stateMachine = TestStateMachine::class,
-              rendererFactory = TestRenderer.Factory::class,
               destinationType = DestinationType.SCREEN,
               destinationScope = TestDestinationScope::class,
             )
@@ -541,7 +538,6 @@ internal class FileGeneratorTestRendererFragment {
             @RendererDestination(
               route = TestRoute::class,
               stateMachine = TestStateMachine::class,
-              rendererFactory = TestRenderer.Factory::class,
               destinationType = DestinationType.SCREEN,
             )
             @NavEntryComponent(
@@ -754,7 +750,6 @@ internal class FileGeneratorTestRendererFragment {
               scope = TestScreen::class,
               parentScope = TestParentScope::class,
               stateMachine = TestStateMachine::class,
-              rendererFactory = TestRenderer.Factory::class,
               fragmentBaseClass = DialogFragment::class,
             )
             public class TestRenderer(view: View) : ViewRenderer<TestState, TestAction>(view) {

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
@@ -49,6 +49,9 @@ internal val fragmentRequireRoute = MemberName("com.freeletics.mad.navigator.fra
 internal val internalNavigatorApi = ClassName("com.freeletics.mad.navigator.internal", "InternalNavigatorApi")
 
 // Renderer
+internal val viewRenderer = ClassName("com.gabrielittner.renderer", "ViewRenderer")
+internal val viewRendererFactory = viewRenderer.nestedClass("Factory")
+internal val viewRendererFactoryFqName = FqName(viewRendererFactory.canonicalName)
 internal val rendererConnect = MemberName("com.gabrielittner.renderer.connect", "connect")
 
 // Kotlin

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/parser/CommonParser.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/parser/CommonParser.kt
@@ -6,10 +6,15 @@ import com.freeletics.mad.whetstone.Navigation
 import com.freeletics.mad.whetstone.codegen.util.appScope
 import com.freeletics.mad.whetstone.codegen.util.fragment
 import com.freeletics.mad.whetstone.codegen.util.navEntryComponentFqName
+import com.freeletics.mad.whetstone.codegen.util.viewRendererFactoryFqName
 import com.squareup.anvil.annotations.ExperimentalAnvilApi
 import com.squareup.anvil.compiler.internal.reference.AnnotatedReference
 import com.squareup.anvil.compiler.internal.reference.AnnotationReference
+import com.squareup.anvil.compiler.internal.reference.ClassReference
+import com.squareup.anvil.compiler.internal.reference.AnvilCompilationExceptionClassReference
 import com.squareup.anvil.compiler.internal.reference.TopLevelFunctionReference
+import com.squareup.anvil.compiler.internal.reference.allSuperTypeClassReferences
+import com.squareup.anvil.compiler.internal.reference.asClassName
 import com.squareup.kotlinpoet.ClassName
 
 @OptIn(ExperimentalAnvilApi::class)
@@ -65,3 +70,16 @@ internal val TopLevelFunctionReference.composeParameters: List<ComposableParamet
                 typeName = it.type().asTypeName()
             )
         }
+
+@OptIn(ExperimentalAnvilApi::class)
+internal fun ClassReference.findRendererFactory(): ClassName {
+    val factoryClass = innerClasses().find { innerClass ->
+        innerClass.allSuperTypeClassReferences(false).any { superType ->
+            superType.fqName == viewRendererFactoryFqName
+        }
+    }
+    return factoryClass?.asClassName() ?:
+    throw AnvilCompilationExceptionClassReference(this,
+        "Couldn't find a ViewRender.Factory subclass nested inside $fqName"
+    )
+}

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/parser/FragmentParser.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/parser/FragmentParser.kt
@@ -22,7 +22,7 @@ internal fun ClassReference.toRendererFragmentData(): RendererFragmentData? {
         parentScope = annotation.parentScope,
         stateMachine = annotation.stateMachine,
         fragmentBaseClass = annotation.fragmentBaseClass(3),
-        factory = annotation.requireClassArgument("rendererFactory", 4),
+        factory = findRendererFactory(),
         navigation = null,
         navEntryData = null,
     )
@@ -45,7 +45,7 @@ internal fun ClassReference.toRendererFragmentDestinationData(): RendererFragmen
         parentScope = annotation.parentScope,
         stateMachine = annotation.stateMachine,
         fragmentBaseClass = annotation.fragmentBaseClass(5),
-        factory = annotation.requireClassArgument("rendererFactory", 6),
+        factory = findRendererFactory(),
         navigation = navigation,
         navEntryData = navEntryData(navigation),
     )

--- a/whetstone/navigation-fragment/api/navigation-fragment.api
+++ b/whetstone/navigation-fragment/api/navigation-fragment.api
@@ -19,7 +19,6 @@ public abstract interface annotation class com/freeletics/mad/whetstone/fragment
 	public abstract fun destinationType ()Lcom/freeletics/mad/whetstone/fragment/DestinationType;
 	public abstract fun fragmentBaseClass ()Ljava/lang/Class;
 	public abstract fun parentScope ()Ljava/lang/Class;
-	public abstract fun rendererFactory ()Ljava/lang/Class;
 	public abstract fun route ()Ljava/lang/Class;
 	public abstract fun stateMachine ()Ljava/lang/Class;
 }

--- a/whetstone/navigation-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/RendererDestination.kt
+++ b/whetstone/navigation-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/RendererDestination.kt
@@ -26,5 +26,4 @@ public annotation class RendererDestination(
     val destinationType: DestinationType = DestinationType.SCREEN,
     val destinationScope: KClass<*> = AppScope::class,
     val fragmentBaseClass: KClass<out Fragment> = Fragment::class,
-    val rendererFactory: KClass<out ViewRenderer.Factory<*, *>>,
 )

--- a/whetstone/runtime-fragment/api/runtime-fragment.api
+++ b/whetstone/runtime-fragment/api/runtime-fragment.api
@@ -8,7 +8,6 @@ public abstract interface annotation class com/freeletics/mad/whetstone/fragment
 public abstract interface annotation class com/freeletics/mad/whetstone/fragment/RendererFragment : java/lang/annotation/Annotation {
 	public abstract fun fragmentBaseClass ()Ljava/lang/Class;
 	public abstract fun parentScope ()Ljava/lang/Class;
-	public abstract fun rendererFactory ()Ljava/lang/Class;
 	public abstract fun scope ()Ljava/lang/Class;
 	public abstract fun stateMachine ()Ljava/lang/Class;
 }

--- a/whetstone/runtime-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/RendererFragment.kt
+++ b/whetstone/runtime-fragment/src/main/java/com/freeletics/mad/whetstone/fragment/RendererFragment.kt
@@ -23,5 +23,4 @@ public annotation class RendererFragment(
     val parentScope: KClass<*> = AppScope::class,
     val stateMachine: KClass<out StateMachine<*, *>>,
     val fragmentBaseClass: KClass<out Fragment> = Fragment::class,
-    val rendererFactory: KClass<out ViewRenderer.Factory<*, *>>,
 )


### PR DESCRIPTION
This is done by going through all nested classes of an annotated renderer and then finding one that extends `ViewRenderer.Factory`.


Closes #257 