### PR TITLE
implement MultiStackNavigationExecutor

### DIFF
--- a/navigator/runtime-experimental/navigator-runtime-experimental.gradle.kts
+++ b/navigator/runtime-experimental/navigator-runtime-experimental.gradle.kts
@@ -25,8 +25,10 @@ dependencies {
     implementation(libs.androidx.compose.material)
     implementation(libs.androidx.lifecycle.common)
     implementation(libs.androidx.viewmodel)
+    implementation(libs.androidx.viewmodel.compose)
     implementation(libs.androidx.viewmodel.savedstate)
     implementation(libs.androidx.savedstate)
+    implementation(libs.uri)
 
     testImplementation(libs.junit)
     testImplementation(libs.truth)

--- a/navigator/runtime-experimental/src/main/java/com/freeletics/mad/navigator/compose/internal/MultiStackNavigationExecutor.kt
+++ b/navigator/runtime-experimental/src/main/java/com/freeletics/mad/navigator/compose/internal/MultiStackNavigationExecutor.kt
@@ -1,78 +1,115 @@
 package com.freeletics.mad.navigator.compose.internal
 
+import android.os.Parcelable
 import androidx.compose.runtime.State
 import androidx.lifecycle.SavedStateHandle
 import com.freeletics.mad.navigator.ActivityRoute
 import com.freeletics.mad.navigator.BaseRoute
 import com.freeletics.mad.navigator.NavRoot
 import com.freeletics.mad.navigator.NavRoute
-import com.freeletics.mad.navigator.compose.ActivityDestination
-import com.freeletics.mad.navigator.compose.ContentDestination
 import com.freeletics.mad.navigator.internal.DestinationId
 import com.freeletics.mad.navigator.internal.NavigationExecutor
+import com.freeletics.mad.navigator.internal.destinationId
 
 internal class MultiStackNavigationExecutor(
-    @Suppress("unused") //TODO
-    private val activityStarter: (ActivityRoute, ActivityDestination) -> Unit,
-    @Suppress("unused") //TODO
-    private val contentDestinations: List<ContentDestination<*>>,
-    @Suppress("unused") //TODO
-    private val activityDestinations: List<ActivityDestination>,
+    private val stack: MultiStack,
+    private val viewModel: StoreViewModel,
+    private val activityStarter: (ActivityRoute) -> Unit,
+    deepLinkRoutes: List<Parcelable>,
 ) : NavigationExecutor {
 
     @Suppress("unused") //TODO
     val visibleEntries: State<List<StackEntry<*>>>
-        get() = TODO("Not yet implemented")
+        get() = stack.visibleEntries
 
     @Suppress("unused") //TODO
     val canNavigateBack: State<Boolean>
-        get() = TODO("Not yet implemented")
+        get() = stack.canNavigateBack
+
+    init {
+        if (deepLinkRoutes.isNotEmpty()) {
+            stack.resetToRoot(stack.startRoot)
+            deepLinkRoutes.forEachIndexed { index, route ->
+                when (route) {
+                    is NavRoot -> {
+                        require(index == 0) { "NavRoot can only be the first element of a deep link" }
+                        require(route.destinationId != stack.startRoot.destinationId) {
+                            "$route is the start root which is not allowed to be part of a deep " +
+                                    "link because it will always be on the back stack"
+                        }
+                        stack.push(route, clearTargetStack = true)
+                    }
+                    is NavRoute -> stack.push(route)
+                    is ActivityRoute -> navigate(route)
+                }
+            }
+        }
+
+        viewModel.globalSavedStateHandle.setSavedStateProvider(SAVED_STATE_STACK) {
+            val stackState = stack.saveState()
+            // if this line is reached the stackState contains the deep links already
+            stackState.putBoolean(SAVED_STATE_HANDLED_DEEP_LINKS, true)
+            stackState
+        }
+    }
 
     override fun navigate(route: NavRoute) {
-        TODO("Not yet implemented")
+        stack.push(route)
     }
 
     override fun navigate(root: NavRoot, restoreRootState: Boolean) {
-        TODO("Not yet implemented")
+        stack.push(root, clearTargetStack = !restoreRootState)
     }
 
     override fun navigate(route: ActivityRoute) {
-        TODO("Not yet implemented")
+        activityStarter(route)
     }
 
     override fun navigateUp() {
-        TODO("Not yet implemented")
+        stack.popCurrentStack()
     }
 
     override fun navigateBack() {
-        TODO("Not yet implemented")
+        stack.pop()
     }
 
     override fun <T : BaseRoute> navigateBackTo(
         destinationId: DestinationId<T>,
-        isInclusive: Boolean,
+        isInclusive: Boolean
     ) {
-        TODO("Not yet implemented")
+        stack.popUpTo(destinationId, isInclusive)
     }
 
     override fun resetToRoot(root: NavRoot) {
-        TODO("Not yet implemented")
+        stack.resetToRoot(root)
     }
 
     override fun <T : BaseRoute> routeFor(destinationId: DestinationId<T>): T {
-        TODO("Not yet implemented")
+        return entryFor(destinationId).route
     }
 
     override fun <T : BaseRoute> savedStateHandleFor(destinationId: DestinationId<T>): SavedStateHandle {
-        TODO("Not yet implemented")
+        val entry = entryFor(destinationId)
+        return viewModel.provideSavedStateHandle(entry.id)
     }
 
     override fun <T : BaseRoute> storeFor(destinationId: DestinationId<T>): NavigationExecutor.Store {
-        TODO("Not yet implemented")
+        val entry = entryFor(destinationId)
+        return storeFor(entry.id)
     }
 
     @Suppress("unused", "unused_parameter") //TODO
     fun storeFor(entryId: StackEntry.Id): NavigationExecutor.Store {
-        TODO("Not yet implemented")
+        return viewModel.provideStore(entryId)
+    }
+
+    private fun <T : BaseRoute> entryFor(destinationId: DestinationId<T>): StackEntry<T> {
+        return stack.entryFor(destinationId) ?:
+            throw IllegalStateException("Route $destinationId not found on back stack")
+    }
+
+    internal companion object {
+        const val SAVED_STATE_STACK = "com.freeletics.mad.navigator.stack"
+        const val SAVED_STATE_HANDLED_DEEP_LINKS = "com.freeletics.mad.navigator.handled_deep_links"
     }
 }

--- a/navigator/runtime-experimental/src/main/java/com/freeletics/mad/navigator/compose/internal/MultiStackNavigationExecutorBuilder.kt
+++ b/navigator/runtime-experimental/src/main/java/com/freeletics/mad/navigator/compose/internal/MultiStackNavigationExecutorBuilder.kt
@@ -1,40 +1,78 @@
 package com.freeletics.mad.navigator.compose.internal
 
+import android.content.Context
 import android.content.Intent
+import android.os.Bundle
+import android.os.Parcelable
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.SAVED_STATE_REGISTRY_OWNER_KEY
+import androidx.lifecycle.SavedStateViewModelFactory
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.eygraber.uri.Uri
 import com.freeletics.mad.navigator.ActivityRoute
-import com.freeletics.mad.navigator.BaseRoute
+import com.freeletics.mad.navigator.DeepLink.Companion.EXTRA_DEEPLINK_ROUTES
 import com.freeletics.mad.navigator.DeepLinkHandler
 import com.freeletics.mad.navigator.NavRoot
 import com.freeletics.mad.navigator.compose.ActivityDestination
 import com.freeletics.mad.navigator.compose.ContentDestination
 import com.freeletics.mad.navigator.compose.NavDestination
+import com.freeletics.mad.navigator.compose.findActivity
+import com.freeletics.mad.navigator.compose.internal.MultiStackNavigationExecutor.Companion.SAVED_STATE_STACK
+import com.freeletics.mad.navigator.internal.createDeepLinkIfMatching
 
 @Composable
-@Suppress("unused_parameter") //TODO
 internal fun rememberNavigationExecutor(
-    startRoot: BaseRoute,
+    startRoot: NavRoot,
     destinations: Set<NavDestination>,
     deepLinkHandlers: Set<DeepLinkHandler>,
     deepLinkPrefixes: Set<DeepLinkHandler.Prefix>,
 ) : MultiStackNavigationExecutor {
     val context = LocalContext.current
-    return remember {
-        val activityStarter = { route: ActivityRoute, destination: ActivityDestination ->
-            val intent = Intent(destination.intent)
-            intent.fillIn(route.fillInIntent(), 0)
-            context.startActivity(intent)
-        }
-
+    val viewModel = viewModel<StoreViewModel>(factory = SavedStateViewModelFactory())
+    return remember(context, viewModel) {
         val contentDestinations = destinations.filterIsInstance<ContentDestination<*>>()
         val activityDestinations = destinations.filterIsInstance<ActivityDestination>()
 
+        val navState = viewModel.globalSavedStateHandle.get<Bundle>(SAVED_STATE_STACK)
+        val stack = if (navState == null) {
+            MultiStack.createWith(startRoot, contentDestinations, viewModel::removeEntry)
+        } else {
+            MultiStack.fromState(startRoot, navState, contentDestinations, viewModel::removeEntry)
+        }
+
+        val starter = ActivityStarter(context, activityDestinations)
+
+        val deepLinkRoutes = if (navState?.getBoolean(SAVED_STATE_STACK) != true) {
+            deepLinkRoutes(context, deepLinkHandlers, deepLinkPrefixes)
+        } else {
+            emptyList()
+        }
+
         MultiStackNavigationExecutor(
-            activityStarter,
-            contentDestinations,
-            activityDestinations,
+            stack = stack,
+            viewModel = viewModel,
+            activityStarter = starter::start,
+            deepLinkRoutes = deepLinkRoutes,
         )
     }
+}
+
+private fun deepLinkRoutes(
+    context: Context,
+    deepLinkHandlers: Set<DeepLinkHandler>,
+    deepLinkPrefixes: Set<DeepLinkHandler.Prefix>
+): List<Parcelable> {
+    var intent = context.findActivity().intent
+    val uri = intent.dataString
+    if (uri != null) {
+        val deepLink = deepLinkHandlers.createDeepLinkIfMatching(Uri.parse(uri), deepLinkPrefixes)
+        val deepLinkIntent = deepLink?.buildIntent(context)
+        if (deepLinkIntent != null) {
+            intent = deepLinkIntent
+        }
+    }
+    @Suppress("DEPRECATION")
+    return intent.getParcelableArrayListExtra(EXTRA_DEEPLINK_ROUTES) ?: emptyList()
 }

--- a/navigator/runtime-experimental/src/test/kotlin/com/freeletics/mad/navigator/compose/internal/MultiStackNavigationExecutorTest.kt
+++ b/navigator/runtime-experimental/src/test/kotlin/com/freeletics/mad/navigator/compose/internal/MultiStackNavigationExecutorTest.kt
@@ -1,0 +1,913 @@
+package com.freeletics.mad.navigator.compose.internal
+
+import android.os.Parcelable
+import androidx.lifecycle.SavedStateHandle
+import com.freeletics.mad.navigator.ActivityRoute
+import com.freeletics.mad.navigator.NavRoot
+import com.freeletics.mad.navigator.compose.ActivityDestination
+import com.freeletics.mad.navigator.compose.test.OtherActivity
+import com.freeletics.mad.navigator.compose.test.OtherRoot
+import com.freeletics.mad.navigator.compose.test.OtherRoute
+import com.freeletics.mad.navigator.compose.test.SimpleActivity
+import com.freeletics.mad.navigator.compose.test.SimpleRoot
+import com.freeletics.mad.navigator.compose.test.SimpleRoute
+import com.freeletics.mad.navigator.compose.test.ThirdRoute
+import com.freeletics.mad.navigator.compose.test.activityDestinations
+import com.freeletics.mad.navigator.compose.test.destinations
+import com.freeletics.mad.navigator.compose.test.otherActivityDestination
+import com.freeletics.mad.navigator.compose.test.otherRootDestination
+import com.freeletics.mad.navigator.compose.test.otherRouteDestination
+import com.freeletics.mad.navigator.compose.test.simpleActivityDestination
+import com.freeletics.mad.navigator.compose.test.simpleRootDestination
+import com.freeletics.mad.navigator.compose.test.simpleRouteDestination
+import com.freeletics.mad.navigator.compose.test.thirdRouteDestination
+import com.google.common.truth.Truth.assertThat
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+internal class MultiStackNavigationExecutorTest {
+
+    private var nextId = 100
+    private val idGenerator = { (nextId++).toString() }
+
+    private val removed = mutableListOf<StackEntry.Id>()
+    private val removedCallback: (StackEntry.Id) -> Unit = { removed.add(it) }
+
+    private val started = mutableListOf<ActivityRoute>()
+    private val starter: (ActivityRoute) -> Unit = { route ->
+        started.add(route)
+    }
+
+    private val viewModel = StoreViewModel(SavedStateHandle())
+
+    private fun underTest(
+        deepLinkRoutes: List<Parcelable> = emptyList(),
+    ) : MultiStackNavigationExecutor {
+        return MultiStackNavigationExecutor(
+            activityStarter = starter,
+            viewModel = viewModel,
+            executor = MultiStack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator),
+            deepLinkRoutes = deepLinkRoutes,
+        )
+    }
+
+    @Test
+    fun `removed is empty at the beginning`() {
+        underTest()
+
+        assertThat(removed).isEmpty()
+    }
+
+    @Test
+    fun `started is empty at the beginning`() {
+        underTest()
+
+        assertThat(started).isEmpty()
+    }
+
+    @Test
+    fun `deep link with start root`() {
+        val exception = assertThrows(IllegalArgumentException::class.java) {
+            underTest(
+                listOf(SimpleRoot(3))
+            )
+        }
+
+        assertThat(exception).hasMessageThat().isEqualTo("SimpleRoot(number=3) is the start root" +
+                " which is not allowed to be part of a deep link because it will always be on the" +
+                " back executor")
+    }
+
+    @Test
+    fun `deep links passed with a root at an index other than the first`() {
+        val exception = assertThrows(IllegalArgumentException::class.java) {
+            underTest(
+                listOf(SimpleRoute(1), SimpleRoot(3))
+            )
+        }
+
+        assertThat(exception).hasMessageThat()
+            .isEqualTo("NavRoot can only be the first element of a deep link")
+    }
+
+    @Test
+    fun `deep links passed with a NavRoute`() {
+        val executor = underTest(
+            listOf(SimpleRoute(2))
+        )
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("102"), SimpleRoute(2), simpleRouteDestination)
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isTrue()
+
+        executor.navigateBack()
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("101"), SimpleRoot(1), simpleRootDestination)
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isFalse()
+    }
+
+    @Test
+    fun `deep links passed with a NavRoot`() {
+        val executor = underTest(
+            listOf(OtherRoot(2))
+        )
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("102"), OtherRoot(2), otherRootDestination)
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isTrue()
+
+        executor.navigateBack()
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("101"), SimpleRoot(1), simpleRootDestination)
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isFalse()
+    }
+
+    @Test
+    fun `deep links passed with NavRoot and NavRoute`() {
+        val executor = underTest(
+            listOf(OtherRoot(2), SimpleRoute(3))
+        )
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("103"), SimpleRoute(3), simpleRouteDestination)
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isTrue()
+
+        executor.navigateBack()
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("102"), OtherRoot(2), otherRootDestination)
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isTrue()
+
+        executor.navigateBack()
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("101"), SimpleRoot(1), simpleRootDestination)
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isFalse()
+    }
+
+    @Test
+    fun `deep links passed with multiple NavRoutes`() {
+        val executor = underTest(
+            listOf(SimpleRoute(2), SimpleRoute(3), OtherRoute(4), ThirdRoute(5))
+        )
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("103"), SimpleRoute(3), simpleRouteDestination),
+                StackEntry(StackEntry.Id("104"), OtherRoute(4), otherRouteDestination),
+                StackEntry(StackEntry.Id("105"), ThirdRoute(5), thirdRouteDestination),
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isTrue()
+    }
+
+    @Test
+    fun `deep links passed with an ActivityRoute`() {
+        val executor = underTest(
+            listOf(SimpleActivity(2))
+        )
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("101"), SimpleRoot(1), simpleRootDestination),
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isFalse()
+
+        assertThat(started).containsExactly(SimpleActivity(2))
+    }
+
+    @Test
+    fun `deep links passed with a NavRoute and an ActivityRoute`() {
+        val executor = underTest(
+            listOf(SimpleRoute(2), SimpleActivity(3))
+        )
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("102"), SimpleRoute(2), simpleRouteDestination),
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isTrue()
+
+        assertThat(started).containsExactly(SimpleActivity(3))
+    }
+
+    @Test
+    fun `visibleEntries contains entry for given root at the beginning`() {
+        val executor = underTest()
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("100"), SimpleRoot(1), simpleRootDestination)
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isFalse()
+    }
+
+    @Test
+    fun `visibleEntries contains new entry after navigating to screen destination`() {
+        val executor = underTest()
+        executor.navigate(SimpleRoute(2))
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("101"), SimpleRoute(2), simpleRouteDestination)
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isTrue()
+
+        assertThat(removed).isEmpty()
+    }
+
+    @Test
+    fun `visibleEntries contains original and new entry after navigating to dialog destination`() {
+        val executor = underTest()
+        executor.navigate(OtherRoute(3))
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("100"), SimpleRoot(1), simpleRootDestination),
+                StackEntry(StackEntry.Id("101"), OtherRoute(3), otherRouteDestination),
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isTrue()
+
+        assertThat(removed).isEmpty()
+    }
+
+    @Test
+    fun `visibleEntries contains original and new entry after navigating to bottom sheet destination`() {
+        val executor = underTest()
+        executor.navigate(ThirdRoute(4))
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("100"), SimpleRoot(1), simpleRootDestination),
+                StackEntry(StackEntry.Id("101"), ThirdRoute(4), thirdRouteDestination),
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isTrue()
+
+        assertThat(removed).isEmpty()
+    }
+
+    @Test
+    fun `visibleEntries contains all entries starting from last screen`() {
+        val executor = underTest()
+        executor.navigate(SimpleRoute(2))
+        executor.navigate(SimpleRoute(3))
+        executor.navigate(SimpleRoute(4))
+        executor.navigate(SimpleRoute(5))
+        executor.navigate(OtherRoute(6))
+        executor.navigate(ThirdRoute(7))
+        executor.navigate(OtherRoute(8))
+        executor.navigate(OtherRoute(9))
+        executor.navigate(ThirdRoute(10))
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("104"), SimpleRoute(5), simpleRouteDestination),
+                StackEntry(StackEntry.Id("105"), OtherRoute(6), otherRouteDestination),
+                StackEntry(StackEntry.Id("106"), ThirdRoute(7), thirdRouteDestination),
+                StackEntry(StackEntry.Id("107"), OtherRoute(8), otherRouteDestination),
+                StackEntry(StackEntry.Id("108"), OtherRoute(9), otherRouteDestination),
+                StackEntry(StackEntry.Id("109"), ThirdRoute(10), thirdRouteDestination),
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isTrue()
+
+        assertThat(removed).isEmpty()
+    }
+
+    @Test
+    fun `visibleEntries contains all entries starting from last screen 2`() {
+        val executor = underTest()
+        executor.navigate(SimpleRoute(2))
+        executor.navigate(SimpleRoute(3))
+        executor.navigate(SimpleRoute(4))
+        executor.navigate(OtherRoute(5))
+        executor.navigate(ThirdRoute(6))
+        executor.navigate(SimpleRoute(7))
+        executor.navigate(OtherRoute(8))
+        executor.navigate(OtherRoute(9))
+        executor.navigate(ThirdRoute(10))
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("106"), SimpleRoute(7), simpleRouteDestination),
+                StackEntry(StackEntry.Id("107"), OtherRoute(8), otherRouteDestination),
+                StackEntry(StackEntry.Id("108"), OtherRoute(9), otherRouteDestination),
+                StackEntry(StackEntry.Id("109"), ThirdRoute(10), thirdRouteDestination),
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isTrue()
+
+        assertThat(removed).isEmpty()
+    }
+
+
+    @Test
+    fun `navigate with root and without clearing the target executor`() {
+        val executor = underTest()
+        executor.navigate(OtherRoot(1), restoreRootState = true)
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("101"), OtherRoot(1), otherRootDestination)
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isTrue()
+
+        assertThat(removed).isEmpty()
+    }
+
+    @Test
+    fun `navigate with same root twice`() {
+        val executor = underTest()
+        executor.navigate(OtherRoot(1), restoreRootState = true)
+        val exception = assertThrows(IllegalStateException::class.java) {
+            executor.navigate(OtherRoot(1), restoreRootState = true)
+        }
+
+        assertThat(exception).hasMessageThat()
+            .isEqualTo("OtherRoot(number=1) is already the current executor")
+    }
+
+    @Test
+    fun `navigate with root multiple times without clearing the target executor`() {
+        val executor = underTest()
+        executor.navigate(OtherRoot(1), restoreRootState = true)
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("101"), OtherRoot(1), otherRootDestination)
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isTrue()
+
+        executor.navigate(SimpleRoot(1), restoreRootState = true)
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("100"), SimpleRoot(1), simpleRootDestination)
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isFalse()
+
+        executor.navigate(OtherRoot(1), restoreRootState = true)
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("101"), OtherRoot(1), otherRootDestination)
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isTrue()
+
+        assertThat(removed).isEmpty()
+    }
+
+    @Test
+    fun `navigate with root multiple times with clearing the target executor`() {
+        val executor = underTest()
+        executor.navigate(OtherRoot(1), restoreRootState = false)
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("101"), OtherRoot(1), otherRootDestination)
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isTrue()
+
+        assertThat(removed).isEmpty()
+    }
+
+    @Test
+    fun `navigate with root and clearing the target executor`() {
+        val executor = underTest()
+        executor.navigate(OtherRoot(1), restoreRootState = false)
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("101"), OtherRoot(1), otherRootDestination)
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isTrue()
+
+        executor.navigate(SimpleRoot(1), restoreRootState = false)
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("102"), SimpleRoot(1), simpleRootDestination)
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isFalse()
+
+        executor.navigate(OtherRoot(1), restoreRootState = false)
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("103"), OtherRoot(1), otherRootDestination)
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isTrue()
+
+        assertThat(removed).containsExactly(StackEntry.Id("100"), StackEntry.Id("101"))
+    }
+
+    @Test
+    fun `navigate with root and without clearing the target executor from within back executor`() {
+        val executor = underTest()
+        executor.navigate(SimpleRoute(1))
+        executor.navigate(OtherRoot(1), restoreRootState = true)
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("102"), OtherRoot(1), otherRootDestination)
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isTrue()
+
+        assertThat(removed).isEmpty()
+    }
+
+    @Test
+    fun `navigate with root multiple times and without clearing the target executor from within back executor`() {
+        val executor = underTest()
+        executor.navigate(SimpleRoute(1))
+        executor.navigate(OtherRoot(1), restoreRootState = true)
+        executor.navigate(SimpleRoot(1), restoreRootState = true)
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("101"), SimpleRoute(1), simpleRouteDestination)
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isTrue()
+
+        assertThat(removed).isEmpty()
+    }
+
+    @Test
+    fun `resetToRoot with start root from start executor`() {
+        val executor = underTest()
+        executor.navigate(SimpleRoute(1))
+        executor.resetToRoot(SimpleRoot(2))
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("102"), SimpleRoot(2), simpleRootDestination)
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isFalse()
+
+        assertThat(removed).containsExactly(StackEntry.Id("100"), StackEntry.Id("101"))
+    }
+
+    @Test
+    fun `resetToRoot with start root from other executor`() {
+        val executor = underTest()
+        executor.navigate(OtherRoot(1), restoreRootState = true)
+        executor.resetToRoot(SimpleRoot(2))
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("102"), SimpleRoot(2), simpleRootDestination)
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isFalse()
+
+        assertThat(removed).containsExactly(StackEntry.Id("100"), StackEntry.Id("101"))
+    }
+
+    @Test
+    fun `resetToRoot fails throws exception when root not on back executor`() {
+        val executor = underTest()
+
+        val exception = assertThrows(IllegalStateException::class.java) {
+            executor.resetToRoot(OtherRoot(1))
+        }
+        assertThat(exception).hasMessageThat()
+            .isEqualTo("OtherRoot(number=1) is not on the current back executor")
+    }
+
+    @Test
+    fun `navigateUp throws exception when start executor is at root`() {
+        val executor = underTest()
+        val exception = assertThrows(IllegalStateException::class.java) {
+            executor.navigateUp()
+        }
+        assertThat(exception).hasMessageThat()
+            .isEqualTo("Can't pop the root of the back executor")
+
+        assertThat(removed).isEmpty()
+    }
+
+    @Test
+    fun `visibleEntries contains root entry after navigateUp`() {
+        val executor = underTest()
+        executor.navigate(SimpleRoute(2))
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("101"), SimpleRoute(2), simpleRouteDestination),
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isTrue()
+
+        executor.navigateUp()
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("100"), SimpleRoot(1), simpleRootDestination),
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isFalse()
+
+        assertThat(removed).containsExactly(StackEntry.Id("101"))
+    }
+
+    @Test
+    fun `navigating the same route again after navigateUp will result in different executor entries`() {
+        val executor = underTest()
+        executor.navigate(SimpleRoute(2))
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("101"), SimpleRoute(2), simpleRouteDestination),
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isTrue()
+
+        executor.navigateUp()
+        executor.navigate(SimpleRoute(2))
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("102"), SimpleRoute(2), simpleRouteDestination),
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isTrue()
+
+        assertThat(removed).containsExactly(StackEntry.Id("101"))
+    }
+
+    @Test
+    fun `navigateUp from the root of a second executor`() {
+        val executor = underTest()
+        executor.navigate(OtherRoot(2), restoreRootState = false)
+
+        val exception = assertThrows(IllegalStateException::class.java) {
+            executor.navigateUp()
+        }
+        assertThat(exception).hasMessageThat()
+            .isEqualTo("Can't pop the root of the back executor")
+    }
+
+    @Test
+    fun `navigateUp in a second executor`() {
+        val executor = underTest()
+        executor.navigate(OtherRoot(2), restoreRootState = false)
+        executor.navigate(SimpleRoute(3))
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("102"), SimpleRoute(3), simpleRouteDestination),
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isTrue()
+
+        executor.navigateUp()
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("101"), OtherRoot(2), otherRootDestination),
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isTrue()
+    }
+
+    @Test
+    fun `pop throws exception when the current executor only contains the root`() {
+        val executor = underTest()
+        val exception = assertThrows(IllegalStateException::class.java) {
+            executor.navigateBack()
+        }
+        assertThat(exception).hasMessageThat()
+            .isEqualTo("Can't navigate back from the root of the start back executor")
+
+        assertThat(removed).isEmpty()
+    }
+
+    @Test
+    fun `visibleEntries contains root entry after pop`() {
+        val executor = underTest()
+        executor.navigate(SimpleRoute(2))
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("101"), SimpleRoute(2), simpleRouteDestination),
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isTrue()
+
+        executor.navigateBack()
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("100"), SimpleRoot(1), simpleRootDestination),
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isFalse()
+
+        assertThat(removed).containsExactly(StackEntry.Id("101"))
+    }
+
+    @Test
+    fun `navigating the same route again after pop will result in different executor entries`() {
+        val executor = underTest()
+        executor.navigate(SimpleRoute(2))
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("101"), SimpleRoute(2), simpleRouteDestination),
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isTrue()
+
+        executor.navigateBack()
+        executor.navigate(SimpleRoute(2))
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("102"), SimpleRoute(2), simpleRouteDestination),
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isTrue()
+
+        assertThat(removed).containsExactly(StackEntry.Id("101"))
+    }
+
+    @Test
+    fun `navigateBack from a second root`() {
+        val executor = underTest()
+        executor.navigate(OtherRoot(2), restoreRootState = false)
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("101"), OtherRoot(2), otherRootDestination),
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isTrue()
+
+        executor.navigateBack()
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("100"), SimpleRoot(1), simpleRootDestination),
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isFalse()
+
+        assertThat(removed).containsExactly(StackEntry.Id("101"))
+    }
+
+    @Test
+    fun `navigateBack from a second root and navigating there again`() {
+        val executor = underTest()
+        executor.navigate(OtherRoot(2), restoreRootState = false)
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("101"), OtherRoot(2), otherRootDestination),
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isTrue()
+
+        executor.navigateBack()
+        executor.navigate(OtherRoot(2), restoreRootState = false)
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("102"), OtherRoot(2), otherRootDestination),
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isTrue()
+
+        assertThat(removed).containsExactly(StackEntry.Id("101"))
+    }
+
+    @Test
+    fun `navigateBack in a second root`() {
+        val executor = underTest()
+        executor.navigate(OtherRoot(2), restoreRootState = false)
+        executor.navigate(SimpleRoute(3))
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("102"), SimpleRoute(3), simpleRouteDestination),
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isTrue()
+
+        executor.navigateBack()
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("101"), OtherRoot(2), otherRootDestination),
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isTrue()
+
+        assertThat(removed).containsExactly(StackEntry.Id("102"))
+    }
+
+    @Test
+    fun `popUpTo removes all destinations until first matching entry, inclusive false`() {
+        val executor = underTest()
+        executor.navigate(SimpleRoute(2))
+        executor.navigate(SimpleRoute(3))
+        executor.navigate(SimpleRoute(4))
+        executor.navigate(SimpleRoute(5))
+        executor.navigate(OtherRoute(6))
+        executor.navigate(ThirdRoute(7))
+        executor.navigate(OtherRoute(8))
+        executor.navigate(OtherRoute(9))
+        executor.navigate(ThirdRoute(10))
+
+        assertThat(executor.visibleEntries.value).hasSize(6)
+
+        executor.navigateBackTo(simpleRouteDestination.id, isInclusive = false)
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("104"), SimpleRoute(5), simpleRouteDestination),
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isTrue()
+
+        assertThat(removed).containsExactly(
+            StackEntry.Id("109"),
+            StackEntry.Id("108"),
+            StackEntry.Id("107"),
+            StackEntry.Id("106"),
+            StackEntry.Id("105"),
+        ).inOrder()
+    }
+
+    @Test
+    fun `popUpTo removes all destinations until first matching entry, inclusive true`() {
+        val executor = underTest()
+        executor.navigate(SimpleRoute(2))
+        executor.navigate(SimpleRoute(3))
+        executor.navigate(SimpleRoute(4))
+        executor.navigate(SimpleRoute(5))
+        executor.navigate(OtherRoute(6))
+        executor.navigate(ThirdRoute(7))
+        executor.navigate(OtherRoute(8))
+        executor.navigate(OtherRoute(9))
+        executor.navigate(ThirdRoute(10))
+
+        assertThat(executor.visibleEntries.value).hasSize(6)
+
+        executor.navigateBackTo(simpleRouteDestination.id, isInclusive = true)
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("103"), SimpleRoute(4), simpleRouteDestination),
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isTrue()
+
+        assertThat(removed).containsExactly(
+            StackEntry.Id("109"),
+            StackEntry.Id("108"),
+            StackEntry.Id("107"),
+            StackEntry.Id("106"),
+            StackEntry.Id("105"),
+            StackEntry.Id("104"),
+        ).inOrder()
+    }
+
+    @Test
+    fun `popUpTo with root and inclusive false removes all destinations`() {
+        val executor = underTest()
+        executor.navigate(SimpleRoute(2))
+        executor.navigate(SimpleRoute(3))
+        executor.navigate(SimpleRoute(4))
+        executor.navigate(SimpleRoute(5))
+        executor.navigate(OtherRoute(6))
+        executor.navigate(ThirdRoute(7))
+        executor.navigate(OtherRoute(8))
+        executor.navigate(OtherRoute(9))
+        executor.navigate(ThirdRoute(10))
+
+        assertThat(executor.visibleEntries.value).hasSize(6)
+
+        executor.navigateBackTo(simpleRootDestination.id, isInclusive = false)
+
+        assertThat(executor.visibleEntries.value)
+            .containsExactly(
+                StackEntry(StackEntry.Id("100"), SimpleRoot(1), simpleRootDestination),
+            )
+            .inOrder()
+        assertThat(executor.canNavigateBack.value).isFalse()
+
+        assertThat(removed).containsExactly(
+            StackEntry.Id("109"),
+            StackEntry.Id("108"),
+            StackEntry.Id("107"),
+            StackEntry.Id("106"),
+            StackEntry.Id("105"),
+            StackEntry.Id("104"),
+            StackEntry.Id("103"),
+            StackEntry.Id("102"),
+            StackEntry.Id("101"),
+        ).inOrder()
+    }
+
+    @Test
+    fun `popUpTo with root and inclusive true throws exception`() {
+        val executor = underTest()
+        executor.navigate(SimpleRoute(2))
+        executor.navigate(SimpleRoute(3))
+        executor.navigate(SimpleRoute(4))
+        executor.navigate(SimpleRoute(5))
+        executor.navigate(OtherRoute(6))
+        executor.navigate(ThirdRoute(7))
+        executor.navigate(OtherRoute(8))
+        executor.navigate(OtherRoute(9))
+        executor.navigate(ThirdRoute(10))
+
+        assertThat(executor.visibleEntries.value).hasSize(6)
+
+        val exception = assertThrows(IllegalStateException::class.java) {
+            executor.navigateBackTo(simpleRootDestination.id, isInclusive = true)
+        }
+        assertThat(exception).hasMessageThat().isEqualTo("Can't pop the root of the back executor")
+
+        assertThat(removed).containsExactly(
+            StackEntry.Id("109"),
+            StackEntry.Id("108"),
+            StackEntry.Id("107"),
+            StackEntry.Id("106"),
+            StackEntry.Id("105"),
+            StackEntry.Id("104"),
+            StackEntry.Id("103"),
+            StackEntry.Id("102"),
+            StackEntry.Id("101"),
+        ).inOrder()
+    }
+
+    @Test
+    fun `popUpTo with route not present on the executor throws exception`() {
+        val executor = underTest()
+        executor.navigate(SimpleRoute(2))
+        executor.navigate(SimpleRoute(3))
+        executor.navigate(SimpleRoute(4))
+        executor.navigate(SimpleRoute(5))
+        executor.navigate(ThirdRoute(6))
+        executor.navigate(ThirdRoute(7))
+
+        assertThat(executor.visibleEntries.value).hasSize(3)
+
+        val exception = assertThrows(IllegalStateException::class.java) {
+            executor.navigateBackTo(otherRouteDestination.id, isInclusive = false)
+        }
+        assertThat(exception).hasMessageThat()
+            .isEqualTo("Route class com.freeletics.mad.navigator.compose.test.OtherRoute (Kotlin " +
+                    "reflection is not available) not found on back executor")
+
+        assertThat(removed).containsExactly(
+            StackEntry.Id("106"),
+            StackEntry.Id("105"),
+            StackEntry.Id("104"),
+            StackEntry.Id("103"),
+            StackEntry.Id("102"),
+            StackEntry.Id("101"),
+        ).inOrder()
+    }
+}

