### PR TITLE
implement global StoreViewModel

### DIFF
--- a/navigator/runtime-experimental/navigator-runtime-experimental.gradle.kts
+++ b/navigator/runtime-experimental/navigator-runtime-experimental.gradle.kts
@@ -17,12 +17,15 @@ dependencies {
     api(libs.androidx.compose.ui)
 
     implementation(libs.coroutines.core)
+    implementation(libs.androidx.annotations)
     implementation(libs.androidx.activity)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.compose.foundation)
     implementation(libs.androidx.compose.material)
     implementation(libs.androidx.lifecycle.common)
+    implementation(libs.androidx.viewmodel)
     implementation(libs.androidx.viewmodel.savedstate)
+    implementation(libs.androidx.savedstate)
 
     testImplementation(libs.junit)
     testImplementation(libs.truth)

--- a/navigator/runtime-experimental/src/main/java/com/freeletics/mad/navigator/compose/internal/StoreViewModel.kt
+++ b/navigator/runtime-experimental/src/main/java/com/freeletics/mad/navigator/compose/internal/StoreViewModel.kt
@@ -16,24 +16,17 @@ internal class StoreViewModel(
     private val savedStateHandles = mutableMapOf<StackEntry.Id, SavedStateHandle>()
 
     fun provideStore(id: StackEntry.Id): NavigationExecutor.Store {
-        var store = stores[id]
-        if (store == null) {
-            store = NavigationExecutorStore()
-            stores[id] = store
-        }
-        return store
+        return stores.getOrPut(id) { NavigationExecutorStore() }
     }
 
     @SuppressLint("RestrictedApi")
     fun provideSavedStateHandle(id: StackEntry.Id): SavedStateHandle {
-        var savedStateHandle = savedStateHandles[id]
-        if (savedStateHandle == null) {
+        return savedStateHandles.getOrPut(id) {
             val restoredBundle = globalSavedStateHandle.get<Bundle>(id.value)
-            savedStateHandle = SavedStateHandle.createHandle(restoredBundle, null)
-            globalSavedStateHandle.setSavedStateProvider(id.value, savedStateHandle.savedStateProvider())
-            savedStateHandles[id] = savedStateHandle
+            SavedStateHandle.createHandle(restoredBundle, null).also {
+                globalSavedStateHandle.setSavedStateProvider(id.value, it.savedStateProvider())
+            }
         }
-        return savedStateHandle
     }
 
     fun removeEntry(id: StackEntry.Id) {

--- a/navigator/runtime-experimental/src/main/java/com/freeletics/mad/navigator/compose/internal/StoreViewModel.kt
+++ b/navigator/runtime-experimental/src/main/java/com/freeletics/mad/navigator/compose/internal/StoreViewModel.kt
@@ -1,0 +1,61 @@
+package com.freeletics.mad.navigator.compose.internal
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import androidx.annotation.VisibleForTesting
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import com.freeletics.mad.navigator.internal.NavigationExecutor
+import com.freeletics.mad.navigator.internal.NavigationExecutorStore
+
+internal class StoreViewModel(
+    internal val globalSavedStateHandle: SavedStateHandle
+) : ViewModel() {
+
+    private val stores = mutableMapOf<StackEntry.Id, NavigationExecutorStore>()
+    private val savedStateHandles = mutableMapOf<StackEntry.Id, SavedStateHandle>()
+
+    fun provideStore(id: StackEntry.Id): NavigationExecutor.Store {
+        var store = stores[id]
+        if (store == null) {
+            store = NavigationExecutorStore()
+            stores[id] = store
+        }
+        return store
+    }
+
+    @SuppressLint("RestrictedApi")
+    fun provideSavedStateHandle(id: StackEntry.Id): SavedStateHandle {
+        var savedStateHandle = savedStateHandles[id]
+        if (savedStateHandle == null) {
+            val restoredBundle = globalSavedStateHandle.get<Bundle>(id.value)
+            savedStateHandle = SavedStateHandle.createHandle(restoredBundle, null)
+            globalSavedStateHandle.setSavedStateProvider(id.value, savedStateHandle.savedStateProvider())
+            savedStateHandles[id] = savedStateHandle
+        }
+        return savedStateHandle
+    }
+
+    fun removeEntry(id: StackEntry.Id) {
+        val store = stores.remove(id)
+        store?.close()
+
+        savedStateHandles.remove(id)
+        globalSavedStateHandle.clearSavedStateProvider(id.value)
+        globalSavedStateHandle.remove<Any>(id.value)
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
+    public override fun onCleared() {
+        for (store in stores.values) {
+            store.close()
+        }
+        stores.clear()
+
+        for (key in savedStateHandles.keys) {
+            globalSavedStateHandle.clearSavedStateProvider(key.value)
+            globalSavedStateHandle.remove<Any>(key.value)
+        }
+        savedStateHandles.clear()
+    }
+}

--- a/navigator/runtime-experimental/src/test/kotlin/com/freeletics/mad/navigator/compose/internal/StoreViewModelTest.kt
+++ b/navigator/runtime-experimental/src/test/kotlin/com/freeletics/mad/navigator/compose/internal/StoreViewModelTest.kt
@@ -1,0 +1,116 @@
+package com.freeletics.mad.navigator.compose.internal
+
+import androidx.lifecycle.SavedStateHandle
+import com.freeletics.mad.navigator.compose.test.FakeCloseable
+import com.google.common.truth.Truth.assertThat
+import java.io.Closeable
+import org.junit.Test
+
+internal class StoreViewModelTest {
+
+    private val savedStateHandle = SavedStateHandle()
+    private val underTest = StoreViewModel(savedStateHandle)
+
+    @Test
+    fun `StoreViewModel returns same store for same id`() {
+        val valueA = underTest.provideStore(StackEntry.Id("1"))
+        val valueB = underTest.provideStore(StackEntry.Id("1"))
+        assertThat(valueA).isSameInstanceAs(valueB)
+    }
+
+    @Test
+    fun `StoreViewModel returns different stores for different ids`() {
+        val valueA = underTest.provideStore(StackEntry.Id("1"))
+        val valueB = underTest.provideStore(StackEntry.Id("2"))
+        assertThat(valueA).isNotSameInstanceAs(valueB)
+    }
+
+    @Test
+    fun `StoreViewModel returns different store for same id after removeEntry`() {
+        val valueA = underTest.provideStore(StackEntry.Id("1"))
+        underTest.removeEntry(StackEntry.Id("1"))
+        val valueB = underTest.provideStore(StackEntry.Id("1"))
+        assertThat(valueA).isNotSameInstanceAs(valueB)
+    }
+
+    @Test
+    fun `StoreViewModel closes store after removeEntry`() {
+        val closeable = FakeCloseable()
+        val valueA = underTest.provideStore(StackEntry.Id("1"))
+        valueA.getOrCreate(FakeCloseable::class) { closeable }
+        underTest.removeEntry(StackEntry.Id("1"))
+        assertThat(closeable.closed).isTrue()
+    }
+
+    @Test
+    fun `StoreViewModel returns same store for same id after removeEntry for different id`() {
+        val valueA = underTest.provideStore(StackEntry.Id("1"))
+        underTest.removeEntry(StackEntry.Id("2"))
+        val valueB = underTest.provideStore(StackEntry.Id("1"))
+        assertThat(valueA).isSameInstanceAs(valueB)
+    }
+
+    @Test
+    fun `StoreViewModel does not close store after removeEntry for different id`() {
+        val closeable = FakeCloseable()
+        val valueA = underTest.provideStore(StackEntry.Id("1"))
+        valueA.getOrCreate(FakeCloseable::class) { closeable }
+        underTest.removeEntry(StackEntry.Id("2"))
+        assertThat(closeable.closed).isFalse()
+    }
+
+    @Test
+    fun `StoreViewModel returns different store for same id after onCleared`() {
+        val valueA = underTest.provideStore(StackEntry.Id("1"))
+        underTest.onCleared()
+        val valueB = underTest.provideStore(StackEntry.Id("1"))
+        assertThat(valueA).isNotSameInstanceAs(valueB)
+    }
+
+    @Test
+    fun `StoreViewModel closes store after onCleared`() {
+        val closeable = FakeCloseable()
+        val valueA = underTest.provideStore(StackEntry.Id("1"))
+        valueA.getOrCreate(FakeCloseable::class) { closeable }
+        underTest.onCleared()
+        assertThat(closeable.closed).isTrue()
+    }
+
+    @Test
+    fun `StoreViewModel returns same handle for same id`() {
+        val valueA = underTest.provideSavedStateHandle(StackEntry.Id("1"))
+        val valueB = underTest.provideSavedStateHandle(StackEntry.Id("1"))
+        assertThat(valueA).isSameInstanceAs(valueB)
+    }
+
+    @Test
+    fun `StoreViewModel returns different handles for different ids`() {
+        val valueA = underTest.provideSavedStateHandle(StackEntry.Id("1"))
+        val valueB = underTest.provideSavedStateHandle(StackEntry.Id("2"))
+        assertThat(valueA).isNotSameInstanceAs(valueB)
+    }
+
+    @Test
+    fun `StoreViewModel returns different handle for same id after removeEntry`() {
+        val valueA = underTest.provideSavedStateHandle(StackEntry.Id("1"))
+        underTest.removeEntry(StackEntry.Id("1"))
+        val valueB = underTest.provideSavedStateHandle(StackEntry.Id("1"))
+        assertThat(valueA).isNotSameInstanceAs(valueB)
+    }
+
+    @Test
+    fun `StoreViewModel returns same handle for same id after removeEntry for different id`() {
+        val valueA = underTest.provideSavedStateHandle(StackEntry.Id("1"))
+        underTest.removeEntry(StackEntry.Id("2"))
+        val valueB = underTest.provideSavedStateHandle(StackEntry.Id("1"))
+        assertThat(valueA).isSameInstanceAs(valueB)
+    }
+
+    @Test
+    fun `StoreViewModel returns different handle for same id after onCleared`() {
+        val valueA = underTest.provideSavedStateHandle(StackEntry.Id("1"))
+        underTest.onCleared()
+        val valueB = underTest.provideSavedStateHandle(StackEntry.Id("1"))
+        assertThat(valueA).isNotSameInstanceAs(valueB)
+    }
+}

--- a/navigator/runtime-experimental/src/test/kotlin/com/freeletics/mad/navigator/compose/test/FakeCloseable.kt
+++ b/navigator/runtime-experimental/src/test/kotlin/com/freeletics/mad/navigator/compose/test/FakeCloseable.kt
@@ -1,0 +1,11 @@
+package com.freeletics.mad.navigator.compose.test
+
+import java.io.Closeable
+
+internal class FakeCloseable : Closeable {
+    var closed = false
+
+    override fun close() {
+        closed = true
+    }
+}


### PR DESCRIPTION
This will be used by `MultiStackNavigationExecutor` to store a `SavedStateHandle` and `NavigationExecutorStore` for each `StackEntry` that needs one. This will be a single `Activity` level (or whatever else the parent of the `NavHost` is) `ViewModel` for all screens/entries compared to having one per screen like the AndroidX navigation based implementations have. `removeEntry` will be called manually on backstack changes through the `onStackEntryRemoved` callback which will clear stores and handles once they are unused. 

The `SavedStateHandle.createHandle(...)` and `savedStateHandle.savedStateProvider()` calls are both restricted on the AndroidX side. It would theorectically be possible to have handles without accessing those 2 but that would require having an entry specific `ViewModelStore` (ok to implement and I had this already, but it's overkill for what we need so I removed it again and settled for this solution) as well as a `SavedStateRegistryOwner` and the latter would then also require implementing a `LifecycleOwner` and managing a lifecycle for each entry.