### PR TITLE
Add bottom sheet feature to simple sample

### DIFF
--- a/sample/simple/app/simple/app-simple.gradle.kts
+++ b/sample/simple/app/simple/app-simple.gradle.kts
@@ -11,5 +11,7 @@ dependencies {
     implementation(libs.fl.navigator.runtime.compose)
     implementation(projects.feature.a.implementation)
     implementation(projects.feature.a.nav)
+    implementation(projects.feature.bottomSheet.implementation)
+    implementation(projects.feature.bottomSheet.nav)
     implementation(projects.feature.main)
 }

--- a/sample/simple/feature/a/implementation/src/main/java/com/freeletics/mad/sample/feature/a/FeatureANavigator.kt
+++ b/sample/simple/feature/a/implementation/src/main/java/com/freeletics/mad/sample/feature/a/FeatureANavigator.kt
@@ -2,10 +2,15 @@ package com.freeletics.mad.sample.feature.a
 
 import com.freeletics.mad.sample.feature.a.nav.FeatureARoute
 import com.freeletics.mad.navigator.NavEventNavigator
+import com.freeletics.mad.sample.feature.bottomsheet.nav.BottomSheetRoute
 import com.freeletics.mad.whetstone.ScopeTo
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 
 @ScopeTo(FeatureARoute::class)
 @ContributesBinding(FeatureARoute::class, NavEventNavigator::class)
-class FeatureANavigator @Inject constructor() : NavEventNavigator()
+class FeatureANavigator @Inject constructor() : NavEventNavigator() {
+    fun navigateToBottomSheet() {
+        navigateTo(BottomSheetRoute)
+    }
+}

--- a/sample/simple/feature/a/implementation/src/main/java/com/freeletics/mad/sample/feature/a/FeatureAScreen.kt
+++ b/sample/simple/feature/a/implementation/src/main/java/com/freeletics/mad/sample/feature/a/FeatureAScreen.kt
@@ -1,11 +1,17 @@
 package com.freeletics.mad.sample.feature.a
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.freeletics.mad.sample.feature.a.nav.FeatureARoute
 import com.freeletics.mad.whetstone.compose.ComposeDestination
 
@@ -14,11 +20,21 @@ import com.freeletics.mad.whetstone.compose.ComposeDestination
     stateMachine = FeatureAStateMachine::class,
 )
 @Composable
