### PR TITLE
change startRoute to alwasy be a NavRoot, fix destinationCallback type

### DIFF
--- a/navigator/runtime-compose/api/navigator-runtime-compose.api
+++ b/navigator/runtime-compose/api/navigator-runtime-compose.api
@@ -18,7 +18,7 @@ public abstract interface class com/freeletics/mad/navigator/compose/NavDestinat
 }
 
 public final class com/freeletics/mad/navigator/compose/NavHostKt {
-	public static final fun NavHost-lSURzpk (Lcom/freeletics/mad/navigator/BaseRoute;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/graphics/Shape;FJJJLandroidx/compose/runtime/Composer;II)V
+	public static final fun NavHost-lSURzpk (Lcom/freeletics/mad/navigator/NavRoot;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/graphics/Shape;FJJJLandroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/freeletics/mad/navigator/compose/NavigationSetupKt {

--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavHost.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavHost.kt
@@ -1,7 +1,6 @@
 package com.freeletics.mad.navigator.compose
 
 import androidx.navigation.compose.NavHost as AndroidXNavHost
-import android.content.Intent
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.ModalBottomSheetDefaults
 import androidx.compose.material.contentColorFor
@@ -26,8 +25,8 @@ import androidx.navigation.createGraph
 import androidx.navigation.get
 import com.freeletics.mad.navigator.BaseRoute
 import com.freeletics.mad.navigator.NavRoute
-
 import com.freeletics.mad.navigator.DeepLinkHandler
+import com.freeletics.mad.navigator.NavRoot
 import com.freeletics.mad.navigator.internal.AndroidXNavigationExecutor
 import com.freeletics.mad.navigator.internal.CustomActivityNavigator
 import com.freeletics.mad.navigator.internal.InternalNavigatorApi
@@ -58,11 +57,11 @@ import com.google.accompanist.navigation.material.rememberBottomSheetNavigator
 @OptIn(ExperimentalMaterialNavigationApi::class)
 @Composable
 public fun NavHost(
-    startRoute: BaseRoute,
+    startRoute: NavRoot,
     destinations: Set<NavDestination>,
     deepLinkHandlers: Set<DeepLinkHandler> = emptySet(),
     deepLinkPrefixes: Set<DeepLinkHandler.Prefix> = emptySet(),
-    destinationChangedCallback: ((NavRoute) -> Unit)? = null,
+    destinationChangedCallback: ((BaseRoute) -> Unit)? = null,
     bottomSheetShape: Shape = MaterialTheme.shapes.large,
     bottomSheetElevation: Dp = ModalBottomSheetDefaults.Elevation,
     bottomSheetBackgroundColor: Color = MaterialTheme.colors.surface,
@@ -77,7 +76,7 @@ public fun NavHost(
     if (destinationChangedCallback != null) {
         DisposableEffect(key1 = destinationChangedCallback) {
             val listener = OnDestinationChangedListener { _, _, arguments ->
-                val route = arguments.requireRoute<NavRoute>()
+                val route = arguments.requireRoute<BaseRoute>()
                 destinationChangedCallback.invoke(route)
             }
             navController.addOnDestinationChangedListener(listener)

--- a/navigator/runtime-experimental/api/runtime-experimental.api
+++ b/navigator/runtime-experimental/api/runtime-experimental.api
@@ -25,7 +25,7 @@ public abstract interface class com/freeletics/mad/navigator/compose/NavDestinat
 }
 
 public final class com/freeletics/mad/navigator/compose/NavHostKt {
-	public static final fun NavHost-lSURzpk (Lcom/freeletics/mad/navigator/BaseRoute;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/graphics/Shape;FJJJLandroidx/compose/runtime/Composer;II)V
+	public static final fun NavHost-lSURzpk (Lcom/freeletics/mad/navigator/NavRoot;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/graphics/Shape;FJJJLandroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/freeletics/mad/navigator/compose/NavigationSetupKt {

--- a/navigator/runtime-experimental/src/main/java/com/freeletics/mad/navigator/compose/NavHost.kt
+++ b/navigator/runtime-experimental/src/main/java/com/freeletics/mad/navigator/compose/NavHost.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.Dp
 import com.freeletics.mad.navigator.BaseRoute
 import com.freeletics.mad.navigator.DeepLinkHandler
-import com.freeletics.mad.navigator.NavRoute
+import com.freeletics.mad.navigator.NavRoot
 import com.freeletics.mad.navigator.compose.internal.rememberNavigationExecutor
 import com.freeletics.mad.navigator.internal.InternalNavigatorApi
 import com.freeletics.mad.navigator.internal.NavigationExecutor
@@ -24,16 +24,16 @@ import com.freeletics.mad.navigator.internal.NavigationExecutor
  * [NavigationSetup] to chage what is shown in [NavHost]
  *
  * The [destinationChangedCallback] can be used to be notified when the current destination
- * changes. Note that this will not be invoked when navigating to a [NavDestination.Activity].
+ * changes. Note that this will not be invoked when navigating to a [ActivityDestination].
  */
 @Composable
 @Suppress("unused_parameter") //TODO
 public fun NavHost(
-    startRoute: BaseRoute,
+    startRoute: NavRoot,
     destinations: Set<NavDestination>,
     deepLinkHandlers: Set<DeepLinkHandler> = emptySet(),
     deepLinkPrefixes: Set<DeepLinkHandler.Prefix> = emptySet(),
-    destinationChangedCallback: ((NavRoute) -> Unit)? = null,
+    destinationChangedCallback: ((BaseRoute) -> Unit)? = null,
     bottomSheetShape: Shape = MaterialTheme.shapes.large,
     bottomSheetElevation: Dp = ModalBottomSheetDefaults.Elevation,
     bottomSheetBackgroundColor: Color = MaterialTheme.colors.surface,


### PR DESCRIPTION
- For simplicity the API forces the start destination to use `NavRoot` which allows to make the assumption that each back stack always starts with a `NavRoot`
- Fixes the `destinationChangedCallback` to receive a `BaseRoute`, this was actually a bug until now which we just didn't notice because we didn't use `NavRoot` in compose navigation. If we would have this would crash.