--- a/navigator/runtime-experimental/src/test/kotlin/com/freeletics/mad/navigator/compose/internal/MultiStackNavigationExecutorTest.kt
+++ b/navigator/runtime-experimental/src/test/kotlin/com/freeletics/mad/navigator/compose/internal/MultiStackNavigationExecutorTest.kt
@@ -46,7 +46,7 @@ internal class MultiStackNavigationExecutorTest {
         return MultiStackNavigationExecutor(
             activityStarter = starter,
             viewModel = viewModel,
-            executor = MultiStack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator),
+            stack = MultiStack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator),
             deepLinkRoutes = deepLinkRoutes,
         )
     }
@@ -75,7 +75,7 @@ internal class MultiStackNavigationExecutorTest {
 
         assertThat(exception).hasMessageThat().isEqualTo("SimpleRoot(number=3) is the start root" +
                 " which is not allowed to be part of a deep link because it will always be on the" +
-                " back executor")
+                " back stack")
     }
 
     @Test
@@ -354,7 +354,7 @@ internal class MultiStackNavigationExecutorTest {
         }
 
         assertThat(exception).hasMessageThat()
-            .isEqualTo("OtherRoot(number=1) is already the current executor")
+            .isEqualTo("OtherRoot(number=1) is already the current stack")
     }
 
     @Test