-fun FeatureAScreen() {
-    Box(
+fun FeatureAScreen(
+    sendAction: (FeatureAAction) -> Unit,
+) {
+    Column(
         modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
     ) {
         BasicText("Feature A")
+
+        Spacer(Modifier.height(12.dp))
+
+        BasicText(
+            modifier = Modifier.clickable { sendAction(FeatureAAction.ButtonClicked) },
+            text = "Open Bottom Sheet",
+        )
     }
 }

--- a/sample/simple/feature/a/implementation/src/main/java/com/freeletics/mad/sample/feature/a/FeatureAStateMachine.kt
+++ b/sample/simple/feature/a/implementation/src/main/java/com/freeletics/mad/sample/feature/a/FeatureAStateMachine.kt
@@ -2,17 +2,27 @@ package com.freeletics.mad.sample.feature.a
 
 import com.freeletics.mad.statemachine.StateMachine
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import javax.inject.Inject
 
 sealed interface FeatureAState
 
 object Init : FeatureAState
 
-sealed interface FeatureAAction
+sealed interface FeatureAAction {
+    object ButtonClicked : FeatureAAction
+}
 
-class FeatureAStateMachine @Inject constructor() : StateMachine<FeatureAState, FeatureAAction> {
-    override val state: Flow<FeatureAState> = flowOf(Init)
+class FeatureAStateMachine @Inject constructor(
+    private val navigator: FeatureANavigator,
+) : StateMachine<FeatureAState, FeatureAAction> {
+    private val _state = MutableStateFlow(Init)
+    override val state: Flow<FeatureAState> = _state.asStateFlow()
 
-    override suspend fun dispatch(action: FeatureAAction) {}
+    override suspend fun dispatch(action: FeatureAAction) {
+        when (action) {
+            FeatureAAction.ButtonClicked -> navigator.navigateToBottomSheet()
+        }
+    }
 }

--- a/sample/simple/feature/bottom-sheet/implementation/feature-bottom-sheet-implementation.gradle.kts
+++ b/sample/simple/feature/bottom-sheet/implementation/feature-bottom-sheet-implementation.gradle.kts
@@ -13,6 +13,5 @@ dependencies {
     implementation(libs.fl.navigator.runtime.compose)
     implementation(libs.fl.whetstone.runtime.compose)
     implementation(libs.fl.whetstone.scope)
-    implementation(projects.feature.a.nav)
     implementation(projects.feature.bottomSheet.nav)
 }

--- a/sample/simple/feature/bottom-sheet/implementation/src/main/java/com/freeletics/mad/sample/feature/bottomsheet/BottomSheetNavigator.kt
+++ b/sample/simple/feature/bottom-sheet/implementation/src/main/java/com/freeletics/mad/sample/feature/bottomsheet/BottomSheetNavigator.kt
@@ -1,0 +1,11 @@
+package com.freeletics.mad.sample.feature.bottomsheet
+
+import com.freeletics.mad.navigator.NavEventNavigator
+import com.freeletics.mad.sample.feature.bottomsheet.nav.BottomSheetRoute
+import com.freeletics.mad.whetstone.ScopeTo
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+@ScopeTo(BottomSheetRoute::class)
+@ContributesBinding(BottomSheetRoute::class, NavEventNavigator::class)
+class BottomSheetNavigator @Inject constructor() : NavEventNavigator()

--- a/sample/simple/feature/bottom-sheet/implementation/src/main/java/com/freeletics/mad/sample/feature/bottomsheet/BottomSheetScreen.kt
+++ b/sample/simple/feature/bottom-sheet/implementation/src/main/java/com/freeletics/mad/sample/feature/bottomsheet/BottomSheetScreen.kt
@@ -1,0 +1,26 @@
+package com.freeletics.mad.sample.feature.bottomsheet
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.freeletics.mad.sample.feature.bottomsheet.nav.BottomSheetRoute
+import com.freeletics.mad.whetstone.compose.ComposeDestination
+import com.freeletics.mad.whetstone.compose.DestinationType
+
+@ComposeDestination(
+    route = BottomSheetRoute::class,
+    stateMachine = BottomSheetStateMachine::class,
+    destinationType = DestinationType.BOTTOM_SHEET,
+)
+@Composable
+fun BottomSheetScreen() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        BasicText("Feature BottomSheet")
+    }
+}

--- a/sample/simple/feature/bottom-sheet/implementation/src/main/java/com/freeletics/mad/sample/feature/bottomsheet/BottomSheetStateMachine.kt
+++ b/sample/simple/feature/bottom-sheet/implementation/src/main/java/com/freeletics/mad/sample/feature/bottomsheet/BottomSheetStateMachine.kt
@@ -1,0 +1,18 @@
+package com.freeletics.mad.sample.feature.bottomsheet
+
+import com.freeletics.mad.statemachine.StateMachine
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import javax.inject.Inject
+
+sealed interface BottomSheetState
+
+object Init : BottomSheetState
+
+sealed interface BottomSheetAction
+
+class BottomSheetStateMachine @Inject constructor() : StateMachine<BottomSheetState, BottomSheetAction> {
+    override val state: Flow<BottomSheetState> = flowOf(Init)
+
+    override suspend fun dispatch(action: BottomSheetAction) {}
+}

--- a/sample/simple/feature/bottom-sheet/nav/feature-bottom-sheet-nav.gradle.kts
+++ b/sample/simple/feature/bottom-sheet/nav/feature-bottom-sheet-nav.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    alias(libs.plugins.fgp.nav)
+}
+
+dependencies {
+    api(libs.fl.navigator.runtime)
+    implementation(libs.androidx.annotations)
+}

--- a/sample/simple/feature/bottom-sheet/nav/src/main/java/com/freeletics/mad/sample/feature/bottomsheet/nav/BottomSheetRoute.kt
+++ b/sample/simple/feature/bottom-sheet/nav/src/main/java/com/freeletics/mad/sample/feature/bottomsheet/nav/BottomSheetRoute.kt
@@ -1,0 +1,7 @@
+package com.freeletics.mad.sample.feature.bottomsheet.nav
+
+import com.freeletics.mad.navigator.NavRoute
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+object BottomSheetRoute : NavRoute


### PR DESCRIPTION
Added a bottom sheet feature to the simple sample application. This is to demonstrate and debug an issue with the bottom sheet navigation.

Issue:
* Open the bottom sheet by clicking on the "Bottom Sheet" text
* Dismiss the bottom sheet by clicking on the grey scrim area
* Try to open the bottom sheet again by clicking on the text
=> The bottom sheet doesn't open again. It continues working if you press the back button.

Assumption: The bottom sheet is not cleared from the backstack if you click on the scrim area.