### PR TITLE
remember the state machine and other injected dependencies

### DIFF
--- a/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
+++ b/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestCompose.kt
@@ -76,6 +76,7 @@ internal class FileGeneratorTestCompose {
 
             import android.os.Bundle
             import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.remember
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.lifecycle.SavedStateHandle
             import com.freeletics.mad.whetstone.ScopeTo
@@ -144,7 +145,7 @@ internal class FileGeneratorTestCompose {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
-              val stateMachine = component.testStateMachine
+              val stateMachine = remember { component.testStateMachine }
               val state = stateMachine.asComposeState()
               val currentState = state.value
               if (currentState != null) {
@@ -196,6 +197,7 @@ internal class FileGeneratorTestCompose {
             package com.test
 
             import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.remember
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.lifecycle.SavedStateHandle
             import com.freeletics.mad.navigator.NavEventNavigator
@@ -276,7 +278,7 @@ internal class FileGeneratorTestCompose {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
-              val stateMachine = component.testStateMachine
+              val stateMachine = remember { component.testStateMachine }
               val state = stateMachine.asComposeState()
               val currentState = state.value
               if (currentState != null) {
@@ -345,6 +347,7 @@ internal class FileGeneratorTestCompose {
 
             import android.content.Context
             import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.remember
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.lifecycle.SavedStateHandle
             import com.freeletics.mad.navigator.NavEventNavigator
@@ -435,7 +438,7 @@ internal class FileGeneratorTestCompose {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
-              val stateMachine = component.testStateMachine
+              val stateMachine = remember { component.testStateMachine }
               val state = stateMachine.asComposeState()
               val currentState = state.value
               if (currentState != null) {
@@ -562,6 +565,7 @@ internal class FileGeneratorTestCompose {
 
             import android.content.Context
             import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.remember
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.lifecycle.SavedStateHandle
             import com.freeletics.mad.navigator.NavEventNavigator
@@ -650,7 +654,7 @@ internal class FileGeneratorTestCompose {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
-              val stateMachine = component.testStateMachine
+              val stateMachine = remember { component.testStateMachine }
               val state = stateMachine.asComposeState()
               val currentState = state.value
               if (currentState != null) {
@@ -789,6 +793,7 @@ internal class FileGeneratorTestCompose {
 
             import android.os.Bundle
             import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.remember
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.lifecycle.SavedStateHandle
             import com.freeletics.mad.whetstone.ScopeTo
@@ -869,11 +874,11 @@ internal class FileGeneratorTestCompose {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             private fun WhetstoneTest2(component: WhetstoneTest2Component): Unit {
-              val testClass = component.testClass
-              val test = component.test
-              val testSet = component.testSet
-              val testMap = component.testMap
-              val stateMachine = component.testStateMachine
+              val testClass = remember { component.testClass }
+              val test = remember { component.test }
+              val testSet = remember { component.testSet }
+              val testMap = remember { component.testMap }
+              val stateMachine = remember { component.testStateMachine }
               val state = stateMachine.asComposeState()
               val currentState = state.value
               if (currentState != null) {
@@ -924,6 +929,7 @@ internal class FileGeneratorTestCompose {
 
             import android.os.Bundle
             import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.remember
             import androidx.lifecycle.SavedStateHandle
             import com.freeletics.mad.whetstone.ScopeTo
             import com.freeletics.mad.whetstone.`internal`.InternalWhetstoneApi
@@ -990,7 +996,7 @@ internal class FileGeneratorTestCompose {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
-              val stateMachine = component.testStateMachine
+              val stateMachine = remember { component.testStateMachine }
               val state = stateMachine.asComposeState()
               val currentState = state.value
               if (currentState != null) {
@@ -1035,6 +1041,7 @@ internal class FileGeneratorTestCompose {
 
             import android.os.Bundle
             import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.remember
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.lifecycle.SavedStateHandle
             import com.freeletics.mad.whetstone.ScopeTo
@@ -1103,7 +1110,7 @@ internal class FileGeneratorTestCompose {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
-              val stateMachine = component.testStateMachine
+              val stateMachine = remember { component.testStateMachine }
               val state = stateMachine.asComposeState()
               val currentState = state.value
               if (currentState != null) {

--- a/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
+++ b/whetstone/compiler-test/src/test/kotlin/com/freeletics/mad/whetstone/codegen/FileGeneratorTestComposeFragment.kt
@@ -80,6 +80,7 @@ internal class FileGeneratorTestComposeFragment {
             import android.view.View
             import android.view.ViewGroup
             import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.remember
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.compose.ui.platform.ComposeView
             import androidx.compose.ui.platform.ViewCompositionStrategy
@@ -168,7 +169,7 @@ internal class FileGeneratorTestComposeFragment {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
-              val stateMachine = component.testStateMachine
+              val stateMachine = remember { component.testStateMachine }
               val state = stateMachine.asComposeState()
               val currentState = state.value
               if (currentState != null) {
@@ -224,6 +225,7 @@ internal class FileGeneratorTestComposeFragment {
             import android.view.View
             import android.view.ViewGroup
             import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.remember
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.compose.ui.platform.ComposeView
             import androidx.compose.ui.platform.ViewCompositionStrategy
@@ -325,7 +327,7 @@ internal class FileGeneratorTestComposeFragment {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
-              val stateMachine = component.testStateMachine
+              val stateMachine = remember { component.testStateMachine }
               val state = stateMachine.asComposeState()
               val currentState = state.value
               if (currentState != null) {
@@ -397,6 +399,7 @@ internal class FileGeneratorTestComposeFragment {
             import android.view.View
             import android.view.ViewGroup
             import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.remember
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.compose.ui.platform.ComposeView
             import androidx.compose.ui.platform.ViewCompositionStrategy
@@ -508,7 +511,7 @@ internal class FileGeneratorTestComposeFragment {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
-              val stateMachine = component.testStateMachine
+              val stateMachine = remember { component.testStateMachine }
               val state = stateMachine.asComposeState()
               val currentState = state.value
               if (currentState != null) {
@@ -638,6 +641,7 @@ internal class FileGeneratorTestComposeFragment {
             import android.view.View
             import android.view.ViewGroup
             import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.remember
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.compose.ui.platform.ComposeView
             import androidx.compose.ui.platform.ViewCompositionStrategy
@@ -748,7 +752,7 @@ internal class FileGeneratorTestComposeFragment {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
-              val stateMachine = component.testStateMachine
+              val stateMachine = remember { component.testStateMachine }
               val state = stateMachine.asComposeState()
               val currentState = state.value
               if (currentState != null) {
@@ -868,6 +872,7 @@ internal class FileGeneratorTestComposeFragment {
             import android.view.View
             import android.view.ViewGroup
             import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.remember
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.compose.ui.platform.ComposeView
             import androidx.compose.ui.platform.ViewCompositionStrategy
@@ -956,7 +961,7 @@ internal class FileGeneratorTestComposeFragment {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
-              val stateMachine = component.testStateMachine
+              val stateMachine = remember { component.testStateMachine }
               val state = stateMachine.asComposeState()
               val currentState = state.value
               if (currentState != null) {
@@ -1030,6 +1035,7 @@ internal class FileGeneratorTestComposeFragment {
             import android.view.View
             import android.view.ViewGroup
             import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.remember
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.compose.ui.platform.ComposeView
             import androidx.compose.ui.platform.ViewCompositionStrategy
@@ -1130,11 +1136,11 @@ internal class FileGeneratorTestComposeFragment {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             private fun WhetstoneTest2(component: WhetstoneTest2Component): Unit {
-              val testClass = component.testClass
-              val test = component.test
-              val testSet = component.testSet
-              val testMap = component.testMap
-              val stateMachine = component.testStateMachine
+              val testClass = remember { component.testClass }
+              val test = remember { component.test }
+              val testSet = remember { component.testSet }
+              val testMap = remember { component.testMap }
+              val stateMachine = remember { component.testStateMachine }
               val state = stateMachine.asComposeState()
               val currentState = state.value
               if (currentState != null) {
@@ -1188,6 +1194,7 @@ internal class FileGeneratorTestComposeFragment {
             import android.view.View
             import android.view.ViewGroup
             import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.remember
             import androidx.compose.ui.platform.ComposeView
             import androidx.compose.ui.platform.ViewCompositionStrategy
             import androidx.fragment.app.Fragment
@@ -1274,7 +1281,7 @@ internal class FileGeneratorTestComposeFragment {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
-              val stateMachine = component.testStateMachine
+              val stateMachine = remember { component.testStateMachine }
               val state = stateMachine.asComposeState()
               val currentState = state.value
               if (currentState != null) {
@@ -1322,6 +1329,7 @@ internal class FileGeneratorTestComposeFragment {
             import android.view.View
             import android.view.ViewGroup
             import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.remember
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.compose.ui.platform.ComposeView
             import androidx.compose.ui.platform.ViewCompositionStrategy
@@ -1410,7 +1418,7 @@ internal class FileGeneratorTestComposeFragment {
             @Composable
             @OptIn(InternalWhetstoneApi::class)
             private fun WhetstoneTest(component: WhetstoneTestComponent): Unit {
-              val stateMachine = component.testStateMachine
+              val stateMachine = remember { component.testStateMachine }
               val state = stateMachine.asComposeState()
               val currentState = state.value
               if (currentState != null) {

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/ComposeGenerator.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/common/ComposeGenerator.kt
@@ -8,6 +8,7 @@ import com.freeletics.mad.whetstone.codegen.util.composable
 import com.freeletics.mad.whetstone.codegen.util.launch
 import com.freeletics.mad.whetstone.codegen.util.optInAnnotation
 import com.freeletics.mad.whetstone.codegen.util.propertyName
+import com.freeletics.mad.whetstone.codegen.util.remember
 import com.freeletics.mad.whetstone.codegen.util.rememberCoroutineScope
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
@@ -34,10 +35,10 @@ internal class ComposeGenerator(
         return CodeBlock.builder()
             .apply {
                 data.composableParameter.forEach { parameter ->
-                    addStatement("val %L = component.%L", parameter.name, parameter.name)
+                    addStatement("val %L = %M { component.%L }", parameter.name, remember, parameter.name)
                 }
             }
-            .addStatement("val stateMachine = component.%L", data.stateMachine.propertyName)
+            .addStatement("val stateMachine = %M { component.%L }", remember, data.stateMachine.propertyName)
             .addStatement("val state = stateMachine.%M()", asComposeState)
             .addStatement("val currentState = state.value")
             .beginControlFlow("if (currentState != null)")

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
@@ -85,6 +85,7 @@ internal val savedStateHandle = ClassName("androidx.lifecycle", "SavedStateHandl
 // Compose
 internal val composable = ClassName("androidx.compose.runtime", "Composable")
 internal val getValue = MemberName("androidx.compose.runtime", "getValue")
+internal val remember = MemberName("androidx.compose.runtime", "remember")
 internal val rememberCoroutineScope = MemberName("androidx.compose.runtime", "rememberCoroutineScope")
 internal val composeView = ClassName("androidx.compose.ui.platform", "ComposeView")
 internal val viewCompositionStrategy = ClassName("androidx.compose.ui.platform", "ViewCompositionStrategy")


### PR DESCRIPTION
Avoids creating new instances of each injected object on each recomposition when they are not scoped.