### PR TITLE
implement Stack which represents a single back stack

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,7 +69,7 @@ androidx-compose-runtime = { module = "androidx.compose.runtime:runtime", versio
 androidx-compose-ui = { module = "androidx.compose.ui:ui", version.ref = "androidx-compose-ui" }
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "androidx-compose-foundation" }
 androidx-compose-material = { module = "androidx.compose.material:material", version.ref = "androidx-compose-material" }
-androidx-core = { module = "androidx.core:core", version.ref = "androidx-core" }
+androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-lifecycle-common = { module = "androidx.lifecycle:lifecycle-common", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-testing = { module = "androidx.lifecycle:lifecycle-runtime-testing", version.ref = "androidx-lifecycle" }

--- a/navigator/runtime-experimental/navigator-runtime-experimental.gradle.kts
+++ b/navigator/runtime-experimental/navigator-runtime-experimental.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.fgp.android)
+    alias(libs.plugins.poko)
     alias(libs.plugins.fgp.publish)
 }
 
@@ -7,6 +8,7 @@ freeletics {
     explicitApi()
     optIn("com.freeletics.mad.navigator.internal.InternalNavigatorApi")
     enableCompose()
+    enableParcelize()
 }
 
 dependencies {
@@ -21,4 +23,8 @@ dependencies {
     implementation(libs.androidx.compose.material)
     implementation(libs.androidx.lifecycle.common)
     implementation(libs.androidx.viewmodel.savedstate)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.truth)
+    testImplementation(libs.kotlin.parcelize)
 }

--- a/navigator/runtime-experimental/src/main/java/com/freeletics/mad/navigator/compose/internal/Stack.kt
+++ b/navigator/runtime-experimental/src/main/java/com/freeletics/mad/navigator/compose/internal/Stack.kt
@@ -49,7 +49,7 @@ internal class Stack private constructor(
             }
         }
 
