### PR TITLE
split resetToRoot from navigateToRoot

### DIFF
--- a/navigator/androidx-nav/src/main/java/com/freeletics/mad/navigator/internal/AndroidXNavigationExecutor.kt
+++ b/navigator/androidx-nav/src/main/java/com/freeletics/mad/navigator/internal/AndroidXNavigationExecutor.kt
@@ -25,13 +25,13 @@ public class AndroidXNavigationExecutor(
         controller.navigate(route.destinationId(), route.getArguments())
     }
 
-    override fun navigate(root: NavRoot, restoreRootState: Boolean, saveCurrentRootState: Boolean) {
+    override fun navigate(root: NavRoot, restoreRootState: Boolean) {
         val options = NavOptions.Builder()
             // save the state of the current root before leaving it
             .setPopUpTo(
                 controller.graph.startDestinationId,
                 inclusive = false,
-                saveState = saveCurrentRootState
+                saveState = true
             )
             // restoring the state of the target root
             .setRestoreState(restoreRootState)
@@ -52,6 +52,23 @@ public class AndroidXNavigationExecutor(
 
     override fun <T : BaseRoute> navigateBackTo(destinationId: DestinationId<T>, isInclusive: Boolean) {
         controller.popBackStack(destinationId.destinationId(), isInclusive)
+    }
+
+    override fun resetToRoot(root: NavRoot) {
+        val options = NavOptions.Builder()
+            // save the state of the current root before leaving it
+            .setPopUpTo(
+                controller.graph.startDestinationId,
+                inclusive = false,
+                saveState = false,
+            )
+            // restoring the state of the target root
+            .setRestoreState(false)
+            // makes sure that if the destination is already on the backstack, it and
+            // everything above it gets removed
+            .setLaunchSingleTop(true)
+            .build()
+        controller.navigate(root.destinationId(), root.getArguments(), options)
     }
 
     override fun <T : BaseRoute> savedStateHandleFor(destinationId: DestinationId<T>): SavedStateHandle {

--- a/navigator/runtime-experimental/src/main/java/com/freeletics/mad/navigator/compose/internal/MultiStackNavigationExecutor.kt
+++ b/navigator/runtime-experimental/src/main/java/com/freeletics/mad/navigator/compose/internal/MultiStackNavigationExecutor.kt
@@ -32,7 +32,7 @@ internal class MultiStackNavigationExecutor(
         TODO("Not yet implemented")
     }
 
-    override fun navigate(root: NavRoot, restoreRootState: Boolean, saveCurrentRootState: Boolean) {
+    override fun navigate(root: NavRoot, restoreRootState: Boolean) {
         TODO("Not yet implemented")
     }
 
@@ -52,6 +52,10 @@ internal class MultiStackNavigationExecutor(
         destinationId: DestinationId<T>,
         isInclusive: Boolean,
     ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun resetToRoot(root: NavRoot) {
         TODO("Not yet implemented")
     }
 

--- a/navigator/runtime/api/runtime.api
+++ b/navigator/runtime/api/runtime.api
@@ -86,14 +86,15 @@ public class com/freeletics/mad/navigator/NavEventNavigator {
 	public final fun navigateForResult (Lcom/freeletics/mad/navigator/ActivityResultRequest;Ljava/lang/Object;)V
 	public final fun navigateTo (Lcom/freeletics/mad/navigator/ActivityRoute;)V
 	public final fun navigateTo (Lcom/freeletics/mad/navigator/NavRoute;)V
-	public final fun navigateToRoot (Lcom/freeletics/mad/navigator/NavRoot;ZZ)V
-	public static synthetic fun navigateToRoot$default (Lcom/freeletics/mad/navigator/NavEventNavigator;Lcom/freeletics/mad/navigator/NavRoot;ZZILjava/lang/Object;)V
+	public final fun navigateToRoot (Lcom/freeletics/mad/navigator/NavRoot;Z)V
+	public static synthetic fun navigateToRoot$default (Lcom/freeletics/mad/navigator/NavEventNavigator;Lcom/freeletics/mad/navigator/NavRoot;ZILjava/lang/Object;)V
 	public final fun navigateUp ()V
 	protected final fun registerForActivityResult (Landroidx/activity/result/contract/ActivityResultContract;)Lcom/freeletics/mad/navigator/ActivityResultRequest;
 	public final fun registerForNavigationResult-Enyiqp0 (Lkotlin/reflect/KClass;Ljava/lang/String;)Lcom/freeletics/mad/navigator/NavigationResultRequest;
 	protected final fun registerForPermissionsResult ()Lcom/freeletics/mad/navigator/PermissionsResultRequest;
 	public final fun requestPermissions (Lcom/freeletics/mad/navigator/PermissionsResultRequest;Ljava/util/List;)V
 	public final fun requestPermissions (Lcom/freeletics/mad/navigator/PermissionsResultRequest;[Ljava/lang/String;)V
+	public final fun resetToRoot (Lcom/freeletics/mad/navigator/NavRoot;)V
 }
 
 public abstract interface class com/freeletics/mad/navigator/NavRoot : com/freeletics/mad/navigator/BaseRoute {

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
@@ -126,15 +126,14 @@ public open class NavEventNavigator {
 
     /**
      * Triggers a new [NavEvent] to navigate to the given [root]. The current back stack will
-     * be popped and saved it [saveCurrentRootState] is `true`, otherwise it will be discarded.
-     * Whether the backstack of the given `root` is restored depends on [restoreRootState].
+     * be popped and saved. Whether the backstack of the given `root` is restored depends on
+     * [restoreRootState].
      */
     public fun navigateToRoot(
         root: NavRoot,
         restoreRootState: Boolean = false,
-        saveCurrentRootState: Boolean = true,
     ) {
-        val event = NavEvent.NavigateToRootEvent(root, restoreRootState, saveCurrentRootState)
+        val event = NavEvent.NavigateToRootEvent(root, restoreRootState)
         sendNavEvent(event)
     }
 
@@ -173,6 +172,15 @@ public open class NavEventNavigator {
     @PublishedApi
     internal fun <T: BaseRoute> navigateBackTo(popUpTo: DestinationId<T>, inclusive: Boolean = false) {
         val event = BackToEvent(popUpTo, inclusive)
+        sendNavEvent(event)
+    }
+
+    /**
+     * Reset the back stack to the given [root]. The current back stack will cleared and if
+     * root was already on it it will be recreated.
+     */
+    public fun resetToRoot(root: NavRoot) {
+        val event = NavEvent.ResetToRoot(root)
         sendNavEvent(event)
     }
 

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/NavEvent.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/NavEvent.kt
@@ -22,7 +22,6 @@ public sealed interface NavEvent {
     public class NavigateToRootEvent(
         internal val root: NavRoot,
         internal val restoreRootState: Boolean,
-        internal val saveCurrentRootState: Boolean,
     ) : NavEvent
 
     @InternalNavigatorApi
@@ -42,6 +41,12 @@ public sealed interface NavEvent {
     public class BackToEvent(
         internal val popUpTo: DestinationId<*>,
         internal val inclusive: Boolean,
+    ) : NavEvent
+
+    @InternalNavigatorApi
+    @Poko
+    public class ResetToRoot(
+        internal val root: NavRoot,
     ) : NavEvent
 
     @InternalNavigatorApi

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/NavigationExecutor.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/NavigationExecutor.kt
@@ -10,11 +10,12 @@ import kotlin.reflect.KClass
 @InternalNavigatorApi
 public interface NavigationExecutor {
     public fun navigate(route: NavRoute)
-    public fun navigate(root: NavRoot, restoreRootState: Boolean, saveCurrentRootState: Boolean)
+    public fun navigate(root: NavRoot, restoreRootState: Boolean)
     public fun navigate(route: ActivityRoute)
     public fun navigateUp()
     public fun navigateBack()
     public fun <T : BaseRoute> navigateBackTo(destinationId: DestinationId<T>, isInclusive: Boolean)
+    public fun resetToRoot(root: NavRoot)
     public fun <T : BaseRoute> routeFor(destinationId: DestinationId<T>): T
     public fun <T : BaseRoute> savedStateHandleFor(destinationId: DestinationId<T>): SavedStateHandle
     public fun <T : BaseRoute> storeFor(destinationId: DestinationId<T>): Store

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/NavigationSetup.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/internal/NavigationSetup.kt
@@ -35,7 +35,7 @@ private fun NavigationExecutor.navigate(
             navigate(event.route)
         }
         is NavEvent.NavigateToRootEvent -> {
-            navigate(event.root, event.restoreRootState, event.saveCurrentRootState)
+            navigate(event.root, event.restoreRootState)
         }
         is NavEvent.NavigateToActivityEvent -> {
             navigate(event.route)
@@ -48,6 +48,9 @@ private fun NavigationExecutor.navigate(
         }
         is NavEvent.BackToEvent -> {
             navigateBackTo(event.popUpTo, event.inclusive)
+        }
+        is NavEvent.ResetToRoot -> {
+            resetToRoot(event.root)
         }
         is NavEvent.ActivityResultEvent<*> -> {
             val request = event.request

--- a/navigator/runtime/src/test/java/com/freeletics/mad/navigator/NavEventNavigatorTest.kt
+++ b/navigator/runtime/src/test/java/com/freeletics/mad/navigator/NavEventNavigatorTest.kt
@@ -58,13 +58,11 @@ internal class NavEventNavigatorTest {
             navigator.navigateToRoot(
                 root = SimpleRoot(1),
                 restoreRootState = true,
-                saveCurrentRootState = false
             )
 
             assertThat(awaitItem()).isEqualTo(NavigateToRootEvent(
                 root = SimpleRoot(1),
                 restoreRootState = true,
-                saveCurrentRootState = false
             ))
 
             cancel()
@@ -124,6 +122,24 @@ internal class NavEventNavigatorTest {
             cancel()
         }
     }
+
+    @Test
+    fun `resetToRoot event is received`(): Unit = runBlocking {
+        val navigator = TestNavigator()
+
+        navigator.navEvents.test {
+            navigator.resetToRoot(
+                root = SimpleRoot(1),
+            )
+
+            assertThat(awaitItem()).isEqualTo(NavEvent.ResetToRoot(
+                root = SimpleRoot(1),
+            ))
+
+            cancel()
+        }
+    }
+
 
     @Test
     fun `navigateForResult event is received`(): Unit = runBlocking {

--- a/navigator/runtime/src/test/java/com/freeletics/mad/navigator/internal/NavigationSetupTest.kt
+++ b/navigator/runtime/src/test/java/com/freeletics/mad/navigator/internal/NavigationSetupTest.kt
@@ -87,13 +87,11 @@ internal class NavigationSetupTest {
         navigator.navigateToRoot(
             root = SimpleRoot(2),
             restoreRootState = false,
-            saveCurrentRootState = true
         )
         assertThat(executor.received.awaitItem())
             .isEqualTo(NavEvent.NavigateToRootEvent(
                 root = SimpleRoot(2),
                 restoreRootState = false,
-                saveCurrentRootState = true
             ))
     }
 
@@ -131,6 +129,15 @@ internal class NavigationSetupTest {
         navigator.navigateBackTo<SimpleRoute>(inclusive = true)
         assertThat(executor.received.awaitItem())
             .isEqualTo(NavEvent.BackToEvent(DestinationId(SimpleRoute::class), inclusive = true))
+    }
+
+    @Test
+    fun `ResetToRoot is forwarded to executor`() = runBlocking {
+        setup()
+
+        navigator.resetToRoot(SimpleRoot(2))
+        assertThat(executor.received.awaitItem())
+            .isEqualTo(NavEvent.ResetToRoot(SimpleRoot(2)))
     }
 
     @Test

--- a/navigator/runtime/src/test/java/com/freeletics/mad/navigator/test/TestNavigationExecutor.kt
+++ b/navigator/runtime/src/test/java/com/freeletics/mad/navigator/test/TestNavigationExecutor.kt
@@ -19,8 +19,8 @@ internal class TestNavigationExecutor : NavigationExecutor {
         received.add(NavEvent.NavigateToEvent(route))
     }
 
-    override fun navigate(root: NavRoot, restoreRootState: Boolean, saveCurrentRootState: Boolean) {
-        received.add(NavEvent.NavigateToRootEvent(root, restoreRootState, saveCurrentRootState))
+    override fun navigate(root: NavRoot, restoreRootState: Boolean) {
+        received.add(NavEvent.NavigateToRootEvent(root, restoreRootState))
     }
 
     override fun navigate(route: ActivityRoute) {
@@ -40,6 +40,10 @@ internal class TestNavigationExecutor : NavigationExecutor {
         isInclusive: Boolean,
     ) {
         received.add(NavEvent.BackToEvent(destinationId, isInclusive))
+    }
+
+    override fun resetToRoot(root: NavRoot) {
+        received.add(NavEvent.ResetToRoot(root))
     }
 
     override fun <T : BaseRoute> routeFor(destinationId: DestinationId<T>): T {

--- a/navigator/testing/api/testing.api
+++ b/navigator/testing/api/testing.api
@@ -5,11 +5,12 @@ public abstract interface class com/freeletics/mad/navigator/NavigatorTurbine {
 	public abstract fun awaitNavigateForResult (Lcom/freeletics/mad/navigator/ActivityResultRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun awaitNavigateTo (Lcom/freeletics/mad/navigator/ActivityRoute;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun awaitNavigateTo (Lcom/freeletics/mad/navigator/NavRoute;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun awaitNavigateToRoot (Lcom/freeletics/mad/navigator/NavRoot;ZZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun awaitNavigateToRoot (Lcom/freeletics/mad/navigator/NavRoot;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun awaitNavigateUp (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun awaitNavigationResult (Lcom/freeletics/mad/navigator/NavigationResultRequest$Key;Landroid/os/Parcelable;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun awaitRequestPermissions (Lcom/freeletics/mad/navigator/PermissionsResultRequest;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun awaitRequestPermissions (Lcom/freeletics/mad/navigator/PermissionsResultRequest;[Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun awaitResetToRoot (Lcom/freeletics/mad/navigator/NavRoot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun cancel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun cancelAndIgnoreRemainingNavEvents (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun dispatchBackPress ()V

--- a/navigator/testing/src/main/java/com/freeletics/mad/navigator/NavigatorTurbine.kt
+++ b/navigator/testing/src/main/java/com/freeletics/mad/navigator/NavigatorTurbine.kt
@@ -82,7 +82,6 @@ public interface NavigatorTurbine {
     public suspend fun awaitNavigateToRoot(
         root: NavRoot,
         restoreRootState: Boolean,
-        saveCurrentRootState: Boolean,
     )
 
     /**
@@ -118,6 +117,16 @@ public interface NavigatorTurbine {
     public suspend fun <T: BaseRoute> awaitNavigateBackTo(
         popUpTo: KClass<T>,
         inclusive: Boolean
+    )
+
+    /**
+     * Assert that the next event received was a "reset to root" navigation event with matching
+     * parameters. This function will suspend if no events have been received.
+     *
+     * @throws AssertionError - if the next event was not a matching event.
+     */
+    public suspend fun awaitResetToRoot(
+        root: NavRoot
     )
 
     /**
@@ -200,9 +209,8 @@ internal class DefaultNavigatorTurbine(
     override suspend fun awaitNavigateToRoot(
         root: NavRoot,
         restoreRootState: Boolean,
-        saveCurrentRootState: Boolean,
     ) {
-        val event = NavEvent.NavigateToRootEvent(root, restoreRootState, saveCurrentRootState)
+        val event = NavEvent.NavigateToRootEvent(root, restoreRootState)
         Truth.assertThat(turbine.awaitItem()).isEqualTo(event)
     }
 
@@ -226,6 +234,13 @@ internal class DefaultNavigatorTurbine(
         inclusive: Boolean
     ) {
         val event = NavEvent.BackToEvent(DestinationId(popUpTo), inclusive)
+        Truth.assertThat(turbine.awaitItem()).isEqualTo(event)
+    }
+
+    override suspend fun awaitResetToRoot(
+        root: NavRoot,
+    ) {
+        val event = NavEvent.ResetToRoot(root)
         Truth.assertThat(turbine.awaitItem()).isEqualTo(event)
     }
 


### PR DESCRIPTION
As discussed in #372.

One thing that I don't like entirely is that for the AndroidX navigation implementation there isn't anything that enforces that `resetToRoot` is called with the current root or the start destination root (that one is always the parent). Not a big issue though and it would still result in a valid back stack, it's just that in that case navigateToRoot(..., restore = false) would be the better choice. In `MultiStack` we can enforce this ourselves.