@@ -511,7 +511,7 @@ internal class MultiStackNavigationExecutorTest {
             executor.resetToRoot(OtherRoot(1))
         }
         assertThat(exception).hasMessageThat()
-            .isEqualTo("OtherRoot(number=1) is not on the current back executor")
+            .isEqualTo("OtherRoot(number=1) is not on the current back stack")
     }
 
     @Test
@@ -521,7 +521,7 @@ internal class MultiStackNavigationExecutorTest {
             executor.navigateUp()
         }
         assertThat(exception).hasMessageThat()
-            .isEqualTo("Can't pop the root of the back executor")
+            .isEqualTo("Can't pop the root of the back stack")
 
         assertThat(removed).isEmpty()
     }
@@ -584,7 +584,7 @@ internal class MultiStackNavigationExecutorTest {
             executor.navigateUp()
         }
         assertThat(exception).hasMessageThat()
-            .isEqualTo("Can't pop the root of the back executor")
+            .isEqualTo("Can't pop the root of the back stack")
     }
 
     @Test
@@ -617,7 +617,7 @@ internal class MultiStackNavigationExecutorTest {
             executor.navigateBack()
         }
         assertThat(exception).hasMessageThat()
-            .isEqualTo("Can't navigate back from the root of the start back executor")
+            .isEqualTo("Can't navigate back from the root of the start back stack")
 
         assertThat(removed).isEmpty()
     }