-        throw IllegalStateException("Stack did not contain a ScreenDestination $stack")
+        error("Stack did not contain a ScreenDestination $stack")
     }
 
     fun push(route: NavRoute) {

--- a/navigator/runtime-experimental/src/main/java/com/freeletics/mad/navigator/compose/internal/Stack.kt
+++ b/navigator/runtime-experimental/src/main/java/com/freeletics/mad/navigator/compose/internal/Stack.kt
@@ -1,0 +1,139 @@
+package com.freeletics.mad.navigator.compose.internal
+
+import android.os.Bundle
+import androidx.core.os.bundleOf
+import com.freeletics.mad.navigator.BaseRoute
+import com.freeletics.mad.navigator.NavRoot
+import com.freeletics.mad.navigator.NavRoute
+import com.freeletics.mad.navigator.compose.ContentDestination
+import com.freeletics.mad.navigator.compose.ScreenDestination
+import com.freeletics.mad.navigator.internal.DestinationId
+import com.freeletics.mad.navigator.internal.destinationId
+import java.util.UUID
+
+internal class Stack private constructor(
+    initialStack: List<StackEntry<*>>,
+    private val destinations: List<ContentDestination<*>>,
+    private val onStackEntryRemoved: (StackEntry.Id) -> Unit,
+    private val idGenerator: () -> String,
+) {
+    private val stack = ArrayDeque<StackEntry<*>>(20).also {
+        it.addAll(initialStack)
+    }
+
+    val id: DestinationId<*> get() = rootEntry.destinationId
+    val rootEntry: StackEntry<*> get() = stack.first()
+    val isAtRoot: Boolean get() = !stack.last().removable
+
+    @Suppress("UNCHECKED_CAST")
+    fun <T : BaseRoute> entryFor(destinationId: DestinationId<T>): StackEntry<T>? {
+        return stack.findLast { it.destinationId == destinationId } as StackEntry<T>?
+    }
+
+    fun computeVisibleEntries(): List<StackEntry<*>> {
+        if (stack.size == 1) {
+            return stack.toList()
+        }
+
+        // go through the stack from the top until reaching the first ScreenDestination
+        // then create a List of the elements starting from there
+        val iterator = stack.listIterator(stack.size)
+        while (iterator.hasPrevious()) {
+            if (iterator.previous().destination is ScreenDestination<*>) {
+                val expectedSize = stack.size - iterator.nextIndex()
+                return ArrayList<StackEntry<*>>(expectedSize).apply {
+                    while (iterator.hasNext()) {
+                        add(iterator.next())
+                    }
+                }
+            }
+        }
+
+        throw IllegalStateException("Stack did not contain a ScreenDestination $stack")
+    }
+
+    fun push(route: NavRoute) {
+        stack.add(entry(route, destinations, idGenerator))
+    }
+
+    fun pop() {
+        check(stack.last().removable) { "Can't pop the root of the back stack" }
+        popInternal()
+    }
+
+    private fun popInternal() {
+        val entry = stack.removeLast()
+        onStackEntryRemoved(entry.id)
+    }
+
+    fun popUpTo(destinationId: DestinationId<*>, isInclusive: Boolean) {
+        while (stack.last().destinationId != destinationId) {
+            check(stack.last().removable) { "Route ${destinationId.route} not found on back stack" }
+            popInternal()
+        }
+
+        if (isInclusive) {
+            // using pop here to get the default removable check
+            pop()
+        }
+    }
+
+    fun clear() {
+        while (stack.last().removable) {
+            popInternal()
+        }
+    }
+
+    fun saveState(): Bundle {
+        val ids = ArrayList<String>(stack.size)
+        val routes = ArrayList<BaseRoute>(stack.size)
+        stack.forEach {
+            ids.add(it.id.value)
+            routes.add(it.route)
+        }
+        return bundleOf(
+            SAVED_STATE_IDS to ids,
+            SAVED_STATE_ROUTES to routes,
+        )
+    }
+
+    companion object {
+        fun createWith(
+            root: NavRoot,
+            destinations: List<ContentDestination<*>>,
+            onStackEntryRemoved: (StackEntry.Id) -> Unit,
+            idGenerator: () -> String = { UUID.randomUUID().toString() },
+        ): Stack {
+            val rootEntry = entry(root, destinations, idGenerator)
+            return Stack(listOf(rootEntry), destinations, onStackEntryRemoved, idGenerator)
+        }
+
+        fun fromState(
+            bundle: Bundle,
+            destinations: List<ContentDestination<*>>,
+            onStackEntryRemoved: (StackEntry.Id) -> Unit,
+            idGenerator: () -> String = { UUID.randomUUID().toString() },
+        ): Stack {
+            val ids = bundle.getStringArrayList(SAVED_STATE_IDS)!!
+            @Suppress("DEPRECATION")
+            val routes = bundle.getParcelableArrayList<BaseRoute>(SAVED_STATE_ROUTES)!!
+            val entries = ids.mapIndexed { index, id ->
+                entry(routes[index], destinations) { id }
+            }
+            return Stack(entries, destinations, onStackEntryRemoved, idGenerator)
+        }
+
+        private inline fun <T : BaseRoute> entry(
+            route: T,
+            destinations: List<ContentDestination<*>>,
+            idGenerator: () -> String,
+        ): StackEntry<T> {
+            @Suppress("UNCHECKED_CAST")
+            val destination = destinations.find { it.id == route.destinationId } as ContentDestination<T>
+            return StackEntry(StackEntry.Id(idGenerator()), route, destination)
+        }
+
+        private const val SAVED_STATE_IDS = "com.freeletics.mad.navigator.stack.ids"
+        private const val SAVED_STATE_ROUTES = "com.freeletics.mad.navigator.stack.routes"
+    }
+}

--- a/navigator/runtime-experimental/src/main/java/com/freeletics/mad/navigator/compose/internal/StackEntry.kt
+++ b/navigator/runtime-experimental/src/main/java/com/freeletics/mad/navigator/compose/internal/StackEntry.kt
@@ -2,6 +2,7 @@ package com.freeletics.mad.navigator.compose.internal
 
 import androidx.compose.runtime.Immutable
 import com.freeletics.mad.navigator.BaseRoute
+import com.freeletics.mad.navigator.NavRoot
 import com.freeletics.mad.navigator.NavRoute
 import com.freeletics.mad.navigator.compose.ContentDestination
 import com.freeletics.mad.navigator.internal.destinationId
@@ -18,7 +19,12 @@ internal class StackEntry<T : BaseRoute>(
         get() = route.destinationId
 
     val removable
-        get() = route is NavRoute
+        // cast is needed for the compiler to recognize that the when is exhaustive
+        @Suppress("USELESS_CAST")
+        get() = when(route as BaseRoute) {
+            is NavRoute -> true
+            is NavRoot -> false
+        }
 
     @JvmInline
     value class Id(val value: String)

--- a/navigator/runtime-experimental/src/main/java/com/freeletics/mad/navigator/compose/internal/StackEntry.kt
+++ b/navigator/runtime-experimental/src/main/java/com/freeletics/mad/navigator/compose/internal/StackEntry.kt
@@ -1,0 +1,25 @@
+package com.freeletics.mad.navigator.compose.internal
+
+import androidx.compose.runtime.Immutable
+import com.freeletics.mad.navigator.BaseRoute
+import com.freeletics.mad.navigator.NavRoute
+import com.freeletics.mad.navigator.compose.ContentDestination
+import com.freeletics.mad.navigator.internal.destinationId
+import dev.drewhamilton.poko.Poko
+
+@Poko
+@Immutable
+internal class StackEntry<T : BaseRoute>(
+    val id: Id,
+    val route: T,
+    val destination: ContentDestination<T>,
+){
+    val destinationId
+        get() = route.destinationId
+
+    val removable
+        get() = route is NavRoute
+
+    @JvmInline
+    value class Id(val value: String)
+}

--- a/navigator/runtime-experimental/src/test/kotlin/com/freeletics/mad/navigator/compose/internal/StackEntryTest.kt
+++ b/navigator/runtime-experimental/src/test/kotlin/com/freeletics/mad/navigator/compose/internal/StackEntryTest.kt
@@ -1,0 +1,36 @@
+package com.freeletics.mad.navigator.compose.internal
+
+import com.freeletics.mad.navigator.compose.test.SimpleRoot
+import com.freeletics.mad.navigator.compose.test.SimpleRoute
+import com.freeletics.mad.navigator.compose.test.simpleRootDestination
+import com.freeletics.mad.navigator.compose.test.simpleRouteDestination
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+internal class StackEntryTest {
+
+    @Test
+    fun `StackEntry hashCode does not equal other's with the different id`() {
+        val first = StackEntry(StackEntry.Id("a"), SimpleRoute(0), simpleRouteDestination)
+        val other = StackEntry(StackEntry.Id("b"), SimpleRoute(0), simpleRouteDestination)
+        assertThat(first.hashCode()).isNotEqualTo(other.hashCode())
+    }
+
+    @Test
+    fun `StackEntry destinationId matches destination's id`() {
+        val entry = StackEntry(StackEntry.Id("a"), SimpleRoute(0), simpleRouteDestination)
+        assertThat(entry.destinationId).isEqualTo(simpleRouteDestination.id)
+    }
+
+    @Test
+    fun `StackEntry with a NavRoute is removable`() {
+        val entry = StackEntry(StackEntry.Id("a"), SimpleRoute(0), simpleRouteDestination)
+        assertThat(entry.removable).isTrue()
+    }
+
+    @Test
+    fun `StackEntry with a NavRoot is not removable`() {
+        val entry = StackEntry(StackEntry.Id("a"), SimpleRoot(0), simpleRootDestination)
+        assertThat(entry.removable).isFalse()
+    }
+}

--- a/navigator/runtime-experimental/src/test/kotlin/com/freeletics/mad/navigator/compose/internal/StackTest.kt
+++ b/navigator/runtime-experimental/src/test/kotlin/com/freeletics/mad/navigator/compose/internal/StackTest.kt
@@ -1,0 +1,408 @@
+package com.freeletics.mad.navigator.compose.internal
+
+import com.freeletics.mad.navigator.compose.test.OtherRoute
+import com.freeletics.mad.navigator.compose.test.SimpleRoot
+import com.freeletics.mad.navigator.compose.test.SimpleRoute
+import com.freeletics.mad.navigator.compose.test.ThirdRoute
+import com.freeletics.mad.navigator.compose.test.destinations
+import com.freeletics.mad.navigator.compose.test.otherRouteDestination
+import com.freeletics.mad.navigator.compose.test.simpleRootDestination
+import com.freeletics.mad.navigator.compose.test.simpleRouteDestination
+import com.freeletics.mad.navigator.compose.test.thirdRouteDestination
+import com.google.common.truth.Truth.assertThat
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+internal class StackTest {
+
+    private var nextId = 100
+    private val idGenerator = { (nextId++).toString() }
+
+    private val removed = mutableListOf<StackEntry.Id>()
+    private val removedCallback: (StackEntry.Id) -> Unit = { removed.add(it) }
+
+    @Test
+    fun id() {
+        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+
+        assertThat(stack.id).isEqualTo(simpleRootDestination.id)
+    }
+
+    @Test
+    fun rootEntry() {
+        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+
+        assertThat(stack.rootEntry)
+            .isEqualTo(StackEntry(StackEntry.Id("100"), SimpleRoot(1), simpleRootDestination))
+    }
+
+    @Test
+    fun `isAtRoot after construction`() {
+        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+
+        assertThat(stack.isAtRoot).isTrue()
+    }
+
+    @Test
+    fun `removed after construction`() {
+        Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+
+        assertThat(removed).isEmpty()
+    }
+
+    @Test
+    fun `computeVisibleEntries after construction`() {
+        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+
+        assertThat(stack.computeVisibleEntries())
+            .containsExactly(
+                StackEntry(StackEntry.Id("100"), SimpleRoot(1), simpleRootDestination)
+            )
+            .inOrder()
+    }
+
+    @Test
+    fun `push with a screen destination`() {
+        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+        stack.push(SimpleRoute(2))
+
+        assertThat(stack.computeVisibleEntries())
+            .containsExactly(
+                StackEntry(StackEntry.Id("101"), SimpleRoute(2), simpleRouteDestination)
+            )
+            .inOrder()
+
+        assertThat(removed).isEmpty()
+    }
+
+    @Test
+    fun `push with a dialog destination`() {
+        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+        stack.push(OtherRoute(3))
+
+        assertThat(stack.computeVisibleEntries())
+            .containsExactly(
+                StackEntry(StackEntry.Id("100"), SimpleRoot(1), simpleRootDestination),
+                StackEntry(StackEntry.Id("101"), OtherRoute(3), otherRouteDestination),
+            )
+            .inOrder()
+
+        assertThat(removed).isEmpty()
+    }
+
+    @Test
+    fun `push with a bottom sheet destination`() {
+        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+        stack.push(ThirdRoute(4))
+
+        assertThat(stack.computeVisibleEntries())
+            .containsExactly(
+                StackEntry(StackEntry.Id("100"), SimpleRoot(1), simpleRootDestination),
+                StackEntry(StackEntry.Id("101"), ThirdRoute(4), thirdRouteDestination),
+            )
+            .inOrder()
+
+        assertThat(removed).isEmpty()
+    }
+
+    @Test
+    fun `computeVisibleEntries with multiple screens, dialogs and bottom sheets`() {
+        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+        stack.push(SimpleRoute(2))
+        stack.push(SimpleRoute(3))
+        stack.push(SimpleRoute(4))
+        stack.push(SimpleRoute(5))
+        stack.push(OtherRoute(6))
+        stack.push(ThirdRoute(7))
+        stack.push(OtherRoute(8))
+        stack.push(OtherRoute(9))
+        stack.push(ThirdRoute(10))
+
+        assertThat(stack.computeVisibleEntries())
+            .containsExactly(
+                StackEntry(StackEntry.Id("104"), SimpleRoute(5), simpleRouteDestination),
+                StackEntry(StackEntry.Id("105"), OtherRoute(6), otherRouteDestination),
+                StackEntry(StackEntry.Id("106"), ThirdRoute(7), thirdRouteDestination),
+                StackEntry(StackEntry.Id("107"), OtherRoute(8), otherRouteDestination),
+                StackEntry(StackEntry.Id("108"), OtherRoute(9), otherRouteDestination),
+                StackEntry(StackEntry.Id("109"), ThirdRoute(10), thirdRouteDestination),
+            )
+            .inOrder()
+
+        assertThat(removed).isEmpty()
+    }
+
+    @Test
+    fun `computeVisibleEntries with multiple screens, dialogs and bottom sheets 2`() {
+        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+        stack.push(SimpleRoute(2))
+        stack.push(SimpleRoute(3))
+        stack.push(SimpleRoute(4))
+        stack.push(OtherRoute(5))
+        stack.push(ThirdRoute(6))
+        stack.push(SimpleRoute(7))
+        stack.push(OtherRoute(8))
+        stack.push(OtherRoute(9))
+        stack.push(ThirdRoute(10))
+
+        assertThat(stack.computeVisibleEntries())
+            .containsExactly(
+                StackEntry(StackEntry.Id("106"), SimpleRoute(7), simpleRouteDestination),
+                StackEntry(StackEntry.Id("107"), OtherRoute(8), otherRouteDestination),
+                StackEntry(StackEntry.Id("108"), OtherRoute(9), otherRouteDestination),
+                StackEntry(StackEntry.Id("109"), ThirdRoute(10), thirdRouteDestination),
+            )
+            .inOrder()
+
+        assertThat(removed).isEmpty()
+    }
+
+    @Test
+    fun `pop from the root`() {
+        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+        val exception = assertThrows(IllegalStateException::class.java) {
+            stack.pop()
+        }
+        assertThat(exception).hasMessageThat().isEqualTo("Can't pop the root of the back stack")
+
+        assertThat(removed).isEmpty()
+    }
+
+    @Test
+    fun `pop from a screen`() {
+        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+        stack.push(SimpleRoute(2))
+        assertThat(stack.computeVisibleEntries())
+            .containsExactly(
+                StackEntry(StackEntry.Id("101"), SimpleRoute(2), simpleRouteDestination),
+            )
+            .inOrder()
+
+        stack.pop()
+
+        assertThat(stack.computeVisibleEntries())
+            .containsExactly(
+                StackEntry(StackEntry.Id("100"), SimpleRoot(1), simpleRootDestination),
+            )
+            .inOrder()
+
+        assertThat(removed).containsExactly(StackEntry.Id("101"))
+    }
+
+    @Test
+    fun `pop from a screen and then opening that screen again`() {
+        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+        stack.push(SimpleRoute(2))
+
+        assertThat(stack.computeVisibleEntries())
+            .containsExactly(
+                StackEntry(StackEntry.Id("101"), SimpleRoute(2), simpleRouteDestination),
+            )
+            .inOrder()
+
+        stack.pop()
+        stack.push(SimpleRoute(2))
+
+        assertThat(stack.computeVisibleEntries())
+            .containsExactly(
+                StackEntry(StackEntry.Id("102"), SimpleRoute(2), simpleRouteDestination),
+            )
+            .inOrder()
+
+        assertThat(removed).containsExactly(StackEntry.Id("101"))
+    }
+
+    @Test
+    fun `popUpTo with inclusive false`() {
+        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+        stack.push(SimpleRoute(2))
+        stack.push(SimpleRoute(3))
+        stack.push(SimpleRoute(4))
+        stack.push(SimpleRoute(5))
+        stack.push(OtherRoute(6))
+        stack.push(ThirdRoute(7))
+        stack.push(OtherRoute(8))
+        stack.push(OtherRoute(9))
+        stack.push(ThirdRoute(10))
+
+        assertThat(stack.computeVisibleEntries()).hasSize(6)
+
+        stack.popUpTo(simpleRouteDestination.id, isInclusive = false)
+
+        assertThat(stack.computeVisibleEntries())
+            .containsExactly(
+                StackEntry(StackEntry.Id("104"), SimpleRoute(5), simpleRouteDestination),
+            )
+            .inOrder()
+
+        assertThat(removed).containsExactly(
+            StackEntry.Id("109"),
+            StackEntry.Id("108"),
+            StackEntry.Id("107"),
+            StackEntry.Id("106"),
+            StackEntry.Id("105"),
+        ).inOrder()
+    }
+
+    @Test
+    fun `popUpTo with inclusive true`() {
+        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+        stack.push(SimpleRoute(2))
+        stack.push(SimpleRoute(3))
+        stack.push(SimpleRoute(4))
+        stack.push(SimpleRoute(5))
+        stack.push(OtherRoute(6))
+        stack.push(ThirdRoute(7))
+        stack.push(OtherRoute(8))
+        stack.push(OtherRoute(9))
+        stack.push(ThirdRoute(10))
+
+        assertThat(stack.computeVisibleEntries()).hasSize(6)
+
+        stack.popUpTo(simpleRouteDestination.id, isInclusive = true)
+
+        assertThat(stack.computeVisibleEntries())
+            .containsExactly(
+                StackEntry(StackEntry.Id("103"), SimpleRoute(4), simpleRouteDestination),
+            )
+            .inOrder()
+
+        assertThat(removed).containsExactly(
+            StackEntry.Id("109"),
+            StackEntry.Id("108"),
+            StackEntry.Id("107"),
+            StackEntry.Id("106"),
+            StackEntry.Id("105"),
+            StackEntry.Id("104"),
+        ).inOrder()
+    }
+
+    @Test
+    fun `popUpTo with root and inclusive false`() {
+        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+        stack.push(SimpleRoute(2))
+        stack.push(SimpleRoute(3))
+        stack.push(SimpleRoute(4))
+        stack.push(SimpleRoute(5))
+        stack.push(OtherRoute(6))
+        stack.push(ThirdRoute(7))
+        stack.push(OtherRoute(8))
+        stack.push(OtherRoute(9))
+        stack.push(ThirdRoute(10))
+
+        assertThat(stack.computeVisibleEntries()).hasSize(6)
+
+        stack.popUpTo(simpleRootDestination.id, isInclusive = false)
+
+        assertThat(stack.computeVisibleEntries())
+            .containsExactly(
+                StackEntry(StackEntry.Id("100"), SimpleRoot(1), simpleRootDestination),
+            )
+            .inOrder()
+
+        assertThat(removed).containsExactly(
+            StackEntry.Id("109"),
+            StackEntry.Id("108"),
+            StackEntry.Id("107"),
+            StackEntry.Id("106"),
+            StackEntry.Id("105"),
+            StackEntry.Id("104"),
+            StackEntry.Id("103"),
+            StackEntry.Id("102"),
+            StackEntry.Id("101"),
+        ).inOrder()
+    }
+
+    @Test
+    fun `popUpTo with root and inclusive true`() {
+        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+        stack.push(SimpleRoute(2))
+        stack.push(SimpleRoute(3))
+        stack.push(SimpleRoute(4))
+        stack.push(SimpleRoute(5))
+        stack.push(OtherRoute(6))
+        stack.push(ThirdRoute(7))
+        stack.push(OtherRoute(8))
+        stack.push(OtherRoute(9))
+        stack.push(ThirdRoute(10))
+
+        assertThat(stack.computeVisibleEntries()).hasSize(6)
+
+        val exception = assertThrows(IllegalStateException::class.java) {
+            stack.popUpTo(simpleRootDestination.id, isInclusive = true)
+        }
+        assertThat(exception).hasMessageThat().isEqualTo("Can't pop the root of the back stack")
+
+        assertThat(removed).containsExactly(
+            StackEntry.Id("109"),
+            StackEntry.Id("108"),
+            StackEntry.Id("107"),
+            StackEntry.Id("106"),
+            StackEntry.Id("105"),
+            StackEntry.Id("104"),
+            StackEntry.Id("103"),
+            StackEntry.Id("102"),
+            StackEntry.Id("101"),
+        ).inOrder()
+    }
+
+    @Test
+    fun `popUpTo with route not present on the stack`() {
+        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+        stack.push(SimpleRoute(2))
+        stack.push(SimpleRoute(3))
+        stack.push(SimpleRoute(4))
+        stack.push(SimpleRoute(5))
+        stack.push(ThirdRoute(6))
+        stack.push(ThirdRoute(7))
+
+        assertThat(stack.computeVisibleEntries()).hasSize(3)
+
+        val exception = assertThrows(IllegalStateException::class.java) {
+            stack.popUpTo(otherRouteDestination.id, isInclusive = false)
+        }
+        assertThat(exception).hasMessageThat()
+            .isEqualTo("Route class com.freeletics.mad.navigator.compose.test.OtherRoute (Kotlin " +
+                    "reflection is not available) not found on back stack")
+
+        assertThat(removed).containsExactly(
+            StackEntry.Id("106"),
+            StackEntry.Id("105"),
+            StackEntry.Id("104"),
+            StackEntry.Id("103"),
+            StackEntry.Id("102"),
+            StackEntry.Id("101"),
+        ).inOrder()
+    }
+
+    @Test
+    fun `clear removes everything except for the root`() {
+        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+        stack.push(SimpleRoute(2))
+        stack.push(SimpleRoute(3))
+        stack.push(SimpleRoute(4))
+        stack.push(SimpleRoute(5))
+        stack.push(ThirdRoute(6))
+        stack.push(ThirdRoute(7))
+
+        assertThat(stack.computeVisibleEntries()).hasSize(3)
+
+        stack.clear()
+
+
+        assertThat(stack.computeVisibleEntries())
+            .containsExactly(
+                StackEntry(StackEntry.Id("100"), SimpleRoot(1), simpleRootDestination),
+            )
+            .inOrder()
+
+        assertThat(removed).containsExactly(
+            StackEntry.Id("106"),
+            StackEntry.Id("105"),
+            StackEntry.Id("104"),
+            StackEntry.Id("103"),
+            StackEntry.Id("102"),
+            StackEntry.Id("101"),
+        ).inOrder()
+    }
+}

--- a/navigator/runtime-experimental/src/test/kotlin/com/freeletics/mad/navigator/compose/test/Destinations.kt
+++ b/navigator/runtime-experimental/src/test/kotlin/com/freeletics/mad/navigator/compose/test/Destinations.kt
@@ -1,0 +1,18 @@
+package com.freeletics.mad.navigator.compose.test
+
+import com.freeletics.mad.navigator.compose.BottomSheetDestination
+import com.freeletics.mad.navigator.compose.DialogDestination
+import com.freeletics.mad.navigator.compose.ScreenDestination
+import com.freeletics.mad.navigator.internal.DestinationId
+
+internal val simpleRootDestination = ScreenDestination(DestinationId(SimpleRoot::class)) {}
+internal val simpleRouteDestination = ScreenDestination(DestinationId(SimpleRoute::class)) {}
+internal val otherRouteDestination = DialogDestination(DestinationId(OtherRoute::class)) {}
+internal val thirdRouteDestination = BottomSheetDestination(DestinationId(ThirdRoute::class)) {}
+
+internal val destinations = listOf(
+    simpleRootDestination,
+    simpleRouteDestination,
+    otherRouteDestination,
+    thirdRouteDestination,
+)

--- a/navigator/runtime-experimental/src/test/kotlin/com/freeletics/mad/navigator/compose/test/Routes.kt
+++ b/navigator/runtime-experimental/src/test/kotlin/com/freeletics/mad/navigator/compose/test/Routes.kt
@@ -1,0 +1,22 @@
+package com.freeletics.mad.navigator.compose.test
+
+import com.freeletics.mad.navigator.NavRoot
+import com.freeletics.mad.navigator.NavRoute
+import dev.drewhamilton.poko.Poko
+import kotlinx.parcelize.Parcelize
+
+@Poko
+@Parcelize
+internal class SimpleRoute(val number: Int) : NavRoute
+
+@Poko
+@Parcelize
+internal class OtherRoute(val number: Int) : NavRoute
+
+@Poko
+@Parcelize
+internal class ThirdRoute(val number: Int) : NavRoute
+
+@Poko
+@Parcelize
+internal class SimpleRoot(val number: Int) : NavRoot


### PR DESCRIPTION
`Stack` exposes some simple functions to mutate the stack like `push`, `pop`, `popUpTo` and `clear`. The backs stack itself is internal and only `computeVisibleEntries` is there to expose the visible part of the back stack which can then be used to show UI on the screen. The stack contains `StackEntry` which have an unique id, the destination that is shown for the entry and the route that was used to navigate there. 

Saving and restoring the state is handled by writing the ids and routes to a `Bundle` and then using that to create new entries from it.