### PR TITLE
make state and sendAction optional and prepare to make them more dynamic

### DIFF
--- a/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
+++ b/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
@@ -8,9 +8,11 @@ import com.freeletics.mad.whetstone.Navigation
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.INT
 import com.squareup.kotlinpoet.MAP
+import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.SET
 import com.squareup.kotlinpoet.STRING
+import com.squareup.kotlinpoet.UNIT
 import com.squareup.kotlinpoet.asClassName
 import org.junit.Test
 
@@ -30,7 +32,15 @@ internal class FileGeneratorTestCompose {
         stateMachine = ClassName("com.test", "TestStateMachine"),
         navigation = null,
         navEntryData = null,
-        composableParameter = emptyList()
+        composableParameter = emptyList(),
+        stateParameter = ComposableParameter("state", ClassName("com.test", "TestState")),
+        sendActionParameter = ComposableParameter(
+            "sendAction",
+            Function1::class.asClassName().parameterizedBy(
+                ClassName("com.test", "TestAction"),
+                UNIT,
+            ),
+        ),
     )
 
     private val navEntryData = NavEntryData(
@@ -883,5 +893,230 @@ internal class FileGeneratorTestCompose {
         """.trimIndent()
 
         test(withInjectedParameters, "com/test/Test2.kt", source, expected)
+    }
+
+    @Test
+    fun `generates code for ComposeScreenData without sendAction`() {
+        val withoutSendAction = data.copy(
+            sendActionParameter = null
+        )
+
+        val source = """
+            package com.test
+            
+            import androidx.compose.runtime.Composable
+            import com.freeletics.mad.whetstone.compose.ComposeScreen
+            import com.test.parent.TestParentScope
+            
+            @ComposeScreen(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+              stateMachine = TestStateMachine::class,
+            )
+            @Composable
+            @Suppress("unused_parameter")
+            public fun Test(
+              state: TestState,
+            ) {}
+        """.trimIndent()
+
+        val expected = """
+            package com.test
+
+            import android.os.Bundle
+            import androidx.compose.runtime.Composable
+            import androidx.lifecycle.SavedStateHandle
+            import com.freeletics.mad.whetstone.ScopeTo
+            import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
+            import com.freeletics.mad.whetstone.`internal`.asComposeState
+            import com.freeletics.mad.whetstone.compose.`internal`.rememberComponent
+            import com.squareup.anvil.annotations.ContributesSubcomponent
+            import com.squareup.anvil.annotations.ContributesTo
+            import com.test.parent.TestParentScope
+            import dagger.BindsInstance
+            import dagger.Module
+            import dagger.multibindings.Multibinds
+            import java.io.Closeable
+            import kotlin.OptIn
+            import kotlin.Unit
+            import kotlin.collections.Set
+
+            @OptIn(InternalWhetstoneApi::class)
+            @ScopeTo(TestScreen::class)
+            @ContributesSubcomponent(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+            )
+            public interface WhetstoneTestComponent : Closeable {
+              public val testStateMachine: TestStateMachine
+
+              public val closeables: Set<Closeable>
+    
+              public override fun close(): Unit {
+                closeables.forEach {
+                  it.close()
+                }
+              }
+
+              @ContributesSubcomponent.Factory
+              public interface Factory {
+                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
+                    arguments: Bundle): WhetstoneTestComponent
+              }
+
+              @ContributesTo(TestParentScope::class)
+              public interface ParentComponent {
+                public fun whetstoneTestComponentFactory(): Factory
+              }
+            }
+
+            @Module
+            @ContributesTo(TestScreen::class)
+            public interface WhetstoneTestModule {
+              @Multibinds
+              public fun bindCloseables(): Set<Closeable>
+            }
+
+            @Composable
+            @OptIn(InternalWhetstoneApi::class)
+            public fun WhetstoneTest(arguments: Bundle): Unit {
+              val component = rememberComponent(TestParentScope::class, arguments) { parentComponent:
+                  WhetstoneTestComponent.ParentComponent, savedStateHandle, argumentsForComponent ->
+                parentComponent.whetstoneTestComponentFactory().create(savedStateHandle, argumentsForComponent)
+              }
+
+              WhetstoneTest(component)
+            }
+            
+            @Composable
+            @OptIn(InternalWhetstoneApi::class)
+            private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
+              val stateMachine = component.testStateMachine
+              val state = stateMachine.asComposeState()
+              val currentState = state.value
+              if (currentState != null) {
+                Test(
+                  state = currentState,
+                )
+              }
+            }
+            
+        """.trimIndent()
+
+        test(withoutSendAction, "com/test/Test.kt", source, expected)
+    }
+
+    @Test
+    fun `generates code for ComposeScreenData without state`() {
+        val withoutSendAction = data.copy(
+            stateParameter = null
+        )
+
+        val source = """
+            package com.test
+            
+            import androidx.compose.runtime.Composable
+            import com.freeletics.mad.whetstone.compose.ComposeScreen
+            import com.test.parent.TestParentScope
+            
+            @ComposeScreen(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+              stateMachine = TestStateMachine::class,
+            )
+            @Composable
+            @Suppress("unused_parameter")
+            public fun Test(
+              sendAction: (TestAction) -> Unit
+            ) {}
+        """.trimIndent()
+
+        val expected = """
+            package com.test
+
+            import android.os.Bundle
+            import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.rememberCoroutineScope
+            import androidx.lifecycle.SavedStateHandle
+            import com.freeletics.mad.whetstone.ScopeTo
+            import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
+            import com.freeletics.mad.whetstone.`internal`.asComposeState
+            import com.freeletics.mad.whetstone.compose.`internal`.rememberComponent
+            import com.squareup.anvil.annotations.ContributesSubcomponent
+            import com.squareup.anvil.annotations.ContributesTo
+            import com.test.parent.TestParentScope
+            import dagger.BindsInstance
+            import dagger.Module
+            import dagger.multibindings.Multibinds
+            import java.io.Closeable
+            import kotlin.OptIn
+            import kotlin.Unit
+            import kotlin.collections.Set
+            import kotlinx.coroutines.launch
+
+            @OptIn(InternalWhetstoneApi::class)
+            @ScopeTo(TestScreen::class)
+            @ContributesSubcomponent(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+            )
+            public interface WhetstoneTestComponent : Closeable {
+              public val testStateMachine: TestStateMachine
+
+              public val closeables: Set<Closeable>
+    
+              public override fun close(): Unit {
+                closeables.forEach {
+                  it.close()
+                }
+              }
+
+              @ContributesSubcomponent.Factory
+              public interface Factory {
+                public fun create(@BindsInstance savedStateHandle: SavedStateHandle, @BindsInstance
+                    arguments: Bundle): WhetstoneTestComponent
+              }
+
+              @ContributesTo(TestParentScope::class)
+              public interface ParentComponent {
+                public fun whetstoneTestComponentFactory(): Factory
+              }
+            }
+
+            @Module
+            @ContributesTo(TestScreen::class)
+            public interface WhetstoneTestModule {
+              @Multibinds
+              public fun bindCloseables(): Set<Closeable>
+            }
+
+            @Composable
+            @OptIn(InternalWhetstoneApi::class)
+            public fun WhetstoneTest(arguments: Bundle): Unit {
+              val component = rememberComponent(TestParentScope::class, arguments) { parentComponent:
+                  WhetstoneTestComponent.ParentComponent, savedStateHandle, argumentsForComponent ->
+                parentComponent.whetstoneTestComponentFactory().create(savedStateHandle, argumentsForComponent)
+              }
+
+              WhetstoneTest(component)
+            }
+            
+            @Composable
+            @OptIn(InternalWhetstoneApi::class)
+            private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
+              val stateMachine = component.testStateMachine
+              val state = stateMachine.asComposeState()
+              val currentState = state.value
+              if (currentState != null) {
+                val scope = rememberCoroutineScope()
+                Test(
+                  sendAction = { scope.launch { stateMachine.dispatch(it) } },
+                )
+              }
+            }
+            
+        """.trimIndent()
+
+        test(withoutSendAction, "com/test/Test.kt", source, expected)
     }
 }

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/Data.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/Data.kt
@@ -25,6 +25,8 @@ public sealed interface BaseData {
 public sealed interface ComposeData : BaseData {
     override val stateMachine: ClassName
     public val navEntryData: NavEntryData?
+    public val stateParameter: ComposableParameter?
+    public val sendActionParameter: ComposableParameter?
     public val composableParameter: List<ComposableParameter>
 }
 
@@ -44,6 +46,9 @@ public data class ComposeScreenData(
 
     override val navigation: Navigation.Compose?,
     override val navEntryData: NavEntryData?,
+
+    override val stateParameter: ComposableParameter?,
+    override val sendActionParameter: ComposableParameter?,
     override val composableParameter: List<ComposableParameter>,
 ) :  ComposeData
 
@@ -65,6 +70,9 @@ public data class ComposeFragmentData(
 
     override val navigation: Navigation.Fragment?,
     override val navEntryData: NavEntryData?,
+
+    override val stateParameter: ComposableParameter?,
+    override val sendActionParameter: ComposableParameter?,
     override val composableParameter: List<ComposableParameter>,
 ) : ComposeData, FragmentData
 

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/parser/CommonParser.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/parser/CommonParser.kt
@@ -60,16 +60,26 @@ internal fun AnnotatedReference.navEntryData(
     )
 }
 
+private const val STATE_PARAMETER = "state"
+private const val SEND_ACTION_PARAMETER = "sendAction"
+
+@OptIn(ExperimentalAnvilApi::class)
+internal val TopLevelFunctionReference.stateParameter: ComposableParameter?
+    get() = parameters
+        .find { it.name == STATE_PARAMETER }
+        ?.toComposableParameter()
+
+@OptIn(ExperimentalAnvilApi::class)
+internal val TopLevelFunctionReference.sendActionParameter: ComposableParameter?
+    get() = parameters
+        .find { it.name == SEND_ACTION_PARAMETER }
+        ?.toComposableParameter()
+
 @OptIn(ExperimentalAnvilApi::class)
 internal val TopLevelFunctionReference.composeParameters: List<ComposableParameter>
     get() = parameters
-        .filter { it.name != "state" && it.name != "sendAction" }
-        .map {
-            ComposableParameter(
-                name = it.name,
-                typeName = it.type().asTypeName()
-            )
-        }
+        .filter { it.name != STATE_PARAMETER && it.name != SEND_ACTION_PARAMETER }
+        .map { it.toComposableParameter() }
 
 @OptIn(ExperimentalAnvilApi::class)
 internal fun ClassReference.findRendererFactory(): ClassName {

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/parser/ComposeParser.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/parser/ComposeParser.kt
@@ -19,7 +19,9 @@ internal fun TopLevelFunctionReference.toComposeScreenData(): ComposeScreenData?
         stateMachine = annotation.stateMachine,
         navigation = null,
         navEntryData = null,
-        composableParameter = composeParameters
+        composableParameter = composeParameters,
+        stateParameter = stateParameter,
+        sendActionParameter = sendActionParameter,
     )
 }
 
@@ -41,6 +43,8 @@ internal fun TopLevelFunctionReference.toComposeScreenDestinationData(): Compose
         stateMachine = annotation.stateMachine,
         navigation = navigation,
         navEntryData = navEntryData(navigation),
-        composableParameter = composeParameters
+        composableParameter = composeParameters,
+        stateParameter = stateParameter,
+        sendActionParameter = sendActionParameter,
     )
 }

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/parser/FragmentParser.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/parser/FragmentParser.kt
@@ -64,7 +64,9 @@ internal fun TopLevelFunctionReference.toComposeFragmentData(): ComposeFragmentD
         fragmentBaseClass = annotation.fragmentBaseClass(3),
         navigation = null,
         navEntryData = null,
-        composableParameter = composeParameters
+        composableParameter = composeParameters,
+        stateParameter = stateParameter,
+        sendActionParameter = sendActionParameter,
     )
 }
 
@@ -87,6 +89,8 @@ internal fun TopLevelFunctionReference.toComposeFragmentDestinationData(): Compo
         fragmentBaseClass = annotation.fragmentBaseClass(5),
         navigation = navigation,
         navEntryData = navEntryData(navigation),
-        composableParameter = composeParameters
+        composableParameter = composeParameters,
+        stateParameter = stateParameter,
+        sendActionParameter = sendActionParameter,
     )
 }

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/parser/Reference.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/parser/Reference.kt
@@ -1,5 +1,6 @@
 package com.freeletics.mad.whetstone.parser
 
+import com.freeletics.mad.whetstone.ComposableParameter
 import com.squareup.anvil.annotations.ExperimentalAnvilApi
 import com.squareup.anvil.compiler.internal.reference.AnnotatedReference
 import com.squareup.anvil.compiler.internal.reference.AnnotationReference
@@ -7,7 +8,7 @@ import com.squareup.anvil.compiler.internal.reference.AnvilCompilationExceptionA
 import com.squareup.anvil.compiler.internal.reference.ClassReference
 import com.squareup.anvil.compiler.internal.reference.MemberFunctionReference
 import com.squareup.anvil.compiler.internal.reference.MemberPropertyReference
-import com.squareup.anvil.compiler.internal.reference.PropertyReference
+import com.squareup.anvil.compiler.internal.reference.ParameterReference
 import com.squareup.anvil.compiler.internal.reference.TopLevelFunctionReference
 import com.squareup.anvil.compiler.internal.reference.argumentAt
 import com.squareup.anvil.compiler.internal.reference.asClassName
@@ -40,6 +41,14 @@ internal fun AnnotationReference.requireEnumArgument(name: String, index: Int): 
 @OptIn(ExperimentalAnvilApi::class)
 internal fun AnnotationReference.optionalEnumArgument(name: String, index: Int): String? {
     return argumentAt(name, index)?.value<FqName>()?.shortName()?.asString()
+}
+
+@OptIn(ExperimentalAnvilApi::class)
+internal fun ParameterReference.toComposableParameter(): ComposableParameter {
+    return ComposableParameter(
+        name = name,
+        typeName = type().asTypeName()
+    )
 }
 
 @OptIn(ExperimentalAnvilApi::class)


### PR DESCRIPTION
Closes #310.

This does 2 things
- we are searching for the `state` and `sendAction` parameter in the annotated composable and put them into our models, this logic allows for them to not be present (matching is still done by name)
- the code generation will use the parameters values and also skip generating the relevant bits if the parameters are not present, the state machine will still be collected in any case as it might do some work even if there is no communication with the UI