### PR TITLE
compose: replace dialog and bottom sheet destinations with overlay

### DIFF
--- a/docs/navigator/get-started.md
+++ b/docs/navigator/get-started.md
@@ -86,17 +86,20 @@ like this:
     that was passed as the generic type parameter. The lambda function then gets an instance of that
     `NavRoute` and calls the `@Composable` function that should be shown.
 
-    The other 2 functions to create destinations are `DialogDestination` and `BottomSheetDestination` -
-    they declare destinations that use a dialog or bottom sheet as a container instead of being shown
-    full screen.
+    There is also an `OverlayDestination` function to declare destinations that use a dialog or bottom 
+    sheet as a container instead of being shown full screen. 
 
     ```kotlin
-    val infoSheetDestination: NavDestination = BottomSheetDestination { route: InfoSheetRoute ->
-        InfoSheetContent(route)
+    val infoSheetDestination: NavDestination = OverlayDestination { route: InfoSheetRoute ->
+        ModalBottomSheet(onDismissRequest = { /* TODO */ }) {
+            InfoSheetContent(route)
+        }
     }
 
-    val confirmationDialogDestination: NavDestination = DialogDestination { route: ConfirmationDialogRoute ->
-        ConfirmationDialogContent(route)
+    val confirmationDialogDestination: NavDestination = OverlayDestination { route: ConfirmationDialogRoute ->
+        Dialog(onDismissRequest = { /* TODO */ }) {
+            ConfirmationDialogContent(route)
+        }
     }
     ```
 
@@ -116,7 +119,7 @@ like this:
     should extend `DialogFragment`.
 
     ```kotlin
-    val infoSheetDestination: NavDestination = BottomSheetDestination<InfoSheetRoute, InfoBottomSheetFragment>()
+    val infoSheetDestination: NavDestination = DialogDestination<InfoSheetRoute, InfoBottomSheetFragment>()
 
     val confirmationDialogDestination: NavDestination = DialogDestination<ConfirmationDialogRoute, ConfirmationDialogFragment>()
     ```

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,15 +17,12 @@ androidx-annotations = "1.5.0"
 androidx-compose-compiler = "1.4.7"
 androidx-compose-runtime = "1.4.3"
 androidx-compose-ui = "1.4.3"
-androidx-compose-foundation = "1.4.3"
-androidx-compose-material = "1.4.3"
 androidx-core = "1.10.1"
 androidx-lifecycle = "2.6.1"
 androidx-fragment = "1.6.0"
 androidx-navigation = "2.6.0"
 androidx-savedstate = "1.2.1"
 
-accompanist = "0.30.1"
 uri = "0.0.12"
 
 inject = "1"
@@ -68,8 +65,6 @@ androidx-compose-compiler = { module = "androidx.compose.compiler:compiler", ver
 androidx-compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "androidx-compose-runtime" }
 androidx-compose-runtime-saveable = { module = "androidx.compose.runtime:runtime-saveable", version.ref = "androidx-compose-runtime" }
 androidx-compose-ui = { module = "androidx.compose.ui:ui", version.ref = "androidx-compose-ui" }
-androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "androidx-compose-foundation" }
-androidx-compose-material = { module = "androidx.compose.material:material", version.ref = "androidx-compose-material" }
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-lifecycle-common = { module = "androidx.lifecycle:lifecycle-common", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidx-lifecycle" }
@@ -85,8 +80,6 @@ androidx-fragment = { module = "androidx.fragment:fragment", version.ref = "andr
 androidx-savedstate = { module = "androidx.savedstate:savedstate", version.ref = "androidx-savedstate" }
 androidx-viewbinding = { module = "androidx.databinding:viewbinding", version.ref = "android-gradle" }
 
-
-accompanist-navigation = { module = "com.google.accompanist:accompanist-navigation-material", version.ref = "accompanist" }
 uri = { module = "com.eygraber:uri-kmp-android", version.ref = "uri" }
 
 inject = { module = "javax.inject:javax.inject", version.ref = "inject" }

--- a/navigator/runtime-compose/api/runtime-compose.api
+++ b/navigator/runtime-compose/api/runtime-compose.api
@@ -2,32 +2,33 @@ public final class com/freeletics/mad/navigator/compose/ActivityDestination : co
 	public synthetic fun <init> (Lkotlin/reflect/KClass;Landroid/content/Intent;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
-public final class com/freeletics/mad/navigator/compose/BottomSheetDestination : com/freeletics/mad/navigator/compose/ContentDestination {
-	public synthetic fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getContent ()Lkotlin/jvm/functions/Function3;
-	public fun getId-fAlktE8 ()Lkotlin/reflect/KClass;
-}
-
-public final class com/freeletics/mad/navigator/compose/DialogDestination : com/freeletics/mad/navigator/compose/ContentDestination {
-	public synthetic fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getContent ()Lkotlin/jvm/functions/Function3;
-	public fun getId-fAlktE8 ()Lkotlin/reflect/KClass;
-}
-
 public abstract interface class com/freeletics/mad/navigator/compose/NavDestination {
 }
 
 public final class com/freeletics/mad/navigator/compose/NavHostKt {
-	public static final fun NavHost-lSURzpk (Lcom/freeletics/mad/navigator/NavRoot;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/graphics/Shape;FJJJLandroidx/compose/runtime/Composer;II)V
+	public static final fun NavHost (Lcom/freeletics/mad/navigator/NavRoot;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/freeletics/mad/navigator/compose/NavigationSetupKt {
 	public static final fun NavigationSetup (Lcom/freeletics/mad/navigator/NavEventNavigator;Landroidx/compose/runtime/Composer;I)V
 }
 
+public final class com/freeletics/mad/navigator/compose/OverlayDestination : com/freeletics/mad/navigator/compose/ContentDestination {
+	public synthetic fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getContent ()Lkotlin/jvm/functions/Function3;
+	public fun getId-fAlktE8 ()Lkotlin/reflect/KClass;
+}
+
 public final class com/freeletics/mad/navigator/compose/ScreenDestination : com/freeletics/mad/navigator/compose/ContentDestination {
 	public synthetic fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getContent ()Lkotlin/jvm/functions/Function3;
 	public fun getId-fAlktE8 ()Lkotlin/reflect/KClass;
+}
+
+public final class com/freeletics/mad/navigator/compose/internal/ComposableSingletons$OverlayNavigatorKt {
+	public static final field INSTANCE Lcom/freeletics/mad/navigator/compose/internal/ComposableSingletons$OverlayNavigatorKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public fun <init> ()V
+	public final fun getLambda-1$runtime_compose_release ()Lkotlin/jvm/functions/Function3;
 }
 

--- a/navigator/runtime-compose/navigator-runtime-compose.gradle.kts
+++ b/navigator/runtime-compose/navigator-runtime-compose.gradle.kts
@@ -18,16 +18,13 @@ dependencies {
     api(projects.navigator.runtime)
     api(libs.androidx.compose.runtime)
     api(libs.androidx.compose.ui)
+    api(libs.androidx.navigation.common)
     implementation(libs.androidx.navigation.runtime)
 
     implementation(projects.navigator.androidxNav)
     implementation(libs.coroutines.core)
     implementation(libs.androidx.activity)
     implementation(libs.androidx.activity.compose)
-    implementation(libs.androidx.compose.foundation)
-    implementation(libs.androidx.compose.material)
     implementation(libs.androidx.lifecycle.common)
-    implementation(libs.androidx.navigation.common)
     implementation(libs.androidx.navigation.compose)
-    implementation(libs.accompanist.navigation)
 }

--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavDestination.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/NavDestination.kt
@@ -35,33 +35,17 @@ internal class ScreenDestination<T : BaseRoute>(
 ) : ContentDestination<T>
 
 /**
- * Creates a new [NavDestination] that represents a dialog. The class of [T] will be used
- * as a unique identifier. The given [content] will be shown inside the dialog window when
+ * Creates a new [NavDestination] that is shown on top a [ScreenDestination], for example a dialog or bottom sheet. The
+ * class of [T] will be used as a unique identifier. The given [content] will be shown inside the dialog window when
  * navigating to it by using an instance of [T].
  */
 @Suppress("FunctionName")
-public inline fun <reified T : NavRoute> DialogDestination(
+public inline fun <reified T : NavRoute> OverlayDestination(
     noinline content: @Composable (T) -> Unit,
-): NavDestination = DialogDestination(DestinationId(T::class), content)
+): NavDestination = OverlayDestination(DestinationId(T::class), content)
 
 @PublishedApi
-internal class DialogDestination<T : NavRoute>(
-    override val id: DestinationId<T>,
-    override val content: @Composable (T) -> Unit,
-) : ContentDestination<T>
-
-/**
- * Creates a new [NavDestination] that represents a bottom sheet. The class of [T] will be used
- * as a unique identifier. The given [content] will be shown inside the bottom sheet
- * when navigating to it by using an instance of [T].
- */
-@Suppress("FunctionName")
-public inline fun <reified T : NavRoute> BottomSheetDestination(
-    noinline content: @Composable (T) -> Unit,
-): NavDestination = BottomSheetDestination(DestinationId(T::class), content)
-
-@PublishedApi
-internal class BottomSheetDestination<T : NavRoute>(
+internal class OverlayDestination<T : NavRoute>(
     override val id: DestinationId<T>,
     override val content: @Composable (T) -> Unit,
 ) : ContentDestination<T>

--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/internal/OverlayHost.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/internal/OverlayHost.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.freeletics.mad.navigator.compose.internal
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveableStateHolder
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.compose.LocalOwnersProvider
+
+@Composable
+internal fun OverlayHost(overlayNavigator: OverlayNavigator) {
+    val saveableStateHolder = rememberSaveableStateHolder()
+    val dialogBackStack by overlayNavigator.backStack.collectAsState()
+    val visibleBackStack = rememberVisibleList(dialogBackStack)
+    visibleBackStack.PopulateVisibleList(dialogBackStack)
+
+    visibleBackStack.forEach { backStackEntry ->
+        val destination = backStackEntry.destination as OverlayNavigator.Destination
+        DisposableEffect(backStackEntry) {
+            onDispose {
+                overlayNavigator.onTransitionComplete(backStackEntry)
+            }
+        }
+
+        // while in the scope of the composable, we provide the navBackStackEntry as the
+        // ViewModelStoreOwner and LifecycleOwner
+        backStackEntry.LocalOwnersProvider(saveableStateHolder) {
+            destination.content(backStackEntry)
+        }
+    }
+}
+
+@Composable
+internal fun MutableList<NavBackStackEntry>.PopulateVisibleList(
+    transitionsInProgress: Collection<NavBackStackEntry>,
+) {
+    val isInspecting = LocalInspectionMode.current
+    transitionsInProgress.forEach { entry ->
+        DisposableEffect(entry.lifecycle) {
+            val observer = LifecycleEventObserver { _, event ->
+                // show dialog in preview
+                if (isInspecting && !contains(entry)) {
+                    add(entry)
+                }
+                // ON_START -> add to visibleBackStack, ON_STOP -> remove from visibleBackStack
+                if (event == Lifecycle.Event.ON_START) {
+                    // We want to treat the visible lists as Sets but we want to keep
+                    // the functionality of mutableStateListOf() so that we recompose in response
+                    // to adds and removes.
+                    if (!contains(entry)) {
+                        add(entry)
+                    }
+                }
+                if (event == Lifecycle.Event.ON_STOP) {
+                    remove(entry)
+                }
+            }
+            entry.lifecycle.addObserver(observer)
+            onDispose {
+                entry.lifecycle.removeObserver(observer)
+            }
+        }
+    }
+}
+
+@Composable
+internal fun rememberVisibleList(
+    transitionsInProgress: Collection<NavBackStackEntry>,
+): SnapshotStateList<NavBackStackEntry> {
+    // show dialog in preview
+    val isInspecting = LocalInspectionMode.current
+    return remember(transitionsInProgress) {
+        mutableStateListOf<NavBackStackEntry>().also {
+            it.addAll(
+                transitionsInProgress.filter { entry ->
+                    if (isInspecting) {
+                        true
+                    } else {
+                        entry.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
+                    }
+                },
+            )
+        }
+    }
+}

--- a/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/internal/OverlayNavigator.kt
+++ b/navigator/runtime-compose/src/main/java/com/freeletics/mad/navigator/compose/internal/OverlayNavigator.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.freeletics.mad.navigator.compose.internal
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.FloatingWindow
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavDestination
+import androidx.navigation.NavOptions
+import androidx.navigation.Navigator
+import com.freeletics.mad.navigator.compose.internal.OverlayNavigator.Destination
+
+@Navigator.Name("overlay")
+internal class OverlayNavigator : Navigator<Destination>() {
+
+    /**
+     * Get the back stack from the [state].
+     */
+    internal val backStack get() = state.backStack
+
+    override fun navigate(
+        entries: List<NavBackStackEntry>,
+        navOptions: NavOptions?,
+        navigatorExtras: Extras?,
+    ) {
+        entries.forEach { entry ->
+            state.push(entry)
+        }
+    }
+
+    override fun createDestination(): Destination {
+        return Destination(this) { }
+    }
+
+    override fun popBackStack(popUpTo: NavBackStackEntry, savedState: Boolean) {
+        state.popWithTransition(popUpTo, savedState)
+    }
+
+    internal fun onTransitionComplete(entry: NavBackStackEntry) {
+        state.markTransitionComplete(entry)
+    }
+
+    /**
+     * NavDestination specific to [OverlayNavigator]
+     */
+    @NavDestination.ClassType(Composable::class)
+    class Destination(
+        navigator: OverlayNavigator,
+        internal val content: @Composable (NavBackStackEntry) -> Unit,
+    ) : NavDestination(navigator), FloatingWindow
+}

--- a/navigator/runtime-experimental/api/runtime-experimental.api
+++ b/navigator/runtime-experimental/api/runtime-experimental.api
@@ -2,27 +2,21 @@ public final class com/freeletics/mad/navigator/compose/ActivityDestination : co
 	public synthetic fun <init> (Lkotlin/reflect/KClass;Landroid/content/Intent;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
-public final class com/freeletics/mad/navigator/compose/BottomSheetDestination : com/freeletics/mad/navigator/compose/ContentDestination {
-	public synthetic fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getContent ()Lkotlin/jvm/functions/Function3;
-	public fun getId-fAlktE8 ()Lkotlin/reflect/KClass;
-}
-
-public final class com/freeletics/mad/navigator/compose/DialogDestination : com/freeletics/mad/navigator/compose/ContentDestination {
-	public synthetic fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getContent ()Lkotlin/jvm/functions/Function3;
-	public fun getId-fAlktE8 ()Lkotlin/reflect/KClass;
-}
-
 public abstract interface class com/freeletics/mad/navigator/compose/NavDestination {
 }
 
 public final class com/freeletics/mad/navigator/compose/NavHostKt {
-	public static final fun NavHost-lSURzpk (Lcom/freeletics/mad/navigator/NavRoot;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/graphics/Shape;FJJJLandroidx/compose/runtime/Composer;II)V
+	public static final fun NavHost (Lcom/freeletics/mad/navigator/NavRoot;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/freeletics/mad/navigator/compose/NavigationSetupKt {
 	public static final fun NavigationSetup (Lcom/freeletics/mad/navigator/NavEventNavigator;Landroidx/compose/runtime/Composer;I)V
+}
+
+public final class com/freeletics/mad/navigator/compose/OverlayDestination : com/freeletics/mad/navigator/compose/ContentDestination {
+	public synthetic fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getContent ()Lkotlin/jvm/functions/Function3;
+	public fun getId-fAlktE8 ()Lkotlin/reflect/KClass;
 }
 
 public final class com/freeletics/mad/navigator/compose/ScreenDestination : com/freeletics/mad/navigator/compose/ContentDestination {

--- a/navigator/runtime-experimental/navigator-runtime-experimental.gradle.kts
+++ b/navigator/runtime-experimental/navigator-runtime-experimental.gradle.kts
@@ -21,8 +21,6 @@ dependencies {
     implementation(libs.androidx.activity)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.compose.runtime.saveable)
-    implementation(libs.androidx.compose.foundation)
-    implementation(libs.androidx.compose.material)
     implementation(libs.androidx.lifecycle.common)
     implementation(libs.androidx.viewmodel)
     implementation(libs.androidx.viewmodel.compose)

--- a/navigator/runtime-experimental/src/main/java/com/freeletics/mad/navigator/compose/NavDestination.kt
+++ b/navigator/runtime-experimental/src/main/java/com/freeletics/mad/navigator/compose/NavDestination.kt
@@ -35,33 +35,17 @@ internal class ScreenDestination<T : BaseRoute>(
 ) : ContentDestination<T>
 
 /**
- * Creates a new [NavDestination] that represents a dialog. The class of [T] will be used
- * as a unique identifier. The given [content] will be shown inside the dialog window when
+ * Creates a new [NavDestination] that is shown on top a [ScreenDestination], for example a dialog or bottom sheet. The
+ * class of [T] will be used as a unique identifier. The given [content] will be shown inside the dialog window when
  * navigating to it by using an instance of [T].
  */
 @Suppress("FunctionName")
-public inline fun <reified T : NavRoute> DialogDestination(
+public inline fun <reified T : NavRoute> OverlayDestination(
     noinline content: @Composable (T) -> Unit,
-): NavDestination = DialogDestination(DestinationId(T::class), content)
+): NavDestination = OverlayDestination(DestinationId(T::class), content)
 
 @PublishedApi
-internal class DialogDestination<T : NavRoute>(
-    override val id: DestinationId<T>,
-    override val content: @Composable (T) -> Unit,
-) : ContentDestination<T>
-
-/**
- * Creates a new [NavDestination] that represents a bottom sheet. The class of [T] will be used
- * as a unique identifier. The given [content] will be shown inside the bottom sheet
- * when navigating to it by using an instance of [T].
- */
-@Suppress("FunctionName")
-public inline fun <reified T : NavRoute> BottomSheetDestination(
-    noinline content: @Composable (T) -> Unit,
-): NavDestination = BottomSheetDestination(DestinationId(T::class), content)
-
-@PublishedApi
-internal class BottomSheetDestination<T : NavRoute>(
+internal class OverlayDestination<T : NavRoute>(
     override val id: DestinationId<T>,
     override val content: @Composable (T) -> Unit,
 ) : ContentDestination<T>

--- a/navigator/runtime-experimental/src/test/kotlin/com/freeletics/mad/navigator/compose/test/Destinations.kt
+++ b/navigator/runtime-experimental/src/test/kotlin/com/freeletics/mad/navigator/compose/test/Destinations.kt
@@ -2,8 +2,7 @@ package com.freeletics.mad.navigator.compose.test
 
 import android.content.Intent
 import com.freeletics.mad.navigator.compose.ActivityDestination
-import com.freeletics.mad.navigator.compose.BottomSheetDestination
-import com.freeletics.mad.navigator.compose.DialogDestination
+import com.freeletics.mad.navigator.compose.OverlayDestination
 import com.freeletics.mad.navigator.compose.ScreenDestination
 import com.freeletics.mad.navigator.internal.ActivityDestinationId
 import com.freeletics.mad.navigator.internal.DestinationId
@@ -11,8 +10,8 @@ import com.freeletics.mad.navigator.internal.DestinationId
 internal val simpleRootDestination = ScreenDestination(DestinationId(SimpleRoot::class)) {}
 internal val otherRootDestination = ScreenDestination(DestinationId(OtherRoot::class)) {}
 internal val simpleRouteDestination = ScreenDestination(DestinationId(SimpleRoute::class)) {}
-internal val otherRouteDestination = DialogDestination(DestinationId(OtherRoute::class)) {}
-internal val thirdRouteDestination = BottomSheetDestination(DestinationId(ThirdRoute::class)) {}
+internal val otherRouteDestination = OverlayDestination(DestinationId(OtherRoute::class)) {}
+internal val thirdRouteDestination = OverlayDestination(DestinationId(ThirdRoute::class)) {}
 
 internal val destinations = listOf(
     simpleRootDestination,

--- a/sample/simple/feature/bottom-sheet/implementation/feature-bottom-sheet-implementation.gradle.kts
+++ b/sample/simple/feature/bottom-sheet/implementation/feature-bottom-sheet-implementation.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
 
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.foundation)
+    implementation(libs.androidx.compose.material)
     implementation(libs.mad.whetstone)
     implementation(libs.mad.whetstone.runtime)
     implementation(libs.mad.whetstone.scope)

--- a/sample/simple/feature/bottom-sheet/implementation/src/main/java/com/freeletics/mad/sample/feature/bottomsheet/BottomSheetScreen.kt
+++ b/sample/simple/feature/bottom-sheet/implementation/src/main/java/com/freeletics/mad/sample/feature/bottomsheet/BottomSheetScreen.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.BasicText
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -12,19 +14,24 @@ import com.freeletics.mad.sample.feature.bottomsheet.nav.BottomSheetRoute
 import com.freeletics.mad.whetstone.compose.ComposeDestination
 import com.freeletics.mad.whetstone.compose.DestinationType
 
+@OptIn(ExperimentalMaterial3Api::class)
 @ComposeDestination(
     route = BottomSheetRoute::class,
     stateMachine = BottomSheetStateMachine::class,
-    destinationType = DestinationType.BOTTOM_SHEET,
+    destinationType = DestinationType.OVERLAY,
 )
 @Composable
-fun BottomSheetScreen() {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 48.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        BasicText("Feature BottomSheet")
+fun BottomSheetScreen(
+    sendAction: (BottomSheetAction) -> Unit,
+) {
+    ModalBottomSheet(onDismissRequest = { sendAction(BottomSheetAction.DismissRequested) }) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 48.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            BasicText("Feature Bottom Sheet")
+        }
     }
 }

--- a/sample/simple/feature/bottom-sheet/implementation/src/main/java/com/freeletics/mad/sample/feature/bottomsheet/BottomSheetStateMachine.kt
+++ b/sample/simple/feature/bottom-sheet/implementation/src/main/java/com/freeletics/mad/sample/feature/bottomsheet/BottomSheetStateMachine.kt
@@ -9,10 +9,18 @@ sealed interface BottomSheetState
 
 object Init : BottomSheetState
 
-sealed interface BottomSheetAction
+sealed interface BottomSheetAction {
+    object DismissRequested : BottomSheetAction
+}
 
-class BottomSheetStateMachine @Inject constructor() : StateMachine<BottomSheetState, BottomSheetAction> {
+class BottomSheetStateMachine @Inject constructor(
+    private val navigator: BottomSheetNavigator,
+) : StateMachine<BottomSheetState, BottomSheetAction> {
     override val state: Flow<BottomSheetState> = flowOf(Init)
 
-    override suspend fun dispatch(action: BottomSheetAction) {}
+    override suspend fun dispatch(action: BottomSheetAction) {
+        when (action) {
+            BottomSheetAction.DismissRequested -> navigator.navigateBack()
+        }
+    }
 }

--- a/sample/simple/feature/dialog/implementation/src/main/java/com/freeletics/mad/sample/feature/dialog/DialogScreen.kt
+++ b/sample/simple/feature/dialog/implementation/src/main/java/com/freeletics/mad/sample/feature/dialog/DialogScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
 import com.freeletics.mad.sample.feature.dialog.nav.DialogRoute
 import com.freeletics.mad.whetstone.compose.ComposeDestination
 import com.freeletics.mad.whetstone.compose.DestinationType
@@ -17,17 +18,21 @@ import com.freeletics.mad.whetstone.compose.DestinationType
 @ComposeDestination(
     route = DialogRoute::class,
     stateMachine = DialogStateMachine::class,
-    destinationType = DestinationType.DIALOG,
+    destinationType = DestinationType.OVERLAY,
 )
 @Composable
-fun DialogScreen() {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(Color.White)
-            .padding(vertical = 48.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        BasicText("Feature Dialog")
+fun DialogScreen(
+    sendAction: (DialogAction) -> Unit,
+) {
+    Dialog(onDismissRequest = { sendAction(DialogAction.DismissRequested) }) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(Color.White)
+                .padding(vertical = 48.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            BasicText("Feature Dialog")
+        }
     }
 }

--- a/sample/simple/feature/dialog/implementation/src/main/java/com/freeletics/mad/sample/feature/dialog/DialogStateMachine.kt
+++ b/sample/simple/feature/dialog/implementation/src/main/java/com/freeletics/mad/sample/feature/dialog/DialogStateMachine.kt
@@ -7,11 +7,19 @@ import kotlinx.coroutines.flow.MutableStateFlow
 
 object DialogState
 
-sealed interface DialogAction
+sealed interface DialogAction {
+    object DismissRequested : DialogAction
+}
 
-class DialogStateMachine @Inject constructor() : StateMachine<DialogState, DialogAction> {
+class DialogStateMachine @Inject constructor(
+    private val navigator: DialogNavigator,
+) : StateMachine<DialogState, DialogAction> {
     private val _state = MutableStateFlow(DialogState)
     override val state: Flow<DialogState> = _state
 
-    override suspend fun dispatch(action: DialogAction) {}
+    override suspend fun dispatch(action: DialogAction) {
+        when (action) {
+            DialogAction.DismissRequested -> navigator.navigateBack()
+        }
+    }
 }

--- a/sample/simple/gradle/libs.versions.toml
+++ b/sample/simple/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ androidx-compose-compiler = "1.4.7"
 androidx-compose-runtime = "1.4.3"
 androidx-compose-ui = "1.4.3"
 androidx-compose-foundation = "1.4.3"
+androidx-compose-material = "1.1.0"
 androidx-core = "1.10.1"
 androidx-lifecycle = "2.6.1"
 anvil = "2.4.6"
@@ -34,6 +35,7 @@ androidx-compose-compiler = { module = "androidx.compose.compiler:compiler", ver
 androidx-compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "androidx-compose-runtime" }
 androidx-compose-ui = { module = "androidx.compose.ui:ui", version.ref = "androidx-compose-ui" }
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "androidx-compose-foundation" }
+androidx-compose-material = { module = "androidx.compose.material3:material3", version.ref = "androidx-compose-material" }
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-lifecycle-common = { module = "androidx.lifecycle:lifecycle-common", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel", version.ref = "androidx-lifecycle" }

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/Data.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/Data.kt
@@ -1,8 +1,7 @@
 package com.freeletics.mad.whetstone
 
-import com.freeletics.mad.whetstone.codegen.util.composeBottomSheetDestination
 import com.freeletics.mad.whetstone.codegen.util.composeDestination
-import com.freeletics.mad.whetstone.codegen.util.composeDialogDestination
+import com.freeletics.mad.whetstone.codegen.util.composeOverlayDestination
 import com.freeletics.mad.whetstone.codegen.util.composeScreenDestination
 import com.freeletics.mad.whetstone.codegen.util.fragmentDestination
 import com.freeletics.mad.whetstone.codegen.util.fragmentDialogDestination
@@ -119,8 +118,7 @@ public sealed interface Navigation {
 
         override val destinationMethod: MemberName = when (destinationType) {
             "SCREEN" -> composeScreenDestination
-            "DIALOG" -> composeDialogDestination
-            "BOTTOM_SHEET" -> composeBottomSheetDestination
+            "OVERLAY" -> composeOverlayDestination
             else -> throw IllegalArgumentException("Unknown destinationType $destinationType")
         }
     }

--- a/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
+++ b/whetstone/compiler/src/main/kotlin/com/freeletics/mad/whetstone/codegen/util/External.kt
@@ -42,11 +42,7 @@ internal val navigationExecutor = ClassName("com.freeletics.mad.navigator.intern
 internal val composeNavigationHandler = MemberName("com.freeletics.mad.navigator.compose", "NavigationSetup")
 internal val composeDestination = ClassName("com.freeletics.mad.navigator.compose", "NavDestination")
 internal val composeScreenDestination = MemberName("com.freeletics.mad.navigator.compose", "ScreenDestination")
-internal val composeDialogDestination = MemberName("com.freeletics.mad.navigator.compose", "DialogDestination")
-internal val composeBottomSheetDestination = MemberName(
-    "com.freeletics.mad.navigator.compose",
-    "BottomSheetDestination",
-)
+internal val composeOverlayDestination = MemberName("com.freeletics.mad.navigator.compose", "OverlayDestination")
 internal val fragmentNavigationHandler = MemberName("com.freeletics.mad.navigator.fragment", "handleNavigation")
 internal val fragmentDestination = ClassName("com.freeletics.mad.navigator.fragment", "NavDestination")
 internal val fragmentScreenDestination = MemberName("com.freeletics.mad.navigator.fragment", "ScreenDestination")

--- a/whetstone/navigation-compose/api/navigation-compose.api
+++ b/whetstone/navigation-compose/api/navigation-compose.api
@@ -7,8 +7,7 @@ public abstract interface annotation class com/freeletics/mad/whetstone/compose/
 }
 
 public final class com/freeletics/mad/whetstone/compose/DestinationType : java/lang/Enum {
-	public static final field BOTTOM_SHEET Lcom/freeletics/mad/whetstone/compose/DestinationType;
-	public static final field DIALOG Lcom/freeletics/mad/whetstone/compose/DestinationType;
+	public static final field OVERLAY Lcom/freeletics/mad/whetstone/compose/DestinationType;
 	public static final field SCREEN Lcom/freeletics/mad/whetstone/compose/DestinationType;
 	public static fun valueOf (Ljava/lang/String;)Lcom/freeletics/mad/whetstone/compose/DestinationType;
 	public static fun values ()[Lcom/freeletics/mad/whetstone/compose/DestinationType;

--- a/whetstone/navigation-compose/src/main/java/com/freeletics/mad/whetstone/compose/DestinationType.kt
+++ b/whetstone/navigation-compose/src/main/java/com/freeletics/mad/whetstone/compose/DestinationType.kt
@@ -5,6 +5,5 @@ package com.freeletics.mad.whetstone.compose
  */
 public enum class DestinationType {
     SCREEN,
-    DIALOG,
-    BOTTOM_SHEET,
+    OVERLAY,
 }


### PR DESCRIPTION
We now have an overlay destination type. The difference compared to dialog and bottom sheet is that this destination type does not add a container like `Dialog` or `ModalBottomSheetLayout` anymore, it will just show the content on top of screen destinations. This moves the responsibility of adding the container to the destinations. For the simple case it's a bit more effort but it gives a lot more flexibility as well since you can customize the bottom sheet or dialog on a per destination basis. It also means we don't need all the bottom sheet parameters on `NavHost` anymore and we can drop the dependency on accompanist-navigation-material.

This fixes the navigation issues that we had with bottom sheets (dismissing it by clicking outside or dragging it closed does not pop the back stack) and dialogs (not displayed).

For the AndroidX navigation implementation this ads `OverlayNavigator` and `OverlayNavHost` (internally). These are a mostly 1:1 copy of `DialogNavigator` and `DialogHost` from AndroidX navigation. The only change to them is that `DialogHost` does not add a wrapper `Dialog` around `destination.content(backStackEntry)`.

In the experimental implementation the change is to just show all visible destinations in the same way instead of wrapping some based on the type.

