### PR TITLE
add missing enableCompose to whetstone runtime

### DIFF
--- a/whetstone/runtime/whetstone-runtime.gradle.kts
+++ b/whetstone/runtime/whetstone-runtime.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 freeletics {
     explicitApi()
     optIn("com.freeletics.mad.whetstone.internal.InternalWhetstoneApi")
+    enableCompose()
 }
 
 


### PR DESCRIPTION
This got lost when migrating to FGP and causes the `asComposeState` method to be not found by callers. 