### PR TITLE
fix type parameter parsing

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -89,6 +89,7 @@ renderer-connect = { module = "com.gabrielittner.renderer:connect", version.ref 
 kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinpoet" }
 auto-service-annotations = { module = "com.google.auto.service:auto-service-annotations", version.ref = "auto-service" }
 auto-service-compiler = { module = "com.google.auto.service:auto-service", version.ref = "auto-service" }
+flowredux = { module = "com.freeletics.flowredux:flowredux", version = "1.0.2" }
 
 junit = { module = "junit:junit", version.ref = "junit" }
 truth = { module = "com.google.truth:truth", version.ref = "truth" }

--- a/whetstone/compiler/build.gradle.kts
+++ b/whetstone/compiler/build.gradle.kts
@@ -25,5 +25,6 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.truth)
     testImplementation(libs.kotlin.compile.testing)
+    testImplementation(libs.flowredux)
     testImplementation(testFixtures(libs.anvil.compiler.utils))
 }

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/parser/CommonParser.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/parser/CommonParser.kt
@@ -91,17 +91,17 @@ internal fun TopLevelFunctionReference.getComposeParameters(stateParameter: Type
 }
 
 @OptIn(ExperimentalAnvilApi::class)
-internal fun ClassReference.stateMachineStateParameter(stateMachineSuperType: TypeReference): TypeName {
+internal fun ClassReference.stateMachineStateParameter(stateMachineSuperType: List<TypeReference>): TypeName {
     return resolveTypeParameter("State", stateMachineSuperType)
 }
 
 @OptIn(ExperimentalAnvilApi::class)
-internal fun ClassReference.stateMachineActionParameter(stateMachineSuperType: TypeReference): TypeName {
+internal fun ClassReference.stateMachineActionParameter(stateMachineSuperType: List<TypeReference>): TypeName {
     return resolveTypeParameter("Action", stateMachineSuperType)
 }
 
 @OptIn(ExperimentalAnvilApi::class)
-internal fun ClassReference.stateMachineActionFunctionParameter(stateMachineSuperType: TypeReference): TypeName {
+internal fun ClassReference.stateMachineActionFunctionParameter(stateMachineSuperType: List<TypeReference>): TypeName {
     return stateMachineActionParameter(stateMachineSuperType).asFunction1Parameter()
 }
 

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/parser/Reference.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/parser/Reference.kt
@@ -97,37 +97,41 @@ internal fun TypeName.asFunction1Parameter(): TypeName {
 }
 
 @OptIn(ExperimentalAnvilApi::class)
-internal fun ClassReference.resolveTypeParameter(
+public fun ClassReference.resolveTypeParameter(
     parameter: String,
-    superType: TypeReference,
+    superTypes: List<TypeReference>,
 ): TypeName {
-    // find the index of the type parameters that the current class has
-    // e.g. for a StateMachine and State this would return 0
-    val index = superType.asClassReference().typeParameters.indexOfFirst { it.name == parameter }
-    // this is the type that is used in the implementation
-    // e.g. for ... : StateMachine<S, A> this would be S
-    val unwrappedType = superType.unwrappedTypes[index]
-    // resolve the type using the implementation class
-    val resolved = unwrappedType.resolveGenericTypeOrNull(this)
-    if (resolved != null) {
-        return resolved.asTypeName()
+    var currentName = parameter
+    superTypes.forEach { superType ->
+        // find the index of the type parameters that the current class has
+        // e.g. for a StateMachine and State this would return 0
+        val index = superType.asClassReference().typeParameters.indexOfFirst { it.name == currentName }
+        // this is the type that is used in the implementation
+        // e.g. for ... : StateMachine<S, A> this would be S
+        val unwrappedType = superType.unwrappedTypes[index]
+        // resolve the type using the implementation class
+        val resolved = unwrappedType.resolveGenericTypeOrNull(this)
+        if (resolved != null) {
+            return resolved.asTypeName()
+        }
+        currentName = unwrappedType.asTypeName().toString()
     }
     throw AnvilCompilationExceptionClassReference(this, "Error resolving type parameters of $fqName")
 }
 
 @OptIn(ExperimentalAnvilApi::class)
-internal fun ClassReference.superTypeReference(superClass: FqName): TypeReference {
-    fun ClassReference.depthFirstSearch(superClass: FqName): TypeReference? {
+public fun ClassReference.superTypeReference(superClass: FqName): List<TypeReference> {
+    fun ClassReference.depthFirstSearch(superClass: FqName): List<TypeReference>? {
         directSuperTypeReferences().forEach {
             val classReference = it.asClassReferenceOrNull()
             if (classReference != null) {
                 if (classReference.fqName == superClass) {
-                    return it
+                    return listOf(it)
                 }
 
                 val fromSuperClasses = classReference.depthFirstSearch(superClass)
                 if (fromSuperClasses != null) {
-                    return fromSuperClasses
+                    return fromSuperClasses + it
                 }
             }
         }

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/parser/Reference.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/parser/Reference.kt
@@ -97,7 +97,7 @@ internal fun TypeName.asFunction1Parameter(): TypeName {
 }
 
 @OptIn(ExperimentalAnvilApi::class)
-public fun ClassReference.resolveTypeParameter(
+internal fun ClassReference.resolveTypeParameter(
     parameter: String,
     superTypes: List<TypeReference>,
 ): TypeName {
@@ -120,7 +120,7 @@ public fun ClassReference.resolveTypeParameter(
 }
 
 @OptIn(ExperimentalAnvilApi::class)
-public fun ClassReference.superTypeReference(superClass: FqName): List<TypeReference> {
+internal fun ClassReference.superTypeReference(superClass: FqName): List<TypeReference> {
     fun ClassReference.depthFirstSearch(superClass: FqName): List<TypeReference>? {
         directSuperTypeReferences().forEach {
             val classReference = it.asClassReferenceOrNull()

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/parser/TestStateMachine.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/parser/TestStateMachine.kt
@@ -1,0 +1,7 @@
+package com.freeletics.mad.whetstone.parser
+
+import com.freeletics.flowredux.dsl.FlowReduxStateMachine
+
+abstract class TestStateMachine<S : Any, A : Any>(
+    initial: S
+) : FlowReduxStateMachine<S, A>(initial)


### PR DESCRIPTION
Found an issue with the type resolving while preparing to update our internal code base. I'm not entirely sure why it doesn't work but it has something to do with mixing classes from different sources. The new test case would not fail if `TestStateMachine` is defined in the source string in the test instead of as regular class in the test source set and it would also not fail if `TestStateMachine` would extend `StateMachine` instead of `FlowReduxStateMachine`.