### PR TITLE
NavHost: support comopose saveable on a per destination basis

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,6 +66,7 @@ androidx-activity-compose = { module = "androidx.activity:activity-compose", ver
 androidx-annotations = { module = "androidx.annotation:annotation", version.ref = "androidx-annotations" }
 androidx-compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "androidx-compose-compiler" }
 androidx-compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "androidx-compose-runtime" }
+androidx-compose-runtime-saveable = { module = "androidx.compose.runtime:runtime-saveable", version.ref = "androidx-compose-runtime" }
 androidx-compose-ui = { module = "androidx.compose.ui:ui", version.ref = "androidx-compose-ui" }
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "androidx-compose-foundation" }
 androidx-compose-material = { module = "androidx.compose.material:material", version.ref = "androidx-compose-material" }

--- a/navigator/runtime-experimental/navigator-runtime-experimental.gradle.kts
+++ b/navigator/runtime-experimental/navigator-runtime-experimental.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     implementation(libs.androidx.annotations)
     implementation(libs.androidx.activity)
     implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.compose.runtime.saveable)
     implementation(libs.androidx.compose.foundation)
     implementation(libs.androidx.compose.material)
     implementation(libs.androidx.lifecycle.common)

--- a/navigator/runtime-experimental/src/main/java/com/freeletics/mad/navigator/compose/NavHost.kt
+++ b/navigator/runtime-experimental/src/main/java/com/freeletics/mad/navigator/compose/NavHost.kt
@@ -11,6 +11,8 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.SaveableStateHolder
+import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
@@ -24,6 +26,8 @@ import com.freeletics.mad.navigator.compose.internal.StackEntry
 import com.freeletics.mad.navigator.compose.internal.rememberNavigationExecutor
 import com.freeletics.mad.navigator.internal.InternalNavigatorApi
 import com.freeletics.mad.navigator.internal.NavigationExecutor
+import java.io.Closeable
+import java.lang.ref.WeakReference
 import kotlinx.coroutines.flow.distinctUntilChanged
 
 /**
@@ -62,27 +66,55 @@ public fun NavHost(
         }
     }
 
+    val saveableStateHolder = rememberSaveableStateHolder()
     CompositionLocalProvider(LocalNavigationExecutor provides executor) {
         val entries = executor.visibleEntries.value
 
-        Show(entries)
+        Show(entries, executor, saveableStateHolder)
     }
 }
 
 @Composable
 private fun Show(
     entries: List<StackEntry<*>>,
+    executor: MultiStackNavigationExecutor,
+    saveableStateHolder: SaveableStateHolder,
 ) {
     // TODO show all entries and differentiate between destination types
     val entry = entries.last()
-    Show(entry)
+    Show(entry, executor, saveableStateHolder)
 }
 
 @Composable
 private fun <T : BaseRoute> Show(
     entry: StackEntry<T>,
+    executor: MultiStackNavigationExecutor,
+    saveableStateHolder: SaveableStateHolder,
 ) {
-    entry.destination.content(entry.route)
+    // From AndroidX Navigation:
+    //   Stash a reference to the SaveableStateHolder in the Store so that
+    //   it is available when the destination is cleared. Which, because of animations,
+    //   only happens after this leaves composition. Which means we can't rely on
+    //   DisposableEffect to clean up this reference (as it'll be cleaned up too early)
+    remember(entry, executor, saveableStateHolder) {
+        executor.storeFor(entry.id).getOrCreate(SaveableCloseable::class) {
+            SaveableCloseable(entry.id.value, WeakReference(saveableStateHolder))
+        }
+    }
+
+    saveableStateHolder.SaveableStateProvider(entry.id.value) {
+        entry.destination.content(entry.route)
+    }
+}
+
+internal class SaveableCloseable(
+    private val id: String,
+    private val saveableStateHolderRef: WeakReference<SaveableStateHolder>
+) : Closeable {
+    override fun close() {
+        saveableStateHolderRef.get()?.removeState(id)
+        saveableStateHolderRef.clear()
+    }
 }
 
 @Composable


### PR DESCRIPTION
Adds support for `rememberSaveable` which will get cleared when a screen is removed from the back stack.