### PR TITLE
make compose parameters more dynamic by not forcing names

### DIFF
--- a/whetstone/compiler-test/src/test/kotlin/com/test/TestFixtures.kt
+++ b/whetstone/compiler-test/src/test/kotlin/com/test/TestFixtures.kt
@@ -19,7 +19,7 @@ public class TestBinding : ViewBinding {
     override fun getRoot(): View = throw UnsupportedOperationException("Not implemented")
 }
 
-public class TestStateMachine : StateMachine<TestState, TestAction> {
+public class TestStateMachine : FooStateMachine<TestAction, TestState, >() {
     override val state: Flow<TestState>
         get() = throw UnsupportedOperationException("Not implemented")
 
@@ -27,6 +27,8 @@ public class TestStateMachine : StateMachine<TestState, TestAction> {
         throw UnsupportedOperationException("Not implemented")
     }
 }
+
+public abstract class FooStateMachine<A: Any, S : Any, > : StateMachine<S, A>
 
 public object TestAction
 public object TestState

--- a/whetstone/compiler/build.gradle.kts
+++ b/whetstone/compiler/build.gradle.kts
@@ -21,4 +21,9 @@ dependencies {
 
     compileOnly(libs.auto.service.annotations)
     kapt(libs.auto.service.compiler)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.truth)
+    testImplementation(libs.kotlin.compile.testing)
+    testImplementation(testFixtures(libs.anvil.compiler.utils))
 }

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
@@ -48,6 +48,10 @@ internal val fragmentDialogDestination = MemberName("com.freeletics.mad.navigato
 internal val fragmentRequireRoute = MemberName("com.freeletics.mad.navigator.fragment", "requireRoute")
 internal val internalNavigatorApi = ClassName("com.freeletics.mad.navigator.internal", "InternalNavigatorApi")
 
+// StateMachine
+internal val stateMachine = ClassName("com.freeletics.mad.statemachine", "StateMachine")
+internal val stateMachineFqName = FqName(stateMachine.canonicalName)
+
 // Renderer
 internal val viewRenderer = ClassName("com.gabrielittner.renderer", "ViewRenderer")
 internal val viewRendererFactory = viewRenderer.nestedClass("Factory")

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/parser/ComposeParser.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/parser/ComposeParser.kt
@@ -3,31 +3,43 @@ package com.freeletics.mad.whetstone.parser
 import com.freeletics.mad.whetstone.ComposeScreenData
 import com.freeletics.mad.whetstone.Navigation
 import com.freeletics.mad.whetstone.codegen.util.composeFqName
+import com.freeletics.mad.whetstone.codegen.util.stateMachineFqName
 import com.freeletics.mad.whetstone.codegen.util.whetstoneComposeScreenDestinationFqName
 import com.squareup.anvil.annotations.ExperimentalAnvilApi
 import com.squareup.anvil.compiler.internal.reference.TopLevelFunctionReference
+import com.squareup.anvil.compiler.internal.reference.asClassName
 
 @OptIn(ExperimentalAnvilApi::class)
 internal fun TopLevelFunctionReference.toComposeScreenData(): ComposeScreenData? {
     val annotation = findAnnotation(composeFqName) ?: return null
+
+    val stateMachine = annotation.stateMachineReference
+    val stateMachineSuperType = stateMachine.superTypeReference(stateMachineFqName)
+    val stateParameter = stateMachine.stateMachineStateParameter(stateMachineSuperType)
+    val actionParameter = stateMachine.stateMachineActionFunctionParameter(stateMachineSuperType)
 
     return ComposeScreenData(
         baseName = name,
         packageName = packageName,
         scope = annotation.scope,
         parentScope = annotation.parentScope,
-        stateMachine = annotation.stateMachine,
+        stateMachine = stateMachine.asClassName(),
         navigation = null,
         navEntryData = null,
-        composableParameter = composeParameters,
-        stateParameter = stateParameter,
-        sendActionParameter = sendActionParameter,
+        composableParameter = getComposeParameters(stateParameter, actionParameter),
+        stateParameter = getStateParameter(stateParameter),
+        sendActionParameter = getSendActionParameter(actionParameter),
     )
 }
 
 @OptIn(ExperimentalAnvilApi::class)
 internal fun TopLevelFunctionReference.toComposeScreenDestinationData(): ComposeScreenData? {
     val annotation = findAnnotation(whetstoneComposeScreenDestinationFqName) ?: return null
+
+    val stateMachine = annotation.stateMachineReference
+    val stateMachineSuperType = stateMachine.superTypeReference(stateMachineFqName)
+    val stateParameter = stateMachine.stateMachineStateParameter(stateMachineSuperType)
+    val actionParameter = stateMachine.stateMachineActionFunctionParameter(stateMachineSuperType)
 
     val navigation = Navigation.Compose(
         route = annotation.route,
@@ -40,11 +52,11 @@ internal fun TopLevelFunctionReference.toComposeScreenDestinationData(): Compose
         packageName = packageName,
         scope = annotation.route,
         parentScope = annotation.parentScope,
-        stateMachine = annotation.stateMachine,
+        stateMachine = stateMachine.asClassName(),
         navigation = navigation,
         navEntryData = navEntryData(navigation),
-        composableParameter = composeParameters,
-        stateParameter = stateParameter,
-        sendActionParameter = sendActionParameter,
+        composableParameter = getComposeParameters(stateParameter, actionParameter),
+        stateParameter = getStateParameter(stateParameter),
+        sendActionParameter = getSendActionParameter(actionParameter),
     )
 }

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/parser/FragmentParser.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/parser/FragmentParser.kt
@@ -7,9 +7,11 @@ import com.freeletics.mad.whetstone.codegen.util.composeFragmentDestinationFqNam
 import com.freeletics.mad.whetstone.codegen.util.composeFragmentFqName
 import com.freeletics.mad.whetstone.codegen.util.rendererFragmentDestinationFqName
 import com.freeletics.mad.whetstone.codegen.util.rendererFragmentFqName
+import com.freeletics.mad.whetstone.codegen.util.stateMachineFqName
 import com.squareup.anvil.annotations.ExperimentalAnvilApi
 import com.squareup.anvil.compiler.internal.reference.ClassReference
 import com.squareup.anvil.compiler.internal.reference.TopLevelFunctionReference
+import com.squareup.anvil.compiler.internal.reference.asClassName
 
 @OptIn(ExperimentalAnvilApi::class)
 internal fun ClassReference.toRendererFragmentData(): RendererFragmentData? {
@@ -55,24 +57,34 @@ internal fun ClassReference.toRendererFragmentDestinationData(): RendererFragmen
 internal fun TopLevelFunctionReference.toComposeFragmentData(): ComposeFragmentData? {
     val annotation = findAnnotation(composeFragmentFqName) ?: return null
 
+    val stateMachine = annotation.stateMachineReference
+    val stateMachineSuperType = stateMachine.superTypeReference(stateMachineFqName)
+    val stateParameter = stateMachine.stateMachineStateParameter(stateMachineSuperType)
+    val actionParameter = stateMachine.stateMachineActionFunctionParameter(stateMachineSuperType)
+
     return ComposeFragmentData(
         baseName = name,
         packageName = packageName,
         scope = annotation.scope,
         parentScope = annotation.parentScope,
-        stateMachine = annotation.stateMachine,
+        stateMachine = stateMachine.asClassName(),
         fragmentBaseClass = annotation.fragmentBaseClass(3),
         navigation = null,
         navEntryData = null,
-        composableParameter = composeParameters,
-        stateParameter = stateParameter,
-        sendActionParameter = sendActionParameter,
+        composableParameter = getComposeParameters(stateParameter, actionParameter),
+        stateParameter = getStateParameter(stateParameter),
+        sendActionParameter = getSendActionParameter(actionParameter),
     )
 }
 
 @OptIn(ExperimentalAnvilApi::class)
 internal fun TopLevelFunctionReference.toComposeFragmentDestinationData(): ComposeFragmentData? {
     val annotation = findAnnotation(composeFragmentDestinationFqName) ?: return null
+
+    val stateMachine = annotation.stateMachineReference
+    val stateMachineSuperType = stateMachine.superTypeReference(stateMachineFqName)
+    val stateParameter = stateMachine.stateMachineStateParameter(stateMachineSuperType)
+    val actionParameter = stateMachine.stateMachineActionFunctionParameter(stateMachineSuperType)
 
     val navigation = Navigation.Fragment(
         route = annotation.route,
@@ -85,12 +97,12 @@ internal fun TopLevelFunctionReference.toComposeFragmentDestinationData(): Compo
         packageName = packageName,
         scope = annotation.route,
         parentScope = annotation.parentScope,
-        stateMachine = annotation.stateMachine,
+        stateMachine = stateMachine.asClassName(),
         fragmentBaseClass = annotation.fragmentBaseClass(5),
         navigation = navigation,
         navEntryData = navEntryData(navigation),
-        composableParameter = composeParameters,
-        stateParameter = stateParameter,
-        sendActionParameter = sendActionParameter,
+        composableParameter = getComposeParameters(stateParameter, actionParameter),
+        stateParameter = getStateParameter(stateParameter),
+        sendActionParameter = getSendActionParameter(actionParameter),
     )
 }

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/parser/ReferenceTest.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/parser/ReferenceTest.kt
@@ -1,0 +1,110 @@
+package com.freeletics.mad.whetstone.parser
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.anvil.annotations.ExperimentalAnvilApi
+import com.squareup.anvil.compiler.api.CodeGenerator
+import com.squareup.anvil.compiler.internal.testing.compileAnvil
+import com.squareup.anvil.compiler.internal.testing.simpleCodeGenerator
+import com.squareup.kotlinpoet.BOOLEAN
+import com.squareup.kotlinpoet.INT
+import com.squareup.kotlinpoet.LONG
+import com.squareup.kotlinpoet.SHORT
+import com.squareup.kotlinpoet.STRING
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.KotlinCompilation.Result
+import org.intellij.lang.annotations.Language
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.jetbrains.kotlin.name.FqName
+import org.junit.Test
+
+@OptIn(ExperimentalAnvilApi::class, ExperimentalCompilerApi::class)
+class ReferenceTest {
+
+    @Test
+    fun `inner classes are parsed`() {
+        compile(
+            """
+            package com.freeletics.test
+              
+            interface StateMachine<State, Action>
+            class Implementation : StateMachine<String, Int>
+            
+            interface StateMachineWithShortTypeParameters<S, A> : StateMachine<S, A>
+            class ImplementationWithShortTypeParameters : StateMachineWithShortTypeParameters<Long, Boolean>
+            
+            interface StateMachineWithSwappedParameters<A2, S2> : StateMachine<S2, A2>
+            class ImplementationWithWithSwappedParameters : StateMachineWithSwappedParameters<Int, String>
+            
+            interface StateMachineWithExtraParameters<T1, T2, S3, A3, T3> : StateMachine<S3, A3>
+            class ImplementationWithWithExtraParameters : StateMachineWithExtraParameters<Boolean, Long, Short, String, Int>
+    
+            abstract class Hierarchy1<A4, S4>: StateMachineWithShortTypeParameters<S4, A4>
+            abstract class Hierarchy2<T1, T2, S5, A5, T3>: Hierarchy1<A5, S5>()
+            class HierarchyImplementation : Hierarchy2<Boolean, Long, Short, String, Int>()
+
+            """.trimIndent(),
+            allWarningsAsErrors = false,
+            codeGenerators = listOf(
+                simpleCodeGenerator { psiRef ->
+                    when (psiRef.shortName) {
+                        "StateMachine" -> {}
+                        "Implementation" -> {
+                            val superType = psiRef.superTypeReference(FqName("com.freeletics.test.StateMachine"))
+                            assertThat(psiRef.resolveTypeParameter("State", superType)).isEqualTo(STRING)
+                            assertThat(psiRef.resolveTypeParameter("Action", superType)).isEqualTo(INT)
+                        }
+                        "StateMachineWithShortTypeParameters" -> {}
+                        "ImplementationWithShortTypeParameters" -> {
+                            val superType = psiRef.superTypeReference(FqName("com.freeletics.test.StateMachine"))
+                            assertThat(psiRef.resolveTypeParameter("State", superType)).isEqualTo(LONG)
+                            assertThat(psiRef.resolveTypeParameter("Action", superType)).isEqualTo(BOOLEAN)
+                        }
+                        "StateMachineWithSwappedParameters" -> {}
+                        "ImplementationWithWithSwappedParameters" -> {
+                            val superType = psiRef.superTypeReference(FqName("com.freeletics.test.StateMachine"))
+                            assertThat(psiRef.resolveTypeParameter("State", superType)).isEqualTo(STRING)
+                            assertThat(psiRef.resolveTypeParameter("Action", superType)).isEqualTo(INT)
+                        }
+                        "StateMachineWithExtraParameters" -> {}
+                        "ImplementationWithWithExtraParameters" -> {
+                            val superType = psiRef.superTypeReference(FqName("com.freeletics.test.StateMachine"))
+                            assertThat(psiRef.resolveTypeParameter("State", superType)).isEqualTo(SHORT)
+                            assertThat(psiRef.resolveTypeParameter("Action", superType)).isEqualTo(STRING)
+                        }
+                        "Hierarchy1" -> {}
+                        "Hierarchy2" -> {}
+                        "HierarchyImplementation" -> {
+                            val superType = psiRef.superTypeReference(FqName("com.freeletics.test.StateMachine"))
+                            assertThat(psiRef.resolveTypeParameter("State", superType)).isEqualTo(SHORT)
+                            assertThat(psiRef.resolveTypeParameter("Action", superType)).isEqualTo(STRING)
+                        }
+                        else -> throw NotImplementedError(psiRef.shortName)
+                    }
+
+                    null
+                }
+            )
+        ) {
+            assertThat(exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        }
+    }
+
+    private fun compile(
+        @Language("kotlin") vararg sources: String,
+        previousCompilationResult: Result? = null,
+        enableDaggerAnnotationProcessor: Boolean = false,
+        codeGenerators: List<CodeGenerator> = emptyList(),
+        allWarningsAsErrors: Boolean = true,
+        block: Result.() -> Unit = { }
+    ): Result {
+        return compileAnvil(
+            sources = sources,
+            useIR = true,
+            allWarningsAsErrors = allWarningsAsErrors,
+            previousCompilationResult = previousCompilationResult,
+            enableDaggerAnnotationProcessor = enableDaggerAnnotationProcessor,
+            codeGenerators = codeGenerators,
+            block = block
+        )
+    }
+}


### PR DESCRIPTION
Instead of expecting `state` and `sendAction` to have specific names the parsing code will not dynamically find them based on the type parameters of `StateMachine`.