### PR TITLE
NavHost: system back handling

### DIFF
--- a/navigator/runtime-experimental/src/main/java/com/freeletics/mad/navigator/compose/NavHost.kt
+++ b/navigator/runtime-experimental/src/main/java/com/freeletics/mad/navigator/compose/NavHost.kt
@@ -70,7 +70,10 @@ public fun NavHost(
 
 @Composable
 private fun SystemBackHandling(executor: MultiStackNavigationExecutor) {
-    val backPressedDispatcher = LocalOnBackPressedDispatcherOwner.current
+    val backPressedDispatcher = requireNotNull(LocalOnBackPressedDispatcherOwner.current) {
+        "No OnBackPressedDispatcher available"
+    }
+
     val callback = remember(executor) {
         object : OnBackPressedCallback(executor.canNavigateBack.value) {
             override fun handleOnBackPressed() {
@@ -79,13 +82,15 @@ private fun SystemBackHandling(executor: MultiStackNavigationExecutor) {
 
         }
     }
+
     LaunchedEffect(executor, callback) {
         snapshotFlow { executor.canNavigateBack.value }
             .distinctUntilChanged()
             .collect { callback.isEnabled = it }
     }
+
     DisposableEffect(backPressedDispatcher, callback) {
-        backPressedDispatcher!!.onBackPressedDispatcher.addCallback(callback)
+        backPressedDispatcher.onBackPressedDispatcher.addCallback(callback)
 
         onDispose {
             callback.remove()

--- a/navigator/runtime-experimental/src/main/java/com/freeletics/mad/navigator/compose/NavHost.kt
+++ b/navigator/runtime-experimental/src/main/java/com/freeletics/mad/navigator/compose/NavHost.kt
@@ -1,12 +1,17 @@
 package com.freeletics.mad.navigator.compose
 
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.ModalBottomSheetDefaults
 import androidx.compose.material.contentColorFor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
@@ -14,9 +19,11 @@ import androidx.compose.ui.unit.Dp
 import com.freeletics.mad.navigator.BaseRoute
 import com.freeletics.mad.navigator.DeepLinkHandler
 import com.freeletics.mad.navigator.NavRoot
+import com.freeletics.mad.navigator.compose.internal.MultiStackNavigationExecutor
 import com.freeletics.mad.navigator.compose.internal.rememberNavigationExecutor
 import com.freeletics.mad.navigator.internal.InternalNavigatorApi
 import com.freeletics.mad.navigator.internal.NavigationExecutor
+import kotlinx.coroutines.flow.distinctUntilChanged
 
 /**
  * Create a new `NavHost containing all given [destinations]. [startRoute] will be used as the
@@ -42,6 +49,8 @@ public fun NavHost(
 ) {
     val executor = rememberNavigationExecutor(startRoute, destinations, deepLinkHandlers, deepLinkPrefixes)
 
+    SystemBackHandling(executor)
+
     if (destinationChangedCallback != null) {
         DisposableEffect(key1 = destinationChangedCallback) {
             // TODO start listening to backstack changes and send them to destinationChangedCallback
@@ -56,6 +65,31 @@ public fun NavHost(
         // TODO show currently visible screen
         // TODO show dialog if needed
         // TODO show bottom sheet if needed
+    }
+}
+
+@Composable
+private fun SystemBackHandling(executor: MultiStackNavigationExecutor) {
+    val backPressedDispatcher = LocalOnBackPressedDispatcherOwner.current
+    val callback = remember(executor) {
+        object : OnBackPressedCallback(executor.canNavigateBack.value) {
+            override fun handleOnBackPressed() {
+                executor.navigateBack()
+            }
+
+        }
+    }
+    LaunchedEffect(executor, callback) {
+        snapshotFlow { executor.canNavigateBack.value }
+            .distinctUntilChanged()
+            .collect { callback.isEnabled = it }
+    }
+    DisposableEffect(backPressedDispatcher, callback) {
+        backPressedDispatcher!!.onBackPressedDispatcher.addCallback(callback)
+
+        onDispose {
+            callback.remove()
+        }
     }
 }
 


### PR DESCRIPTION
Adds a callback to the `OnBackPressedDispatcher` and enables/disables it based on the state exposed by the executor.