### PR TITLE
Fix bottom sheet back navigation

### DIFF
--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavHost.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavHost.kt
@@ -1,25 +1,49 @@
 package com.freeletics.mad.navigator.compose
 
-import androidx.compose.material.*
-import androidx.compose.runtime.*
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.navigation.compose.NavHost as AndroidXNavHost
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.ModalBottomSheetDefaults
+import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.material.SwipeableDefaults
+import androidx.compose.material.contentColorFor
+import androidx.compose.material.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.Dp
-import androidx.navigation.*
+import androidx.navigation.NavArgument
+import androidx.navigation.NavController
 import androidx.navigation.NavController.OnDestinationChangedListener
+import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.ComposeNavigator
 import androidx.navigation.compose.DialogNavigator
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.createGraph
+import androidx.navigation.get
 import com.freeletics.mad.navigator.BaseRoute
+import com.freeletics.mad.navigator.NavRoute
 import com.freeletics.mad.navigator.DeepLinkHandler
 import com.freeletics.mad.navigator.NavRoot
-import com.freeletics.mad.navigator.NavRoute
-import com.freeletics.mad.navigator.internal.*
+import com.freeletics.mad.navigator.internal.AndroidXNavigationExecutor
+import com.freeletics.mad.navigator.internal.CustomActivityNavigator
+import com.freeletics.mad.navigator.internal.InternalNavigatorApi
+import com.freeletics.mad.navigator.internal.NavigationExecutor
+import com.freeletics.mad.navigator.internal.destinationId
+import com.freeletics.mad.navigator.internal.getArguments
+import com.freeletics.mad.navigator.internal.handleDeepLink
+import com.freeletics.mad.navigator.internal.requireRoute
 import com.google.accompanist.navigation.material.BottomSheetNavigator
 import com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi
 import com.google.accompanist.navigation.material.ModalBottomSheetLayout
-import androidx.navigation.compose.NavHost as AndroidXNavHost
 
 /**
  * Create a new [androidx.navigation.compose.NavHost] with a [androidx.navigation.NavGraph]

--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavHost.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavHost.kt
@@ -82,6 +82,7 @@ public fun NavHost(
     val executor = remember(navController) { AndroidXNavigationExecutor(navController) }
     val context = LocalContext.current
 
+    // Pops the bottom sheet from backstack if we close it by swiping down or clicking on the scrim area
     LaunchedEffect(Unit) {
         var previous: ModalBottomSheetValue? = null
         snapshotFlow { bottomSheetNavigator.navigatorSheetState.currentValue }

--- a/sample/simple/settings.gradle
+++ b/sample/simple/settings.gradle
@@ -11,3 +11,7 @@ plugins {
 }
 
 rootProject.name = "simple-sample"
+
+freeletics {
+    includeMad("../../")
+}

--- a/sample/simple/settings.gradle
+++ b/sample/simple/settings.gradle
@@ -11,7 +11,3 @@ plugins {
 }
 
 rootProject.name = "simple-sample"
-
-freeletics {
-    includeMad("../../")
-}

--- a/whetstone/compiler/whetstone-compiler.gradle.kts
+++ b/whetstone/compiler/whetstone-compiler.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     testImplementation(libs.truth)
     testImplementation(libs.kotlin.compile.testing)
     testImplementation(libs.coroutines.core)
-    testImplementation(libs.flowredux)
+//    testImplementation(libs.flowredux)
     testImplementation(testFixtures(libs.anvil.compiler.utils))
 }
 

--- a/whetstone/compiler/whetstone-compiler.gradle.kts
+++ b/whetstone/compiler/whetstone-compiler.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     testImplementation(libs.truth)
     testImplementation(libs.kotlin.compile.testing)
     testImplementation(libs.coroutines.core)
-//    testImplementation(libs.flowredux)
+    testImplementation(libs.flowredux)
     testImplementation(testFixtures(libs.anvil.compiler.utils))
 }
 


### PR DESCRIPTION
Closes #365 

## Description
The back navigation from a bottom sheet feature by clicking on the scrim area (greyed out area) prevents further navigation afterwards.
The simple sample can be used to demonstrate and debug the issue.

Issue:

* Open the bottom sheet by clicking on the "Bottom Sheet" text
* Dismiss the bottom sheet by clicking on the grey scrim area
* Try to open the bottom sheet again by clicking on the text

=> The bottom sheet doesn't open again. It continues working if you press the back button.

## Solution
We pop the backstack if the bottom sheet state changes from open to closed and the current entry has "BottomSheetNavigator" as navigator. This is the case if you press on the scrim area or navigate back by swiping down the bottom sheet.
If you navigate back by using the back button, the entry is already removed from stack when we call this code.

## Testing
You can use commit 6a3d893c832452a9f45138a15562a66129f29203 to test the issue. It includes local module substitution and the fix.