@@ -867,7 +867,7 @@ internal class MultiStackNavigationExecutorTest {
         val exception = assertThrows(IllegalStateException::class.java) {
             executor.navigateBackTo(simpleRootDestination.id, isInclusive = true)
         }
-        assertThat(exception).hasMessageThat().isEqualTo("Can't pop the root of the back executor")
+        assertThat(exception).hasMessageThat().isEqualTo("Can't pop the root of the back stack")
 
         assertThat(removed).containsExactly(
             StackEntry.Id("109"),
@@ -899,7 +899,7 @@ internal class MultiStackNavigationExecutorTest {
         }
         assertThat(exception).hasMessageThat()
             .isEqualTo("Route class com.freeletics.mad.navigator.compose.test.OtherRoute (Kotlin " +
-                    "reflection is not available) not found on back executor")
+                    "reflection is not available) not found on back stack")
 
         assertThat(removed).containsExactly(
             StackEntry.Id("106"),

--- a/navigator/runtime-experimental/src/test/kotlin/com/freeletics/mad/navigator/compose/test/Destinations.kt
+++ b/navigator/runtime-experimental/src/test/kotlin/com/freeletics/mad/navigator/compose/test/Destinations.kt
@@ -1,8 +1,11 @@
 package com.freeletics.mad.navigator.compose.test
 
+import android.content.Intent
+import com.freeletics.mad.navigator.compose.ActivityDestination
 import com.freeletics.mad.navigator.compose.BottomSheetDestination
 import com.freeletics.mad.navigator.compose.DialogDestination
 import com.freeletics.mad.navigator.compose.ScreenDestination
+import com.freeletics.mad.navigator.internal.ActivityDestinationId
 import com.freeletics.mad.navigator.internal.DestinationId
 
 internal val simpleRootDestination = ScreenDestination(DestinationId(SimpleRoot::class)) {}
@@ -17,4 +20,12 @@ internal val destinations = listOf(
     simpleRouteDestination,
     otherRouteDestination,
     thirdRouteDestination,
+)
+
+internal val simpleActivityDestination = ActivityDestination(ActivityDestinationId(SimpleActivity::class), Intent())
+internal val otherActivityDestination = ActivityDestination(ActivityDestinationId(OtherActivity::class), Intent())
+
+internal val activityDestinations = listOf(
+    simpleActivityDestination,
+    otherActivityDestination,
 )

--- a/navigator/runtime-experimental/src/test/kotlin/com/freeletics/mad/navigator/compose/test/Routes.kt
+++ b/navigator/runtime-experimental/src/test/kotlin/com/freeletics/mad/navigator/compose/test/Routes.kt
@@ -1,5 +1,8 @@
 package com.freeletics.mad.navigator.compose.test
 
+import android.os.Parcelable
+import com.freeletics.mad.navigator.ExternalActivityRoute
+import com.freeletics.mad.navigator.InternalActivityRoute
 import com.freeletics.mad.navigator.NavRoot
 import com.freeletics.mad.navigator.NavRoute
 import dev.drewhamilton.poko.Poko
@@ -24,3 +27,15 @@ internal class SimpleRoot(val number: Int) : NavRoot
 @Poko
 @Parcelize
 internal class OtherRoot(val number: Int) : NavRoot
+
+@Poko
+@Parcelize
+internal class SimpleActivity(val number: Int) : InternalActivityRoute()
+
+@Poko
+@Parcelize
+internal class OtherActivity(val number: Int) : ExternalActivityRoute
+
+@Poko
+@Parcelize
+internal class TestParcelable(val value: Int) : Parcelable


### PR DESCRIPTION
The last part to get `navigator-experimental` generally working. Most of the implementation is just delegating to already added components like `MultiStack` and the store. The main new addition is the deep link handling.