### PR TITLE
make whetstone-scope a jvm module again

### DIFF
--- a/whetstone/scope/whetstone-scope.gradle.kts
+++ b/whetstone/scope/whetstone-scope.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    alias(libs.plugins.fgp.android)
+    alias(libs.plugins.fgp.jvm)
     alias(libs.plugins.dokka)
     alias(libs.plugins.fgp.publish)
 }


### PR DESCRIPTION
Accidentally used the wrong plugin in #340 