### PR TITLE
opt into experimental anvil and compiler APIs at the module level

### DIFF
--- a/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/TestHelper.kt
+++ b/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/TestHelper.kt
@@ -5,14 +5,12 @@ import com.freeletics.mad.whetstone.ComposeFragmentData
 import com.freeletics.mad.whetstone.ComposeScreenData
 import com.freeletics.mad.whetstone.RendererFragmentData
 import com.google.common.truth.Truth.assertThat
-import com.squareup.anvil.annotations.ExperimentalAnvilApi
 import com.squareup.anvil.compiler.internal.testing.AnvilCompilation
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
 import com.tschuchort.compiletesting.SourceFile
 import java.io.File
 import java.nio.file.Files
-import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 
 public fun test(data: ComposeScreenData, fileName: String, source: String, expected: String) {
     val actual = FileGenerator().generate(data).toString()
@@ -35,7 +33,6 @@ public fun test(data: RendererFragmentData, fileName: String, source: String, ex
     compileWithAnvil(fileName, source, actual)
 }
 
-@OptIn(ExperimentalCompilerApi::class)
 private fun compile(fileName: String, source: String, output: String) {
     val compilation = KotlinCompilation().apply {
         configure()
@@ -49,7 +46,6 @@ private fun compile(fileName: String, source: String, output: String) {
     assertThat(compilation.compile().exitCode).isEqualTo(ExitCode.OK)
 }
 
-@OptIn(ExperimentalCompilerApi::class, ExperimentalAnvilApi::class)
 private fun compileWithAnvil(fileName: String, source: String, output: String) {
     val compilation = AnvilCompilation().apply {
         configureAnvil()
@@ -65,14 +61,12 @@ private fun compileWithAnvil(fileName: String, source: String, output: String) {
     assertThat(compilation.kotlinCompilation.generatedFile(fileName)).isEqualTo(output)
 }
 
-@OptIn(ExperimentalCompilerApi::class)
 private fun KotlinCompilation.sourceFile(name: String, content: String): SourceFile {
     val path = "${workingDir.absolutePath}/sources/src/main/kotlin/$name"
     Files.createDirectories(File(path).parentFile!!.toPath())
     return SourceFile.kotlin(path, content)
 }
 
-@OptIn(ExperimentalCompilerApi::class)
 private fun KotlinCompilation.generatedFile(name: String): String {
     val path = "${workingDir.absolutePath}/build/anvil/${name.testFileName()}"
     return File(path).readText()
@@ -84,7 +78,6 @@ private fun String.testFileName(): String {
     return "$path/Whetstone$name"
 }
 
-@OptIn(ExperimentalCompilerApi::class)
 private fun KotlinCompilation.configure() {
     @Suppress("DEPRECATION") // can be changed once compose uses ComponentPluginRegistrar
     componentRegistrars = componentRegistrars + listOf(ComposeComponentRegistrar())

--- a/whetstone/compiler-test/whetstone-compiler-test.gradle.kts
+++ b/whetstone/compiler-test/whetstone-compiler-test.gradle.kts
@@ -4,6 +4,10 @@ plugins {
 
 freeletics {
     explicitApi()
+    optIn(
+        "com.squareup.anvil.annotations.ExperimentalAnvilApi",
+        "org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi",
+    )
 }
 
 dependencies {

--- a/whetstone/compiler-test/whetstone-compiler-test.gradle.kts
+++ b/whetstone/compiler-test/whetstone-compiler-test.gradle.kts
@@ -37,11 +37,6 @@ dependencies {
     testImplementation(libs.anvil.annotations)
     testImplementation(libs.anvil.compiler.utils)
     testImplementation(testFixtures(libs.anvil.compiler.utils))
-    testImplementation(libs.kotlin.compiler) {
-        version {
-            strictly(libs.versions.kotlin.asProvider().get())
-        }
-    }
 }
 
 // exclude dependency from renderer connect, we include the local module instead

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/WhetstoneCodeGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/WhetstoneCodeGenerator.kt
@@ -8,7 +8,6 @@ import com.freeletics.mad.whetstone.parser.toComposeScreenDestinationData
 import com.freeletics.mad.whetstone.parser.toRendererFragmentData
 import com.freeletics.mad.whetstone.parser.toRendererFragmentDestinationData
 import com.google.auto.service.AutoService
-import com.squareup.anvil.annotations.ExperimentalAnvilApi
 import com.squareup.anvil.compiler.api.AnvilContext
 import com.squareup.anvil.compiler.api.CodeGenerator
 import com.squareup.anvil.compiler.api.GeneratedFile
@@ -19,7 +18,6 @@ import java.io.File
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.psi.KtFile
 
-@OptIn(ExperimentalAnvilApi::class)
 @AutoService(CodeGenerator::class)
 public class WhetstoneCodeGenerator : CodeGenerator {
 

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/ComponentGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/ComponentGenerator.kt
@@ -17,7 +17,6 @@ import com.freeletics.mad.whetstone.codegen.util.scopeToAnnotation
 import com.freeletics.mad.whetstone.codegen.util.simplePropertySpec
 import com.freeletics.mad.whetstone.codegen.util.subcomponentAnnotation
 import com.freeletics.mad.whetstone.codegen.util.subcomponentFactoryAnnotation
-import com.squareup.anvil.annotations.ExperimentalAnvilApi
 import com.squareup.anvil.compiler.internal.decapitalize
 import com.squareup.kotlinpoet.AnnotationSpec.UseSiteTarget.GET
 import com.squareup.kotlinpoet.FunSpec
@@ -43,7 +42,6 @@ internal const val closeableSetPropertyName = "closeables"
 internal val Generator<out BaseData>.retainedParentComponentClassName
     get() = retainedComponentClassName.nestedClass("ParentComponent")
 
-@OptIn(ExperimentalAnvilApi::class)
 internal val Generator<out BaseData>.retainedParentComponentGetterName
     get() = "${retainedComponentClassName.simpleName.decapitalize()}Factory"
 

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/parser/CommonParser.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/parser/CommonParser.kt
@@ -7,7 +7,6 @@ import com.freeletics.mad.whetstone.codegen.util.appScope
 import com.freeletics.mad.whetstone.codegen.util.fragment
 import com.freeletics.mad.whetstone.codegen.util.navEntryComponentFqName
 import com.freeletics.mad.whetstone.codegen.util.viewRendererFactoryFqName
-import com.squareup.anvil.annotations.ExperimentalAnvilApi
 import com.squareup.anvil.compiler.internal.reference.AnnotatedReference
 import com.squareup.anvil.compiler.internal.reference.AnnotationReference
 import com.squareup.anvil.compiler.internal.reference.ClassReference
@@ -19,40 +18,31 @@ import com.squareup.anvil.compiler.internal.reference.asClassName
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.TypeName
 
-@OptIn(ExperimentalAnvilApi::class)
 internal val AnnotationReference.scope: ClassName
     get() = requireClassArgument("scope", 0)
 
-@OptIn(ExperimentalAnvilApi::class)
 internal val AnnotationReference.route: ClassName
     get() = requireClassArgument("route", 0)
 
-@OptIn(ExperimentalAnvilApi::class)
 internal val AnnotationReference.parentScope: ClassName
     get() = optionalClassArgument("parentScope", 1)?: appScope
 
-@OptIn(ExperimentalAnvilApi::class)
 internal val AnnotationReference.stateMachine: ClassName
     get() = stateMachineReference.asClassName()
 
-@OptIn(ExperimentalAnvilApi::class)
 internal val AnnotationReference.stateMachineReference: ClassReference
     get() = requireClassReferenceArgument("stateMachine", 2)
 
-@OptIn(ExperimentalAnvilApi::class)
 internal val AnnotationReference.destinationType: String
     get() = optionalEnumArgument("destinationType", 3) ?: "SCREEN"
 
-@OptIn(ExperimentalAnvilApi::class)
 internal val AnnotationReference.destinationScope: ClassName
     get() = optionalClassArgument("destinationScope", 4) ?: appScope
 
-@OptIn(ExperimentalAnvilApi::class)
 internal fun AnnotationReference.fragmentBaseClass(index: Int): ClassName {
     return optionalClassArgument("fragmentBaseClass", index) ?: fragment
 }
 
-@OptIn(ExperimentalAnvilApi::class)
 internal fun AnnotatedReference.navEntryData(
     navigation: Navigation
 ): NavEntryData? {
@@ -66,21 +56,18 @@ internal fun AnnotatedReference.navEntryData(
     )
 }
 
-@OptIn(ExperimentalAnvilApi::class)
 internal fun TopLevelFunctionReference.getStateParameter(stateParameter: TypeName): ComposableParameter? {
     return parameters
         .find { it.type().asTypeName() == stateParameter }
         ?.toComposableParameter()
 }
 
-@OptIn(ExperimentalAnvilApi::class)
 internal fun TopLevelFunctionReference.getSendActionParameter(actionParameter: TypeName): ComposableParameter? {
     return parameters
         .find { it.type().asTypeName() == actionParameter }
         ?.toComposableParameter()
 }
 
-@OptIn(ExperimentalAnvilApi::class)
 internal fun TopLevelFunctionReference.getComposeParameters(stateParameter: TypeName, actionParameter: TypeName): List<ComposableParameter> {
     return parameters
         .filter {
@@ -90,22 +77,18 @@ internal fun TopLevelFunctionReference.getComposeParameters(stateParameter: Type
         .map { it.toComposableParameter() }
 }
 
-@OptIn(ExperimentalAnvilApi::class)
 internal fun ClassReference.stateMachineStateParameter(stateMachineSuperType: List<TypeReference>): TypeName {
     return resolveTypeParameter("State", stateMachineSuperType)
 }
 
-@OptIn(ExperimentalAnvilApi::class)
 internal fun ClassReference.stateMachineActionParameter(stateMachineSuperType: List<TypeReference>): TypeName {
     return resolveTypeParameter("Action", stateMachineSuperType)
 }
 
-@OptIn(ExperimentalAnvilApi::class)
 internal fun ClassReference.stateMachineActionFunctionParameter(stateMachineSuperType: List<TypeReference>): TypeName {
     return stateMachineActionParameter(stateMachineSuperType).asFunction1Parameter()
 }
 
-@OptIn(ExperimentalAnvilApi::class)
 internal fun ClassReference.findRendererFactory(): ClassName {
     val factoryClass = innerClasses().find { innerClass ->
         innerClass.allSuperTypeClassReferences().any { superType ->

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/parser/ComposeParser.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/parser/ComposeParser.kt
@@ -5,11 +5,9 @@ import com.freeletics.mad.whetstone.Navigation
 import com.freeletics.mad.whetstone.codegen.util.composeFqName
 import com.freeletics.mad.whetstone.codegen.util.stateMachineFqName
 import com.freeletics.mad.whetstone.codegen.util.whetstoneComposeScreenDestinationFqName
-import com.squareup.anvil.annotations.ExperimentalAnvilApi
 import com.squareup.anvil.compiler.internal.reference.TopLevelFunctionReference
 import com.squareup.anvil.compiler.internal.reference.asClassName
 
-@OptIn(ExperimentalAnvilApi::class)
 internal fun TopLevelFunctionReference.toComposeScreenData(): ComposeScreenData? {
     val annotation = findAnnotation(composeFqName) ?: return null
 
@@ -32,7 +30,6 @@ internal fun TopLevelFunctionReference.toComposeScreenData(): ComposeScreenData?
     )
 }
 
-@OptIn(ExperimentalAnvilApi::class)
 internal fun TopLevelFunctionReference.toComposeScreenDestinationData(): ComposeScreenData? {
     val annotation = findAnnotation(whetstoneComposeScreenDestinationFqName) ?: return null
 

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/parser/FragmentParser.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/parser/FragmentParser.kt
@@ -8,12 +8,10 @@ import com.freeletics.mad.whetstone.codegen.util.composeFragmentFqName
 import com.freeletics.mad.whetstone.codegen.util.rendererFragmentDestinationFqName
 import com.freeletics.mad.whetstone.codegen.util.rendererFragmentFqName
 import com.freeletics.mad.whetstone.codegen.util.stateMachineFqName
-import com.squareup.anvil.annotations.ExperimentalAnvilApi
 import com.squareup.anvil.compiler.internal.reference.ClassReference
 import com.squareup.anvil.compiler.internal.reference.TopLevelFunctionReference
 import com.squareup.anvil.compiler.internal.reference.asClassName
 
-@OptIn(ExperimentalAnvilApi::class)
 internal fun ClassReference.toRendererFragmentData(): RendererFragmentData? {
     val annotation = findAnnotation(rendererFragmentFqName) ?: return null
 
@@ -30,7 +28,6 @@ internal fun ClassReference.toRendererFragmentData(): RendererFragmentData? {
     )
 }
 
-@OptIn(ExperimentalAnvilApi::class)
 internal fun ClassReference.toRendererFragmentDestinationData(): RendererFragmentData? {
     val annotation = findAnnotation(rendererFragmentDestinationFqName) ?: return null
 
@@ -53,7 +50,6 @@ internal fun ClassReference.toRendererFragmentDestinationData(): RendererFragmen
     )
 }
 
-@OptIn(ExperimentalAnvilApi::class)
 internal fun TopLevelFunctionReference.toComposeFragmentData(): ComposeFragmentData? {
     val annotation = findAnnotation(composeFragmentFqName) ?: return null
 
@@ -77,7 +73,6 @@ internal fun TopLevelFunctionReference.toComposeFragmentData(): ComposeFragmentD
     )
 }
 
-@OptIn(ExperimentalAnvilApi::class)
 internal fun TopLevelFunctionReference.toComposeFragmentDestinationData(): ComposeFragmentData? {
     val annotation = findAnnotation(composeFragmentDestinationFqName) ?: return null
 

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/parser/Reference.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/parser/Reference.kt
@@ -1,7 +1,6 @@
 package com.freeletics.mad.whetstone.parser
 
 import com.freeletics.mad.whetstone.ComposableParameter
-import com.squareup.anvil.annotations.ExperimentalAnvilApi
 import com.squareup.anvil.compiler.internal.reference.AnnotatedReference
 import com.squareup.anvil.compiler.internal.reference.AnnotationReference
 import com.squareup.anvil.compiler.internal.reference.AnvilCompilationExceptionAnnotationReference
@@ -22,44 +21,36 @@ import com.squareup.kotlinpoet.asClassName
 import org.jetbrains.kotlin.descriptors.containingPackage
 import org.jetbrains.kotlin.name.FqName
 
-@OptIn(ExperimentalAnvilApi::class)
 internal fun AnnotatedReference.findAnnotation(fqName: FqName): AnnotationReference? {
     return annotations.find { it.fqName == fqName }
 }
 
-@OptIn(ExperimentalAnvilApi::class)
 internal fun AnnotationReference.requireClassArgument(name: String, index: Int): ClassName {
     return requireClassReferenceArgument(name, index).asClassName()
 }
 
-@OptIn(ExperimentalAnvilApi::class)
 internal fun AnnotationReference.optionalClassArgument(name: String, index: Int): ClassName? {
     return optionalClassReferenceArgument(name, index)?.asClassName()
 }
 
-@OptIn(ExperimentalAnvilApi::class)
 internal fun AnnotationReference.requireClassReferenceArgument(name: String, index: Int): ClassReference {
     return optionalClassReferenceArgument(name, index) ?:
         throw AnvilCompilationExceptionAnnotationReference(this, "Couldn't find $name for $fqName")
 }
 
-@OptIn(ExperimentalAnvilApi::class)
 internal fun AnnotationReference.optionalClassReferenceArgument(name: String, index: Int): ClassReference? {
     return argumentAt(name, index)?.value()
 }
 
-@OptIn(ExperimentalAnvilApi::class)
 internal fun AnnotationReference.requireEnumArgument(name: String, index: Int): String {
     return optionalEnumArgument(name, index) ?:
         throw AnvilCompilationExceptionAnnotationReference(this, "Couldn't find $name for $fqName")
 }
 
-@OptIn(ExperimentalAnvilApi::class)
 internal fun AnnotationReference.optionalEnumArgument(name: String, index: Int): String? {
     return argumentAt(name, index)?.value<FqName>()?.shortName()?.asString()
 }
 
-@OptIn(ExperimentalAnvilApi::class)
 internal fun ParameterReference.toComposableParameter(): ComposableParameter {
     return ComposableParameter(
         name = name,
@@ -67,7 +58,6 @@ internal fun ParameterReference.toComposableParameter(): ComposableParameter {
     )
 }
 
-@OptIn(ExperimentalAnvilApi::class)
 internal val AnnotatedReference.packageName: String
     get() = when (this) {
         is ClassReference -> packageName
@@ -77,14 +67,12 @@ internal val AnnotatedReference.packageName: String
         else -> throw UnsupportedOperationException("Can't retrieve packageName for $this")
     }
 
-@OptIn(ExperimentalAnvilApi::class)
 internal val TopLevelFunctionReference.packageName: String
     get() = when (this) {
         is TopLevelFunctionReference.Psi -> function.containingKtFile.packageFqName
         is TopLevelFunctionReference.Descriptor -> function.containingPackage()!!
     }.packageString()
 
-@OptIn(ExperimentalAnvilApi::class)
 internal val ClassReference.packageName: String
     get() = packageFqName.packageString()
 
@@ -96,7 +84,6 @@ internal fun TypeName.asFunction1Parameter(): TypeName {
     return Function1::class.asClassName().parameterizedBy(this, UNIT)
 }
 
-@OptIn(ExperimentalAnvilApi::class)
 internal fun ClassReference.resolveTypeParameter(
     parameter: String,
     superTypes: List<TypeReference>,
@@ -119,7 +106,6 @@ internal fun ClassReference.resolveTypeParameter(
     throw AnvilCompilationExceptionClassReference(this, "Error resolving type parameters of $fqName")
 }
 
-@OptIn(ExperimentalAnvilApi::class)
 internal fun ClassReference.superTypeReference(superClass: FqName): List<TypeReference> {
     fun ClassReference.depthFirstSearch(superClass: FqName): List<TypeReference>? {
         directSuperTypeReferences().forEach {

--- a/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/parser/ReferenceTest.kt
+++ b/whetstone/compiler/src/test/kotlin/com/freeletics/mad/whetstone/parser/ReferenceTest.kt
@@ -1,7 +1,6 @@
 package com.freeletics.mad.whetstone.parser
 
 import com.google.common.truth.Truth.assertThat
-import com.squareup.anvil.annotations.ExperimentalAnvilApi
 import com.squareup.anvil.compiler.api.CodeGenerator
 import com.squareup.anvil.compiler.internal.testing.compileAnvil
 import com.squareup.anvil.compiler.internal.testing.simpleCodeGenerator
@@ -14,11 +13,9 @@ import com.squareup.kotlinpoet.STRING
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.KotlinCompilation.Result
 import org.intellij.lang.annotations.Language
-import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.name.FqName
 import org.junit.Test
 
-@OptIn(ExperimentalAnvilApi::class, ExperimentalCompilerApi::class)
 internal class ReferenceTest {
 
     @Test

--- a/whetstone/compiler/whetstone-compiler.gradle.kts
+++ b/whetstone/compiler/whetstone-compiler.gradle.kts
@@ -9,6 +9,10 @@ plugins {
 
 freeletics {
     explicitApi()
+    optIn(
+        "com.squareup.anvil.annotations.ExperimentalAnvilApi",
+        "org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi",
+    )
 }
 
 dependencies {


### PR DESCRIPTION
It's easier this way and we knowingly use these despite their status.